### PR TITLE
Switch openssl from 1.1.1 to 1.1.1a

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -41,12 +41,7 @@ fi
 
 if [ "${VARIANT}" == "openj9" ]
 then
-  if [ "${ARCHITECTURE}" == "s390x" ] && [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
-  then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/usr/local/openssl-1.1.1 --enable-openssl-bundling"
-  else
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
-  fi
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
 fi
 
 if [ "${ARCHITECTURE}" == "ppc64le" ]

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -77,7 +77,8 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 's390x',
                 additionalNodeLabels: 'build-marist-rhel74-s390x-2',
-                test                : ['openjdktest', 'systemtest', 'perftest']
+                test                : ['openjdktest', 'systemtest', 'perftest'],
+                configureArgs        : '--disable-ccache'
         ],
 
         ppc64leLinux    : [

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -102,7 +102,7 @@ updateOpenj9Sources() {
   # Building OpenJDK with OpenJ9 must run get_source.sh to clone openj9 and openj9-omr repositories
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "openj9" ]; then
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
-    bash get_source.sh --openssl-version=1.1.1
+    bash get_source.sh --openssl-version=1.1.1a
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
Update to openssl 1.1.1a because
1) Linux/s390x doesn't build out of the box with 1.1.1
2) We've stopped using my prebuilt version with a patch which was on the build machines because apparently it wasn't working.

This does not affect Windows which is still using a precompiled 1.1.1