### PR TITLE
Added packages required for the JDK11-13 Docker builds

### DIFF
--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -16,6 +16,7 @@ FROM ubuntu:18.04
 LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
+# dirmngr, gpg-agent & coreutils are all required for the apt-add repository command
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -16,6 +16,7 @@ FROM ubuntu:18.04
 LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
+# dirmngr, gpg-agent & coreutils are all required for the apt-add repository command
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -16,6 +16,7 @@ FROM ubuntu:18.04
 LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
+# dirmngr, gpg-agent & coreutils are all required for the apt-add repository command
 RUN apt-get update \
   && apt-get install -qq -y --no-install-recommends \
     software-properties-common \


### PR DESCRIPTION
Whilst running through the JDK11-13 Dockerfiles, several things weren't able to be installed, probably due to the Docker containers running on Ubuntu1804, as opposed to Ubuntu1604 like the containers for JDK8-10.
The changes made in this PR are installing alternatives that work for Ubuntu1804, as well as some additional packages that are now required for Ubuntu1804.