### PR TITLE
Add better info on retries for debugging/stats and update gradle retry code

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -438,19 +438,12 @@ buildSharedLibs() {
     local gradleJavaHome=$(getGradleHome)
     echo "Running gradle with $gradleJavaHome"
 
-    # Disable cmd line failure shell exit    
-    set +e
     gradlecount=1
-    rc=1
-    while [[ $rc -ne 0 && $gradlecount -le 3 ]]
-    do
-        JAVA_HOME="$gradleJavaHome" GRADLE_USER_HOME=./gradle-cache bash ./gradlew --no-daemon clean uberjar
-        rc=$?
-        echo "gradle attempt $gradlecount : rc=$rc "
-        gradlecount=$(( gradlecount + 1 ))
+    while ! JAVA_HOME="$gradleJavaHome" GRADLE_USER_HOME=./gradle-cache bash ./gradlew --no-daemon clean uberjar; do
+      echo "RETRYWARNING: Gradle failed on attempt $gradlecount"
+      gradlecount=$(( gradlecount + 1 ))
+      [ $gradlecount -gt 3 ] && exit 1
     done
-    # Re-enable cmd line failure shell exit
-    set -e
 
     # Test that the parser can execute as fail fast rather than waiting till after the build to find out
     "$gradleJavaHome"/bin/java -version 2>&1 | "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f semver 1

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -80,13 +80,13 @@ checkoutAndCloneOpenJDKGitRepo() {
 
   checkoutRequiredCodeToBuild
   if [ $checkoutRc -ne 0 ]; then
-    echo "Checkout required source failed, cleaning workspace and retrying..."
+    echo "RETRYWARNING: Checkout required source failed, cleaning workspace and retrying..."
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}"
     rm -rf "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}"
     cloneOpenJDKGitRepo
     checkoutRequiredCodeToBuild
     if [ $checkoutRc -ne 0 ]; then
-      echo "Checkout failed on clean workspace retry, failing job..."
+      echo "RETRYWARNING: Checkout failed on clean workspace retry, failing job..."
       exit 1
     fi
   fi

--- a/sign.sh
+++ b/sign.sh
@@ -63,7 +63,7 @@ signRelease()
       do
         echo "Signing ${f}"
         if ! "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"; then
-          echo "WARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
+          echo "RETRYWARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
           sleep 10
           "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"
         fi        
@@ -75,7 +75,7 @@ signRelease()
       do
         echo "Signing ${f}"
         if ! "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"; then
-          echo "WARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
+          echo "RETRYWARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
           sleep 10
           "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"
         fi


### PR DESCRIPTION
Also adjust the way the retries work on gradle Current system would only go through twice (since the loop checked for less than 3 and it starts at 1) With this version the message will only be displayed if a retry occurred so it's easier to search for `RETRYWARNING` in the logs

See https://ci.adoptopenjdk.net/view/work%20in%20progress/job/SXA-aarch64_jdk11_hs/3/consoleFull for sample output

(If anyone - and lint might - objects to my use of `&&` instead of an if block then I guess I cna change it by I find this format more readable and takes less space ...)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>