### PR TITLE
Fix buildbreak introduced by conflicting changes to gradle retry logic

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -445,11 +445,6 @@ buildSharedLibs() {
       [ $gradlecount -gt 3 ] && exit 1
     done
 
-    if [ $rc -ne 0 ]; then
-        echo "gradle failed to create uberjar"
-        exit $rc
-    fi 
-
     # Test that the parser can execute as fail fast rather than waiting till after the build to find out
     "$gradleJavaHome"/bin/java -version 2>&1 | "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f semver 1
 }


### PR DESCRIPTION
rc is no longer used, so cannot be referenced. forcing this through as all builds will break without it

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>