### PR TITLE
docker: add windows build support

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -181,6 +181,14 @@ then
   fi
 fi
 
+if [ ! -z "${DOCKER_IMAGE}" ]; then
+  # Docker does not support persistent 8dot3name creation
+  fsutil behavior set disable8dot3 0
+  fsutil file setshortname 'c:\program files (x86)' 'PROGRA~2'
+  fsutil file setshortname 'c:\program files (x86)\Microsoft Visual Studio' 'MIB055~1'
+  fsutil file setshortname 'c:\program files (x86)\Windows Kits' 'WINDOW~4'
+fi
+
 if [ ! -z "${TOOLCHAIN_VERSION}" ]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-toolchain-version=${TOOLCHAIN_VERSION}"
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-toolchain-version=${TOOLCHAIN_VERSION}"
 fi

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -26,7 +26,7 @@ export OPENJ9_NASM_VERSION=2.13.03
 TOOLCHAIN_VERSION=""
 
 # Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -26,7 +26,7 @@ export OPENJ9_NASM_VERSION=2.13.03
 TOOLCHAIN_VERSION=""
 
 # Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
+if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -41,8 +41,10 @@ class Config11 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
+                dockerImage: [
+                        hotspot: 'adoptopenjdk/windows2016_build_image:vs2017'
+                ],
                 additionalNodeLabels: [
-                        hotspot: 'win2012',
                         openj9:  'win2012&&vs2017'
                 ],
                 buildArgs : [

--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -47,8 +47,8 @@ class Config15 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: [
-                        hotspot: 'win2012&&vs2017'
+                dockerImage: [
+                        hotspot: 'adoptopenjdk/windows2016_build_image:vs2017'
                 ],
                 test                : 'default'
         ],
@@ -65,8 +65,8 @@ class Config15 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: [
-                        hotspot: 'win2012&&vs2017'
+                dockerImage: [
+                        hotspot: 'adoptopenjdk/windows2016_build_image:vs2017'
                 ],
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -32,8 +32,8 @@ class Config16 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: [
-                        hotspot: 'win2012&&vs2017'
+                dockerImage: [
+                        hotspot: 'adoptopenjdk/windows2016_build_image:vs2017'
                 ],
                 test                : [
                         nightly: [],
@@ -44,8 +44,8 @@ class Config16 {
         x32Windows: [
                 os                  : 'windows',
                 arch                : 'x86-32',
-                additionalNodeLabels: [
-                        hotspot: 'win2012&&vs2017'
+                dockerImage: [
+                        hotspot: 'adoptopenjdk/windows2016_build_image:vs2017'
                 ],
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'

--- a/pipelines/src/main/groovy/testDoubles/ContextStub.groovy
+++ b/pipelines/src/main/groovy/testDoubles/ContextStub.groovy
@@ -51,6 +51,8 @@ class ContextStub {
 
     ContextStub inside(Closure c) {}
 
+    ContextStub powershell(String) {}
+
     ContextStub image(String) {}
 
     ContextStub build(String s, Closure) {}

--- a/pipelines/src/main/groovy/testDoubles/EnvStub.groovy
+++ b/pipelines/src/main/groovy/testDoubles/EnvStub.groovy
@@ -4,4 +4,5 @@ class EnvStub {
     String JOB_NAME
     String BUILD_NUMBER
     String CYGWIN_WORKSPACE
+    String WORKSPACE
 }


### PR DESCRIPTION
This PR allows us to start using dynamic windows x64 machines with docker images to produce builds. Currently, I only have a Visual Studio 2017 image so I've started with **JDK11+**. This change also only applies to **Hotspot** builds right now as I'll need to add further dependencies to the docker image to support the builds.

One area of improvement is the queue times. A dynamic machine takes ~5 minutes to be deployed which is fine but the docker pull takes ~10 minutes. I'm working on ways to improve this by using Azure container registry and storing a copy in the same datacentre as the machines.

## TEST BUILDS:

JDK11 - https://ci.adoptopenjdk.net/view/build-tester/job/build-scripts-pr-tester/job/build-test/job/jobs/job/jdk11u/job/jdk11u-windows-x64-hotspot/323/console

JDK15 - https://ci.adoptopenjdk.net/view/build-tester/job/build-scripts-pr-tester/job/build-test/job/jobs/job/jdk15u/job/jdk15u-windows-x64-hotspot/238/console

JDK16 - https://ci.adoptopenjdk.net/view/build-tester/job/build-scripts-pr-tester/job/build-test/job/jobs/job/jdk/job/jdk-windows-x64-hotspot/271/console