### PR TITLE
OpenJ9 linux always configure --with-openssl=fetched

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -50,20 +50,9 @@ fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
 then
-  # CentOS 6 has openssl 1.0.1 so we use a self-installed 1.0.2 from the playbooks
-  if grep 'release 6' /etc/redhat-release >/dev/null 2>&1 || grep 'jessie' /etc/os-release >/dev/null 2>&1 || grep 'SUSE' /etc/os-release >/dev/null 2>&1; then
-    if [ -r /usr/local/openssl-1.0.2/include/openssl/opensslconf.h ]; then
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/usr/local/openssl-1.0.2"
-    else
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
-    fi
-  else
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=system"
-  fi
-fi
+  # OpenJ9 fetches the latest OpenSSL in their get_source.sh
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
-then
   if [ "${ARCHITECTURE}" == "ppc64le" ] || [ "${ARCHITECTURE}" == "x64" ]
   then
     CUDA_VERSION=9.0


### PR DESCRIPTION
OpenJ9 get_source.sh will fetch the latest OpenSSL version
during the build. We should compile against that version
rather than 1.0.2r on the system.

Related AdoptOpenJDK/openjdk-infrastructure#2084

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>