### PR TITLE
code signing macOS binary directory before creating tar.gz file

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -951,8 +951,7 @@ createOpenJDKTarArchive() {
     local jreName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]}" | sed 's/-jdk/-jre/')
     # for macOS system, code sign directory before creating tar.gz file
     if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then
-      ENTITLEMENTS="$jreTargetPath/Contents/Info.plist"
-      codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" "${jdkTargetPath}"
+      codesign --options runtime --timestamp --sign "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" "${jreTargetPath}"
     fi
     createArchive "${jreTargetPath}" "${jreName}"
   fi
@@ -968,8 +967,7 @@ createOpenJDKTarArchive() {
   fi
   # for macOS system, code sign directory before creating tar.gz file
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then
-    ENTITLEMENTS="$jdkTargetPath/Contents/Info.plist"
-    codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" "${jdkTargetPath}"
+    codesign --options runtime --timestamp --sign "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" "${jdkTargetPath}"
   fi
   createArchive "${jdkTargetPath}" "${BUILD_CONFIG[TARGET_FILE_NAME]}"
 }

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -951,7 +951,7 @@ createOpenJDKTarArchive() {
     local jreName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]}" | sed 's/-jdk/-jre/')
     # for macOS system, code sign directory before creating tar.gz file
     if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then
-      ENTITLEMENTS="$jdkTargetPath/Contents/Info.plist"
+      ENTITLEMENTS="$jreTargetPath/Contents/Info.plist"
       codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" "${jdkTargetPath}"
     fi
     createArchive "${jreTargetPath}" "${jreName}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -949,6 +949,11 @@ createOpenJDKTarArchive() {
   if [ -d "${jreTargetPath}" ]; then
     # shellcheck disable=SC2001
     local jreName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]}" | sed 's/-jdk/-jre/')
+    # for macOS system, code sign directory before creating tar.gz file
+    if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then
+      ENTITLEMENTS="$jdkTargetPath/Contents/Info.plist"
+      codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" "${jdkTargetPath}"
+    fi
     createArchive "${jreTargetPath}" "${jreName}"
   fi
   if [ -d "${testImageTargetPath}" ]; then
@@ -960,6 +965,11 @@ createOpenJDKTarArchive() {
     echo "OpenJDK debug image path will be ${debugImageTargetPath}."
     local debugImageName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-debugimage}")
     createArchive "${debugImageTargetPath}" "${debugImageName}"
+  fi
+  # for macOS system, code sign directory before creating tar.gz file
+  if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then
+    ENTITLEMENTS="$jdkTargetPath/Contents/Info.plist"
+    codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" "${jdkTargetPath}"
   fi
   createArchive "${jdkTargetPath}" "${BUILD_CONFIG[TARGET_FILE_NAME]}"
 }


### PR DESCRIPTION
Issue:

After downloading a macOS tar.gz file build by AdoptOpenJDK and try to access the content directly (for example: `./jdk-11.0.10+9/Contents/Home/bin/java -version`). A dialog will pop up and warn the user that the package is damaged:

![image](https://user-images.githubusercontent.com/53073448/114499875-d6463300-9bdb-11eb-8943-fadf613fffbd.png)

Same problem exist for Corretto & Microsoft Build of OpenJDK (https://github.com/microsoft/openjdk/issues/10). However, Zulu tar.gz file does not have this problem.

I notice the signature information is a little bit different by using: `codesign -dvvv {directory}`:

Zulu:

```
Executable=/Users/junyuanz/Downloads/zulu11.45.27-ca-jdk11.0.10-macosx_x64/zulu-11.jdk/Contents/MacOS/libjli.dylib
Identifier=com.azul.zulu.11.0.10.jdk
Format=bundle with Mach-O thin (x86_64)
CodeDirectory v=20500 size=805 flags=0x10000(runtime) hashes=16+5 location=embedded
Hash type=sha256 size=32
CandidateCDHash sha1=4be45945e2e13a0d4a39c43bbf3ae06db70a4c54
CandidateCDHashFull sha1=4be45945e2e13a0d4a39c43bbf3ae06db70a4c54
CandidateCDHash sha256=d892fe4043a34adff3a916fc1b908b10c7b79bee
CandidateCDHashFull sha256=d892fe4043a34adff3a916fc1b908b10c7b79bee343451ec6ce2873d024c2c29
Hash choices=sha1,sha256
CMSDigest=ceedf995e06cc203f4df390041f953117f05b6c91e2c368bdb9c589d8e78e50b
CMSDigestType=2
CDHash=d892fe4043a34adff3a916fc1b908b10c7b79bee
Signature size=9067
Authority=Developer ID Application: Azul Systems, Inc. (TDTHCUPYFR)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=Jan 14, 2021 at 4:35:30 AM
Info.plist entries=12
TeamIdentifier=TDTHCUPYFR
Runtime Version=10.13.0
Sealed Resources version=2 rules=13 files=616
Internal requirements count=1 size=188
```

Adopt:

```
Executable=/Users/junyuanz/Downloads/jdk-11.0.10+9/Contents/MacOS/libjli.dylib
Identifier=libjli
Format=bundle with Mach-O thin (x86_64)
CodeDirectory v=20500 size=786 flags=0x10000(runtime) hashes=16+5 location=embedded
Hash type=sha256 size=32
CandidateCDHash sha1=92a41aa4daaf37b0dda0bd3ef435356d65b373a7
CandidateCDHashFull sha1=92a41aa4daaf37b0dda0bd3ef435356d65b373a7
CandidateCDHash sha256=5d191a7cf335093b429c8e4cc7ad04f6d27c69de
CandidateCDHashFull sha256=5d191a7cf335093b429c8e4cc7ad04f6d27c69de3e4571194efdaed00322cd30
Hash choices=sha1,sha256
CMSDigest=f7aa370451c9e305d7a3dcfc24147a6a2273c317fae6c10b8649bd1b2a823c2a
CMSDigestType=2
CDHash=5d191a7cf335093b429c8e4cc7ad04f6d27c69de
Signature size=9036
Authority=Developer ID Application: London Jamocha Community CIC (VDX7B37674)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=Jan 20, 2021 at 3:55:44 AM
Info.plist=not bound
TeamIdentifier=VDX7B37674
Runtime Version=10.14.0
Sealed Resources=none
Internal requirements count=1 size=168
```

The major differences are the `Info.plist` & `Sealed Resources` failed.

I believe the root cause is: openjdk-build should sign the root directory before creating the tar.gz file. the proposed change is simply sign the root directory first.