### PR TITLE
Improve cuda enablement test

### DIFF
--- a/test/functional/buildAndPackage/playlist.xml
+++ b/test/functional/buildAndPackage/playlist.xml
@@ -29,8 +29,8 @@
         <command>
             $(JAVA_COMMAND) $(JVM_OPTIONS) -cp \
             $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)BuildAndPackagingTests.jar$(Q) org.testng.TestNG \
-            $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -d $(REPORTDIR) -testnames CommonFeatureTests,HotspotFeatureTests -groups $(TEST_GROUP) \
-            -excludegroups $(DEFAULT_EXCLUDE); $(TEST_STATUS)
+            $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -d $(REPORTDIR) -testnames CommonFeatureTests,HotspotFeatureTests \
+            -groups $(TEST_GROUP) -excludegroups $(DEFAULT_EXCLUDE); $(TEST_STATUS)
         </command>
         <levels>
             <level>extended</level>
@@ -50,8 +50,8 @@
         <command>
             $(JAVA_COMMAND) $(JVM_OPTIONS) -cp \
             $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)BuildAndPackagingTests.jar$(Q) org.testng.TestNG \
-            $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -d $(REPORTDIR) -testnames CommonFeatureTests -groups $(TEST_GROUP) \
-            -excludegroups $(DEFAULT_EXCLUDE); $(TEST_STATUS)
+            $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -d $(REPORTDIR) -testnames CommonFeatureTests,OpenJ9FeatureTests \
+            -groups $(TEST_GROUP) -excludegroups $(DEFAULT_EXCLUDE); $(TEST_STATUS)
         </command>
         <levels>
             <level>extended</level>
@@ -63,22 +63,4 @@
             <impl>openj9</impl>
         </impls>
     </test>
-    <test>
-		<testCaseName>CudaEnabledTest</testCaseName>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)BuildAndPackagingTests.jar$(Q) org.testng.TestNG $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -d $(REPORTDIR) -testnames CudaEnabledTest -groups $(TEST_GROUP) -excludegroups $(DEFAULT_EXCLUDE); \
-		$(TEST_STATUS)</command>
-		<levels>
-			<level>extended</level>
-		</levels>
-		<groups>
-			<group>functional</group>
-		</groups>
-        <platformRequirements>os.linux</platformRequirements>
-        <impls>
-            <impl>openj9</impl>
-        </impls>
-        <vendors>
-            <vendor>adoptium</vendor>
-        </vendors>
-	</test>
 </playlist>

--- a/test/functional/buildAndPackage/testng.xml
+++ b/test/functional/buildAndPackage/testng.xml
@@ -28,9 +28,9 @@
         </classes>
     </test>
 
-    <test name="CudaEnabledTest">
-		<classes>
-			<class name="net.adoptium.test.CudaEnabledTest"/>
-		</classes>
-	</test>
+    <test name="OpenJ9FeatureTests">
+        <classes>
+            <class name="net.adoptium.test.CudaEnabledTest"/>
+        </classes>
+    </test>
 </suite>


### PR DESCRIPTION
This changeset includes several upgrades to the cuda enablement test,
including:
- testing for enablement on Windows
- tolerance for all platforms
- tolerance for multiple-vm builds
- tolerance for builds with their j9prt file in a new place
and
- some tidying up for the playlist and testng files to bring this
j9 feature test in-line with the convention used for hotspot feature
tests.

Signed-off-by: Adam Farley <adfarley@redhat.com>