### PR TITLE
Remove invalid debuginfo symlink

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -769,7 +769,7 @@ deleteDebugSymbols() {
     ;;
   *)
     # on other platforms, we want to remove .debuginfo files
-    find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.debuginfo" | xargs rm -f || true
+    find "${jdkTargetPath}" "${jreTargetPath}" -name "*.debuginfo" | xargs rm -f || true
     ;;
   esac
 }


### PR DESCRIPTION
Fixes https://github.com/adoptium/adoptium-support/issues/298 (Rogue symlink to something that gets deleted)

Signed-off-by: Stewart X Addison <sxa@redhat.com>