### PR TITLE
Clarify test exception for JDK8 on OpenJ9

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/JdkVersion.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/JdkVersion.java
@@ -158,6 +158,16 @@ public class JdkVersion {
 
     /**
      * Are we running on an OpenJDK feature version
+     * that is older than the supplied int?
+     * @param  featureParam  supplied int mentioned above
+     * @return boolean       result
+     */
+    public boolean isOlderThan(final int featureParam) {
+        return feature < featureParam;
+    }
+
+    /**
+     * Are we running on an OpenJDK feature version
      * that is greater than the supplied feature int.
      * OR
      * Are we running on the same OpenJDK feature

--- a/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
@@ -67,11 +67,6 @@ public class VendorPropertiesTest {
      */
     @Test
     public void javaVersionPrintsVendor() {
-        // Skip test on JDK8 for non-Hotspot JDKs.
-        if (!jdkVersion.isNewerOrEqual(9) && !jdkVersion.usesVM(VM.HOTSPOT)) {
-            return;
-        }
-
         String testJdkHome = System.getenv("TEST_JDK_HOME");
         if (testJdkHome == null) {
             throw new AssertionError("TEST_JDK_HOME is not set");
@@ -173,7 +168,13 @@ public class VendorPropertiesTest {
 
         @Override
         public void javaVersion(final String value) {
-            assertTrue(value.contains("Eclipse Foundation"));
+            if (jdkVersion.usesVM(VM.OPENJ9) && jdkVersion.isOlderThan(9)) {
+                // For JDK8 on OpenJ9, the vendor name SHOULD NOT be present in the version output.
+                assertFalse(value.contains("Eclipse Foundation"));
+            } else {
+                // For all other JDKs, the vendor name SHOULD be present in the version output.
+                assertTrue(value.contains("Eclipse Foundation"));
+            }
         }
 
         @Override


### PR DESCRIPTION
This exception is specific to OpenJ9, so the exception should mention
it by name.

Signed-off-by: Adam Farley <adfarley@redhat.com>