### PR TITLE
Correct jdk8u SEM_VER creation from build tag

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1107,7 +1107,10 @@ addSemVer() { # Pulls the semantic version from the tag associated with the open
   local fullVer=$(getOpenJdkVersion)
   SEM_VER="$fullVer"
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
-    SEM_VER=$(echo "$SEM_VER" | cut -c4- | awk -F'[-b0]+' '{print $1"+"$2}' | sed 's/u/.0./')
+    # Translate jdk8uNNN-bBB to 8.0.NNN.BB, where NNN is any number and BB is 2 digits removing leading 0 if present
+    # eg. jdk8u302-b00 => 8.0.302.0
+    # eg. jdk8u292-b10 => 8.0.292.10
+    SEM_VER=$(echo "$SEM_VER" | cut -c4- | awk -F'[-b]+' '{print $1"+"$2}' | sed 's/u/.0./' | sed 's/\+0/\+/')
   else
     SEM_VER=$(echo "$SEM_VER" | cut -c5-) # i.e. 11.0.2+12
   fi


### PR DESCRIPTION
SEM_VER calculation from build tag was incorrectly removing "0" from anywhere in the tag.

Fixes: adoptium/adoptium-support#295
Signed-off-by: Andrew Leonard <anleonar@redhat.com>