### PR TITLE
fix broken vendor version test

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import static net.adoptopenjdk.test.JdkVersion.VM;
+import static net.adoptium.test.JdkVersion.VM;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;


### PR DESCRIPTION
As reported by @andrew-m-leonard

```bash
19:38:37      [javac] /home/jenkins/workspace/build-scripts/jobs/jdk8u/jdk8u-linux-ppc64le-hotspot_SmokeTests/openjdk-tests/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java:26: error: package net.adoptopenjdk.test does not exist
19:38:37      [javac] import static net.adoptopenjdk.test.JdkVersion.VM;
```