### PR TITLE
Switch codesigning to use Eclipse Foundation certificate

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -65,7 +65,7 @@ else
 fi
 
 # The configure option '--with-macosx-codesign-identity' is supported in JDK8 OpenJ9 and JDK11 and JDK14+
-if [[ ( "$JAVA_FEATURE_VERSION" -eq 11 ) || ( "$JAVA_FEATURE_VERSION" -ge 14 ) || ( "$JAVA_FEATURE_VERSION" -eq 8 && "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ) ]]
+if [[ ( "$JAVA_FEATURE_VERSION" -eq 11 ) || ( "$JAVA_FEATURE_VERSION" -ge 14 ) ]]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
   ## Login to KeyChain

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -68,14 +68,14 @@ fi
 if [[ ( "$JAVA_FEATURE_VERSION" -eq 11 ) || ( "$JAVA_FEATURE_VERSION" -ge 14 ) || ( "$JAVA_FEATURE_VERSION" -eq 8 && "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ) ]]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
-  # Login to KeyChain
-  # shellcheck disable=SC2046
-  # shellcheck disable=SC2006
-  security unlock-keychain -p `cat ~/.password` login.keychain-db
-  rm -rf codesign-test && touch codesign-test
-  codesign --sign "Developer ID Application: London Jamocha Community CIC" codesign-test
-  codesign -dvvv codesign-test
-  export BUILD_ARGS="${BUILD_ARGS} --codesign-identity 'Developer ID Application: London Jamocha Community CIC'"
+  ## Login to KeyChain
+  ## shellcheck disable=SC2046
+  ## shellcheck disable=SC2006
+  #security unlock-keychain -p `cat ~/.password` login.keychain-db
+  #rm -rf codesign-test && touch codesign-test
+  #codesign --sign "Developer ID Application: London Jamocha Community CIC" codesign-test
+  #codesign -dvvv codesign-test
+  #export BUILD_ARGS="${BUILD_ARGS} --codesign-identity 'Developer ID Application: London Jamocha Community CIC'"
 fi
 
 echo "[WARNING] You may be asked for your su user password, attempting to switch Xcode version to ${XCODE_SWITCH_PATH}"

--- a/sign.sh
+++ b/sign.sh
@@ -135,7 +135,8 @@ signRelease()
         # shellcheck disable=SC2006
         security unlock-keychain -p `cat ~/.password` login.keychain-db
         xattr -cr .
-        echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
+        # If you're using this script, make sure to update the certificate with your developer application ID
+        echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: XXX" "$f"; done
       fi
       ;;
     *)

--- a/sign.sh
+++ b/sign.sh
@@ -82,9 +82,11 @@ signRelease()
             if [ "$SIGN_TOOL" = "ucl" ]; then
               ucl sign-code --file "$f" -n WindowsSHA -t "${SERVER}" --hash SHA256
             elif [ "$SIGN_TOOL" = "eclipse" ]; then
-              mv "$f" "unsigned-$f"
-              curl -o "$f" -F file="unsigned-$f" https://cbi.eclipse.org/authenticode/sign
-              rm -rf "unsigned-$f"
+              dir=$(dirname "$f")
+              file=$(basename "$f")
+              mv "$f" "${dir}/unsigned_${file}"
+              curl -o "$f" -F file="${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
+              rm -rf "${dir}/unsigned_${file}"
             else
               "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t "${SERVER}" "$f"
             fi

--- a/sign.sh
+++ b/sign.sh
@@ -177,7 +177,7 @@ configDefaults
 parseArguments "$@"
 extractArchive
 
-if [ "${OPERATING_SYSTEM}" == "windows" ]; then
+if [ "${OPERATING_SYSTEM}" = "windows" ]; then
   BUILD_CONFIG[OS_KERNEL_NAME]="cygwin"
 fi
 

--- a/sign.sh
+++ b/sign.sh
@@ -179,6 +179,7 @@ parseArguments "$@"
 extractArchive
 
 if [ "${OPERATING_SYSTEM}" = "windows" ]; then
+  # this is because the windows signing is performed by a Linux machine now. It needs this variable set to know to create a zipfile instead of a tarball
   BUILD_CONFIG[OS_KERNEL_NAME]="cygwin"
 fi
 

--- a/sign.sh
+++ b/sign.sh
@@ -123,8 +123,10 @@ signRelease()
           echo "Signing $f using Eclipse Foundation codesign service"
           dir=$(dirname "$f")
           file=$(basename "$f")
+          permissions=$(stat -c "%a %n" "$f" | awk '{split($0,a); print a[1]}')
           mv "$f" "${dir}/unsigned_${file}"
           curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi-staging.eclipse.org/macos/codesign/sign
+          chmod "$permissions" "$f"
           rm -rf "${dir}/unsigned_${file}"
         done
       else

--- a/sign.sh
+++ b/sign.sh
@@ -125,7 +125,7 @@ signRelease()
           file=$(basename "$f")
           permissions=$(stat -c "%a %n" "$f" | awk '{split($0,a); print a[1]}')
           mv "$f" "${dir}/unsigned_${file}"
-          curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi-staging.eclipse.org/macos/codesign/sign
+          curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
           chmod "$permissions" "$f"
           rm -rf "${dir}/unsigned_${file}"
         done


### PR DESCRIPTION
Currently this only works for Windows and macOS (jdk8u). I will need to fix up the remaining macOS versions.