### PR TITLE
Fix Windows codesign permissions

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -79,8 +79,10 @@ signRelease()
           echo "Signing $f using Eclipse Foundation codesign service"
           dir=$(dirname "$f")
           file=$(basename "$f")
+          permissions=$(stat -c "%a %n" "$f" | awk '{split($0,a); print a[1]}')
           mv "$f" "${dir}/unsigned_${file}"
           curl -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
+          chmod "$permissions" "$f"
           rm -rf "${dir}/unsigned_${file}"
         else
           STAMPED=false

--- a/sign.sh
+++ b/sign.sh
@@ -79,10 +79,9 @@ signRelease()
           echo "Signing $f using Eclipse Foundation codesign service"
           dir=$(dirname "$f")
           file=$(basename "$f")
-          permissions=$(stat -c "%a %n" "$f" | awk '{split($0,a); print a[1]}')
           mv "$f" "${dir}/unsigned_${file}"
           curl -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
-          chmod "$permissions" "$f"
+          chmod --reference="@${dir}/unsigned_${file}" "$f"
           rm -rf "${dir}/unsigned_${file}"
         else
           STAMPED=false
@@ -125,10 +124,9 @@ signRelease()
           echo "Signing $f using Eclipse Foundation codesign service"
           dir=$(dirname "$f")
           file=$(basename "$f")
-          permissions=$(stat -c "%a %n" "$f" | awk '{split($0,a); print a[1]}')
           mv "$f" "${dir}/unsigned_${file}"
           curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-          chmod "$permissions" "$f"
+          chmod --reference="@${dir}/unsigned_${file}" "$f"
           rm -rf "${dir}/unsigned_${file}"
         done
       else

--- a/sign.sh
+++ b/sign.sh
@@ -81,7 +81,7 @@ signRelease()
           file=$(basename "$f")
           mv "$f" "${dir}/unsigned_${file}"
           curl -o "$f" -F file="@${dir}/unsigned_${file}" https://cbi.eclipse.org/authenticode/sign
-          chmod --reference="@${dir}/unsigned_${file}" "$f"
+          chmod --reference="${dir}/unsigned_${file}" "$f"
           rm -rf "${dir}/unsigned_${file}"
         else
           STAMPED=false
@@ -126,7 +126,7 @@ signRelease()
           file=$(basename "$f")
           mv "$f" "${dir}/unsigned_${file}"
           curl -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-          chmod --reference="@${dir}/unsigned_${file}" "$f"
+          chmod --reference="${dir}/unsigned_${file}" "$f"
           rm -rf "${dir}/unsigned_${file}"
         done
       else


### PR DESCRIPTION
Currently, the executable bit isn't added back to the codesigned binary:

```bash
bin/java: Permission denied
```