### PR TITLE
Add extended buildinfo to metadata

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -54,6 +54,9 @@ echo "Starting $0 to configure, build (Adopt)OpenJDK binary"
 configure_build "$@"
 writeConfigToFile
 
+# Store params to this script as "buildinfo"
+echo "$@" > ./workspace/config/makejdk-any-platform.args
+
 # Let's build and test the (Adopt) OpenJDK binary in Docker or natively
 if [ "${BUILD_CONFIG[USE_DOCKER]}" == "true" ] ; then
   buildOpenJDKViaDocker

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1072,6 +1072,10 @@ addInfoToReleaseFile() {
   addImplementor
   echo "ADDING BUILD SHA"
   addBuildSHA
+  echo "ADDING BUILD SOURCE REPO"
+  addBuildSourceRepo
+  echo "ADDING OPENJDK SOURCE REPO"
+  addOpenJDKSourceRepo
   echo "ADDING FULL VER"
   addFullVersion
   echo "ADDING SEM VER"
@@ -1139,6 +1143,26 @@ addBuildSHA() { # git SHA of the build repository i.e. openjdk-build
     echo -e BUILD_SOURCE=\"git:$buildSHA\" >>release
   else
     echo "Unable to fetch build SHA, does a work tree exist?..."
+  fi
+}
+
+addBuildSourceRepo() { # name of git repo for which BUILD_SOURCE sha is from
+  local buildSourceRepo=$(git -C "${BUILD_CONFIG[WORKSPACE_DIR]}" config --get remote.origin.url 2>/dev/null)
+  if [[ $buildSourceRepo ]]; then
+    # shellcheck disable=SC2086
+    echo -e BUILD_SOURCE_REPO=\"$buildSourceRepo\" >>release
+  else
+    echo "Unable to fetch Build Source Repo, does a work tree exist?..."
+  fi
+}
+
+addOpenJDKSourceRepo() { # name of git repo for which SOURCE sha is from
+  local openjdkSourceRepo=$(git -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" config --get remote.origin.url 2>/dev/null)
+  if [[ $openjdkSourceRepo ]]; then
+    # shellcheck disable=SC2086
+    echo -e SOURCE_REPO=\"$openjdkSourceRepo\" >>release
+  else
+    echo "Unable to fetch OpenJDK Source Repo, does a work tree exist?..."
   fi
 }
 
@@ -1210,9 +1234,11 @@ addImageType() {
 
 addInfoToJson(){
   mv "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/configure.txt" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/"
+  mv "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/makeCommandArg.txt" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/"
   addVariantVersionToJson
   addVendorToJson
-  addSourceToJson # Build repository commit SHA
+  addSourceToJson # Build repository and commit SHA
+  addOpenJDKSourceToJson # OpenJDK repository and commit SHA
 }
 
 addVariantVersionToJson(){
@@ -1237,13 +1263,24 @@ addVendorToJson(){
   echo -n "${BUILD_CONFIG[VENDOR]}" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/vendor.txt"
 }
 
-addSourceToJson(){ # Pulls the basename of the origin repo, or uses 'openjdk-build' in rare cases of failure
-  local repoName=$(basename "$(cd "${BUILD_CONFIG[WORKSPACE_DIR]%.git}" && git config --get remote.origin.url 2>/dev/null)")
+addSourceToJson(){ # Pulls the origin repo, or uses 'openjdk-build' in rare cases of failure
+  local repoName=$(git -C "${BUILD_CONFIG[WORKSPACE_DIR]}" config --get remote.origin.url 2>/dev/null)
+  local repoNameStr="${repoName:-"ErrorUnknown"}"
   local buildSHA=$(git -C "${BUILD_CONFIG[WORKSPACE_DIR]}" rev-parse --short HEAD 2>/dev/null)
   if [[ $buildSHA ]]; then
-    echo -n "${repoName:-"openjdk-build"}/$buildSHA" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
+    echo -n "${repoNameStr%%.git}/commit/$buildSHA" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
   else
     echo "Unable to fetch build SHA, does a work tree exist?..."
+  fi
+}
+
+addOpenJDKSourceToJson() { # name of git repo for which SOURCE sha is from
+  local openjdkSourceRepo=$(git -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" config --get remote.origin.url 2>/dev/null)
+  local openjdkSHA=$(git -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" rev-parse --short HEAD 2>/dev/null)
+  if [[ $openjdkSHA ]]; then
+    echo -n "${openjdkSourceRepo%%.git}/commit/${openjdkSHA}" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"
+  else
+    echo "Unable to fetch OpenJDK Source SHA, does a work tree exist?..."
   fi
 }
 

--- a/sbin/build.template
+++ b/sbin/build.template
@@ -40,6 +40,7 @@ else
 fi
 
 #Templated var that, gets replaced by build.sh
+echo "{makeCommandArg}" > "$1/$2/makeCommandArg.txt"
 {makeCommandArg}
 
 exitCode=$?


### PR DESCRIPTION
Extensions for re-recreatable builds as per: adoptium/temurin-build#2594 (comment)

Follow-on PR for ci-jenkins-pipelines will enable in metadata: https://github.com/adoptium/ci-jenkins-pipelines/pull/153

Signed-off-by: Andrew Leonard <anleonar@redhat.com>