### PR TITLE
Remove showCompletionMessage

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1287,7 +1287,6 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   setPlistForMacOS
   addNoticeFile
   createOpenJDKTarArchive
-  showCompletionMessage
   exit 0
 fi
 


### PR DESCRIPTION
It was removed as part of https://github.com/adoptium/temurin-build/pull/2417 but it was clearly missed for the exploded image