### PR TITLE
Add missing steps for ASSEMBLE_EXPLODED_IMAGE build

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1287,6 +1287,9 @@ parseArguments "$@"
 if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   buildTemplatedFile
   executeTemplatedFile
+  printJavaVersionString
+  addInfoToReleaseFile
+  addInfoToJson
   removingUnnecessaryFiles
   copyFreeFontForMacOS
   setPlistForMacOS


### PR DESCRIPTION
These steps are all run on regular builds but weren't added to the ASSEMBLE_EXPLODED_IMAGE function