### PR TITLE
skip running configure again after signing exploded image

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -458,8 +458,12 @@ buildTemplatedFile() {
 
   echo "Currently at '${PWD}'"
 
-  FULL_CONFIGURE="bash ./configure --verbose ${CONFIGURE_ARGS}"
-  echo "Running ./configure with arguments '${FULL_CONFIGURE}'"
+  if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" != "true" ]]; then
+    FULL_CONFIGURE="bash ./configure --verbose ${CONFIGURE_ARGS}"
+    echo "Running ./configure with arguments '${FULL_CONFIGURE}'"
+  else
+    echo "Skipping configure because we're assembling an exploded image"
+  fi
 
   # If it's Java 9+ then we also make test-image to build the native test libraries,
   # For openj9 add debug-image


### PR DESCRIPTION
Fixes the JDK11 OpenJ9 build failure on macOS:

```bash
09:14:56  **********************************************************************
09:14:56  ***                                                                ***
09:14:56  ***   OpenSSL has been successfully configured                     ***
09:14:56  ***                                                                ***
09:14:56  ***   If you encounter a problem while building, please open an    ***
09:14:56  ***   issue on GitHub <https://github.com/openssl/openssl/issues>  ***
09:14:56  ***   and include the output from the following command:           ***
09:14:56  ***                                                                ***
09:14:56  ***       perl configdata.pm --dump                                ***
09:14:56  ***                                                                ***
09:14:56  ***   (If you are new to OpenSSL, you might want to consult the    ***
09:14:56  ***   'Troubleshooting' section in the INSTALL file first)         ***
09:14:56  ***                                                                ***
09:14:56  **********************************************************************
09:14:57  make[5]: *** wait: No child processes.  Stop.
09:14:57  make[4]: *** [all] Error 2
09:14:57  make[3]: *** [build-j9] Error 2
09:14:57  make[2]: *** [j9vm-build] Error 2
09:14:57  
```