### PR TITLE
Enabling Hotspot Smoke Tests and correcting an expected value

### DIFF
--- a/test/functional/buildAndPackage/playlist.xml
+++ b/test/functional/buildAndPackage/playlist.xml
@@ -42,7 +42,7 @@
             <impl>hotspot</impl>
         </impls>
          <vendors>
-            <vendor>adoptium</vendor>
+            <vendor>eclipse</vendor>
         </vendors>
     </test>
     <test>

--- a/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
@@ -201,7 +201,7 @@ public class VendorPropertiesTest {
 
         @Override
         public void javaVmVendor(final String value) {
-            assertTrue(value.equals("Adoptium") || value.equals("Eclipse OpenJ9"));
+            assertTrue(value.equals("Eclipse Foundation") || value.equals("Eclipse OpenJ9"));
         }
 
         @Override


### PR DESCRIPTION
This change includes a playlist tweak to enable the hotspot smoke
tests to run, and also modifies the expected system property
"java.vm.vendor" for adoptium's Hotspot JDK to be "Eclipse Foundation".

As this change brings "java.vm.vendor" in line with the values
expected from other properties, I'm asserting that this is likely
not a bug, but I'll consult with my fellow developers before
merging, just to be safe.

Signed-off-by: Adam Farley <adfarley@redhat.com>