### PR TITLE
Set company name for JDK8 to label version output as Temurin

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -237,8 +237,9 @@ configureVersionStringParameter() {
     BUILD_CONFIG[VENDOR_BUG_URL]="https://gitee.com/openeuler/bishengjdk-11/issues"
     BUILD_CONFIG[VENDOR_VM_BUG_URL]="https://gitee.com/openeuler/bishengjdk-11/issues"
   fi
-
-  addConfigureArg "--with-vendor-name=" "\"${BUILD_CONFIG[VENDOR]}\""
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" != 8 ]; then
+    addConfigureArg "--with-vendor-name=" "\"${BUILD_CONFIG[VENDOR]}\""
+  fi
   addConfigureArg "--with-vendor-url=" "${BUILD_CONFIG[VENDOR_URL]:-"https://adoptium.net/"}"
   addConfigureArg "--with-vendor-bug-url=" "${BUILD_CONFIG[VENDOR_BUG_URL]:-"https://github.com/adoptium/adoptium-support/issues"}"
   addConfigureArg "--with-vendor-vm-bug-url=" "${BUILD_CONFIG[VENDOR_VM_BUG_URL]:-"https://github.com/adoptium/adoptium-support/issues"}"


### PR DESCRIPTION
Version out to be more consistent with JDK11+

```
openjdk version "1.8.0_302-beta"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_302-beta-202106101522-b05)
OpenJDK 64-Bit Server VM (Temurin)(build 25.302-b05, mixed mode)
```