### PR TITLE
skip previous pr tester runs if another push to a branch has been made

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,19 @@ on:
     branches: [ master ]
 
 jobs:
+  cancel-previous-workflow-runs:
+    name: "Cancel previous workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: duplicates
+          cancelFutureDuplicates: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          notifyPRCancel: true
+
   build_linux:
     name: Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, we have lots of PR tester backlog from where people make several pushes to a fork. 

This PR adds a cancel action that will automatically abort the previous runs