### PR TITLE
Allow building of arm32 target on aarch64 kernels with default 32-bit userspace (and use >4 cores)

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -81,12 +81,15 @@ then
   if lscpu | grep aarch64; then
      echo Validating 32-bit environment on 64-bit host - perhaps it is a docker container ...
      if ! file /bin/ls | grep "32-bit.*ARM"; then
-       echo /bin/ls is not a 32-bit system. This configuration is invalid without extra work
+       echo /bin/ls is not a 32-bit binary but ARCHITECTURE=arm. Non-32-bit userland is invalid without extra work
        exit 1
      fi
      echo Looks reasonable - configuring to allow building that way ...
      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --target=armv7l-unknown-linux-gnueabihf --host=armv7l-unknown-linux-gnueabihf"
   fi
+  # "4" is a temporary override which allows us to utilise all build
+  # cores on our scaleway systems while they are still in use but still
+  # allow more on larger machines. Can be revisited post-Scaleway
   if [ "$(lscpu|awk '/^CPU\(s\)/{print$2}')" = "4" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-jobs=4 --with-memory-size=2000"
   fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -78,15 +78,16 @@ fi
 
 if [ "${ARCHITECTURE}" == "arm" ]
 then
-  if [ "$(uname -m)" == "aarch64" ]; then
+  if lscpu | grep aarch64; then
      echo Validating 32-bit environment on 64-bit host - perhaps it is a docker container ...
-     if ! file /bin/ls | grep 32-bit.*ARM; then
+     if ! file /bin/ls | grep "32-bit.*ARM"; then
        echo /bin/ls is not a 32-bit system. This configuration is invalid without extra work
        exit 1
      fi
      echo Looks reasonable - configuring to allow building that way ...
      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --target=armv7l-unknown-linux-gnueabihf --host=armv7l-unknown-linux-gnueabihf"
-  else
+  fi
+  if [ "$(lscpu|awk '/^CPU\(s\)/{print$2}')" = "4" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-jobs=4 --with-memory-size=2000"
   fi
   if [ "$JAVA_FEATURE_VERSION" -eq 8 ]; then

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -44,6 +44,15 @@ then
   fi
 fi
 
+if [ "$(uname -m)" == "aarch64" ] && [ "$ARCHITECTURE" = "arm" ]
+then
+   echo Validating 32-bit environment on 64-bit host - perhaps it is a docker container ...
+   file /bin/ls | grep 32-bit.*ARM
+   [ $? -ne 0 ] && echo /bin/ls is not a 32-bit system. This configuration is invalid without extra work && exit 1
+   echo Looks reasonable - configuring to allow building that way ...
+   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --target=armv7l-unknown-linux-gnueabihf --host=armv7l-unknown-linux-gnueabihf"
+fi
+
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
 then
   # CentOS 6 has openssl 1.0.1 so we use a self-installed 1.0.2 from the playbooks


### PR DESCRIPTION
This will allow us to sped up the arm32 builds by running them in docker containers on the larger aarch64 hosts which we have. (Note that at present the main build will work but `make images` in the JDK currently requires a modified `uname` command which gives the correct result)

Related: https://github.com/adoptium/infrastructure/pull/2201