### PR TITLE
Use Ubuntu-supplied GCC on JDK8u arm32 builds

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -154,7 +154,8 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION
   export PATH=/usr/local/gcc9/bin:$PATH
   export CC=/usr/local/gcc9/bin/gcc-9.3
   export CXX=/usr/local/gcc9/bin/g++-9.3
-elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
+  # arm32 exclusion is due to https://github.com/adoptium/adoptium-support/issues/319
+elif [ -r /usr/local/gcc/bin/gcc-7.5 ] && ! ( [ "$ARCHITECTURE" == "arm" ] && [ "$JAVA_FEATURE_VERSION" -gt 8 ] ); then
   export PATH=/usr/local/gcc/bin:$PATH
   [ -r /usr/local/gcc/bin/gcc-7.5 ] && export CC=/usr/local/gcc/bin/gcc-7.5
   [ -r /usr/local/gcc/bin/g++-7.5 ] && export CXX=/usr/local/gcc/bin/g++-7.5


### PR DESCRIPTION
Fixes https://github.com/adoptium/adoptium-support/issues/319 (As long as we're happy building with gcc 5.4.0 instead of 7.5.0 on this build only)

Signed-off-by: Stewart X Addison <sxa@redhat.com>