### PR TITLE
Arm machines do not have /etc/system-release use /etc/os-release

### DIFF
--- a/aaa
+++ b/aaa
@@ -1,0 +1,17 @@
+NAME="Red Hat Enterprise Linux Server"
+VERSION="7.9 (Maipo)"
+ID="rhel"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="7.9"
+PRETTY_NAME="Red Hat"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.9:GA:server"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.9
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.9"

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -371,10 +371,20 @@ function configDefaults() {
   local unameSys=$(uname -s)
   local unameOSSysVer=$(uname -sr)
   if [ "${unameSys}" == "Linux" ]; then
-    # Linux distribs add more useful distrib in the single line file /etc/system-release
+    # Linux distribs add more useful distrib in the single line file /etc/system-release,
+    # or property file /etc/os-release
     if [ -f "/etc/system-release" ]; then
       local linuxName=$(tr -d '"' < /etc/system-release)
       unameOSSysVer="${unameOSSysVer} : ${linuxName}"
+    elif [ -f "/etc/os-release" ]; then
+      if grep "^NAME=" /etc/os-release; then
+        local osName=$(grep "^NAME=" /etc/os-release | cut -d= -f2 | tr -d '"')
+        unameOSSysVer="${unameOSSysVer} : ${osName}"
+      fi
+      if grep "^VERSION=" /etc/os-release; then
+        local osVersion=$(grep "^VERSION=" /etc/os-release | cut -d= -f2 | tr -d '"')
+        unameOSSysVer="${unameOSSysVer} ${osVersion}"
+      fi
     fi
   elif [ "${unameSys}" == "AIX" ]; then
     # AIX provides full version info using oslevel


### PR DESCRIPTION
Arm machines do not have /etc/system-release, but do have /etc/os-release, default to NAME & VERSION from that if no system-release

Signed-off-by: Andrew Leonard <anleonar@redhat.com>