### PR TITLE
Updates to better handle RISC-V cross envs and alternate OpenJDK repos

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -179,13 +179,14 @@ fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
   # BUILD_C/CXX required for native (non-cross) RISC-V builds of Bisheng
-  if [ ! -z "$CXX" ]; then
+  if [ -n "$CXX" ]; then
     export BUILD_CC="$CC"
     export BUILD_CXX="$CXX"
   fi
   # Bisheng on aarch64 has a KAE option which requires openssl 1.1.1 to be used
-  if [ -x /usr/local/openssl-1.1.1/lib/libcrypto.so.1.1 ]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cflags=-I/usr/local/openssl-1.1.1/include  --with-extra-cxxflags=-I/usr/local/openssl-1.1.1/include --with-extra-ldflags=-L/usr/local/openssl-1.1.1/lib"
+  BISHENG_OPENSSL_111_LOCATION=${BISHENG_OPENSSL_111_LOCATION:-/usr/local/openssl-1.1.1}
+  if [ -x "${BISHENG_OPENSSL_111_LOCATION}/lib/libcrypto.so.1.1" ]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cflags=-I${BISHENG_OPENSSL_111_LOCATION}/include  --with-extra-cxxflags=-I${BISHENG_OPENSSL_111_LOCATION}/include --with-extra-ldflags=-L${BISHENG_OPENSSL_111_LOCATION}/lib"
   fi
 fi
 
@@ -196,7 +197,7 @@ fi
 # Handle cross compilation environment for RISC-V
 NATIVE_API_ARCH=$(uname -m)
 if [ "${NATIVE_API_ARCH}" = "x86_64" ]; then NATIVE_API_ARCH=x64; fi
-if [ "${NATIVE_API_ARCH}" = "armv7l" ]; then NATIVE_ARCH=arm; fi
+if [ "${NATIVE_API_ARCH}" = "armv7l" ]; then NATIVE_API_ARCH=arm; fi
 if [ "${ARCHITECTURE}" == "riscv64" ] && [ "${NATIVE_API_ARCH}" != "riscv64" ]; then
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     export BUILDJDK=${WORKSPACE:-$PWD}/buildjdk
@@ -242,8 +243,9 @@ if [ "${ARCHITECTURE}" == "riscv64" ] && [ "${NATIVE_API_ARCH}" != "riscv64" ]; 
     export RISCV_TOOLCHAIN_TYPE=install
   fi
   RISCV_SYSROOT=${RISCV_SYSROOT:-/opt/fedora28_riscv_root}
-  if [ ! -d "${RISCV_SYSROOT}"]; then
+  if [ ! -d "${RISCV_SYSROOT}" ]; then
      echo "RISCV_SYSROOT=${RISCV_SYSROOT} is undefined or does not exist - cannot proceed"
+     exit 1
   fi
   CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=${RISCV_SYSROOT} -with-boot-jdk=$JDK_BOOT_DIR"
 

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -177,25 +177,38 @@ elif [ -r /usr/bin/gcc-7 ]; then
   [ -r /usr/bin/g++-7 ] && export CXX=/usr/bin/g++-7
 fi
 
-# Bisheng on aarch64 has a KAE option which requires openssl 1.1.1 to be used
-if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ] && [ -x /usr/local/openssl-1.1.1/lib/libcrypto.so.1.1 ]; then
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cflags=-I/usr/local/openssl-1.1.1/include  --with-extra-cxxflags=-I/usr/local/openssl-1.1.1/include --with-extra-ldflags=-L/usr/local/openssl-1.1.1/lib"
+if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
+  # BUILD_C/CXX required for native (non-cross) RISC-V builds of Bisheng
+  if [ ! -z "$CXX" ]; then
+    export BUILD_CC="$CC"
+    export BUILD_CXX="$CXX"
+  fi
+  # Bisheng on aarch64 has a KAE option which requires openssl 1.1.1 to be used
+  if [ -x /usr/local/openssl-1.1.1/lib/libcrypto.so.1.1 ]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cflags=-I/usr/local/openssl-1.1.1/include  --with-extra-cxxflags=-I/usr/local/openssl-1.1.1/include --with-extra-ldflags=-L/usr/local/openssl-1.1.1/lib"
+  fi
 fi
 
 if which ccache 2> /dev/null; then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
 fi
 
-# If we are in a cross compilation environment for RISC-V
-if [ "${ARCHITECTURE}" == "riscv64" ] && [ "$(uname -m)" == "x86_64" ]; then
+# Handle cross compilation environment for RISC-V
+NATIVE_API_ARCH=$(uname -m)
+if [ "${NATIVE_API_ARCH}" = "x86_64" ]; then NATIVE_API_ARCH=x64; fi
+if [ "${NATIVE_API_ARCH}" = "armv7l" ]; then NATIVE_ARCH=arm; fi
+if [ "${ARCHITECTURE}" == "riscv64" ] && [ "${NATIVE_API_ARCH}" != "riscv64" ]; then
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     export BUILDJDK=${WORKSPACE:-$PWD}/buildjdk
-    echo RISCV cross-compilation for OpenJ9 ... Downloading required nightly OpenJ9/x64 as build JDK to "$BUILDJDK"
+    echo "RISCV cross-compilation for OpenJ9 ... Downloading required nightly OpenJ9/${NATIVE_API_ARCH} as build JDK to $BUILDJDK"
     rm -rf "$BUILDJDK"
     mkdir "$BUILDJDK"
-    wget -q -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
-    "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g'
+    wget -q -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/${NATIVE_API_ARCH}/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
+    "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g' || exit 1
     CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-jdk=$BUILDJDK --disable-ddr"
+    if [ -d /usr/local/openssl102 ]; then
+      CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/usr/local/openssl102"
+    fi
   elif [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
     if [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
       BUILD_CC=/usr/local/gcc/bin/gcc-7.5
@@ -208,16 +221,32 @@ if [ "${ARCHITECTURE}" == "riscv64" ] && [ "$(uname -m)" == "x86_64" ]; then
       exit 1
     fi
   fi
+
+  # RISC-V cross compile settings for all VARIANT values
   echo RISC-V cross-compilation setup ...  Setting RISCV64, LD_LIBRARY_PATH, PATH, CC, CXX
   export RISCV64=/opt/riscv_toolchain_linux
   export LD_LIBRARY_PATH=$RISCV64/lib64
   if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BUILD_LIBRARY_PATH
   fi
-  export PATH="$RISCV64/bin:$PATH"
-  export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
-  export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
-  CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR"
+
+  if [ -r "$RISCV64/bin/riscv64-unknown-linux-gnu-g++" ]; then
+    export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
+    export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
+    export PATH="$RISCV64/bin:$PATH"
+  elif [ -r /usr/bin/riscv64-linux-gnu-g++ ]; then
+    export CC=/usr/bin/riscv64-linux-gnu-gcc
+    export CXX=/usr/bin/riscv64-linux-gnu-g++
+    # This is required for OpenJ9 if not using "riscv64-unknown-linux-gnu-*"
+    # i.e. if using the default cross compiler supplied with Debian/Ubuntu
+    export RISCV_TOOLCHAIN_TYPE=install
+  fi
+  RISCV_SYSROOT=${RISCV_SYSROOT:-/opt/fedora28_riscv_root}
+  if [ ! -d "${RISCV_SYSROOT}"]; then
+     echo "RISCV_SYSROOT=${RISCV_SYSROOT} is undefined or does not exist - cannot proceed"
+  fi
+  CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=${RISCV_SYSROOT} -with-boot-jdk=$JDK_BOOT_DIR"
+
   if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
     CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-jvm-features=shenandoahgc BUILD_CC=$BUILD_CC BUILD_CXX=$BUILD_CXX"
   fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1080,6 +1080,17 @@ getFirstTagFromOpenJDKGitRepo() {
 
   if [ -z "$firstMatchingNameFromRepo" ]; then
     echo "WARNING: Failed to identify latest tag in the repository" 1>&2
+    if [ "${BUILD_CONFIG[DISABLE_ADOPT_BRANCH_SAFETY]}" == "true" ]; then
+      if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
+         echo "WARNING: Could not identify latest tag but the ADOPT_BRANCH_SAFETY flag is off so defaulting to 8u000-b00" 1>&2
+         echo "8u000-b00"
+      else
+         echo "WARNING: Could not identify latest tag but the ADOPT_BRANCH_SAFETY flag is off so defaulting to jdk-${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}.0.0+0" 1>&2
+         echo "jdk-${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}.0.0+0"
+      fi
+    else
+      echo "WARNING: Failed to identify latest tag in the repository" 1>&2
+    fi
   else
     echo "$firstMatchingNameFromRepo"
   fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1080,6 +1080,9 @@ getFirstTagFromOpenJDKGitRepo() {
 
   if [ -z "$firstMatchingNameFromRepo" ]; then
     echo "WARNING: Failed to identify latest tag in the repository" 1>&2
+    # If the ADOPT_BRANCH_SAFETY flag is set, we may be building from an alternate
+    # repository that doesn't have the same tags, so allow defaults. For a better 
+    # options see https://github.com/adoptium/temurin-build/issues/2671
     if [ "${BUILD_CONFIG[DISABLE_ADOPT_BRANCH_SAFETY]}" == "true" ]; then
       if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
          echo "WARNING: Could not identify latest tag but the ADOPT_BRANCH_SAFETY flag is off so defaulting to 8u000-b00" 1>&2


### PR DESCRIPTION
A few changes here - mostly in the interests of usability of our scripts:

- Allow cross compilation in environments other than x86-64 (`NATIVE_API_ARCH` variable)
- Set `BUILD_CC` and `BUILD_CXX` for Bisheng if building natively on RISC-V
- Abort immediately if the build JDK is not usable.
- Allow Debian/Ubuntu-supplied native cross compilers from `/usr/bin` to be used
- Allow `RISCV_SYSROOT` to be overriden but still use `/opt/fedora28_riscv_root` *(what Adopt uses) as the default.
- If the tag detection logic fails e.g. building from a different openjdk repository and [--disable-adopt-branch-safety](https://github.com/adoptium/ci-jenkins-pipelines/blob/master/FAQ.md#i-want-to-build-code-from-my-own-forkbranch-of-openjdk-in-jenkins) is specified, use 8u000-b00 or jdk-nn-0.0.0+0 to allow building

I would imagine this is all pretty non-controversial, although I'm "open to offers" on the last item here. See [this Slack thread](https://adoptium.slack.com/archives/C09NW3L2J/p1624872251214000) for the original discussion - I've chosen here to re-use the existing flag to handle all "I'm building from somewhere funky" situations, but it could be an alternate parameter e.g. an "Override the tag to be this value explicitly" (can be done separately in a future PR of course)

I do also wonder whether we should split out `temurin` as a separate variant to HotSpot now - the more I think about it in various conversations (particuarly if other people are using our scripts to build HotSpot codebases) the more I think it would keep things simple ... Raised proposal in https://github.com/adoptium/temurin-build/issues/2671

THIS IS IN DRAFT AS I WANT TO DO SOME FURTHER CHECKS, BUT REVIEWS/COMMENTS ARE VERY WELCOME IN THE MEANTIME.

Signed-off-by: Stewart X Addison <sxa@redhat.com>