### PR TITLE
Add support for creating source archives

### DIFF
--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -70,6 +70,9 @@ specify any custom user configuration arguments.
 .BR \-\-clean-git-repo
 clean out any 'bad' local git repo you already have.
 .TP
+.BR \-\-create-source-archive
+create an archive of the sources which got used to build OpenJDK
+.TP
 .BR \-d ", " \-\-destination " " \fI<path>\fR
 specify the location for the built binary, e.g. /path/.
 This is typically used in conjunction with \fB<-T>\fR to create a custom path

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -48,6 +48,7 @@ COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG
 COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG
 COPY_TO_HOST
 CREATE_DEBUG_IMAGE
+CREATE_SOURCE_ARCHIVE
 CUSTOM_CACERTS
 CROSSCOMPILE
 DEBUG_DOCKER
@@ -233,6 +234,9 @@ function parseConfigurationArguments() {
 
         "--create-debug-image" )
         BUILD_CONFIG[CREATE_DEBUG_IMAGE]="true";;
+
+        "--create-source-archive" )
+        BUILD_CONFIG[CREATE_SOURCE_ARCHIVE]=true;;
 
         "--disable-adopt-branch-safety" )
         BUILD_CONFIG[DISABLE_ADOPT_BRANCH_SAFETY]=true;;
@@ -446,6 +450,9 @@ function configDefaults() {
 
   # The default behavior of whether we want to create a separate debug symbols archive
   BUILD_CONFIG[CREATE_DEBUG_IMAGE]="false"
+
+  # The default behavior of whether we want to create a separate source archive
+  BUILD_CONFIG[CREATE_SOURCE_ARCHIVE]="false"
 
   BUILD_CONFIG[SIGN]="false"
   BUILD_CONFIG[JDK_BOOT_DIR]=""


### PR DESCRIPTION
This is useful to see the exact sources that were used when
building the JDK.

After this patch `./makejdk-any-platform.sh --create-source-archive` can be used to produce `-sources` tarballs/zips.

Closes #2698