### PR TITLE
Temporarily remove building JDK (tip) for GH Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [linux]
-        version: [jdk8u, jdk11u, jdk16u, jdk17, jdk]
+        version: [jdk8u, jdk11u, jdk16u, jdk17]
         vm: [hotspot]
         image: [adoptopenjdk/centos7_build_image]
         include:
@@ -197,12 +197,6 @@ jobs:
        with:
          java-version: 11
 
-     - uses: actions/setup-java@v1
-       id: setup-java17
-       with:
-         java-version: 17
-       if: matrix.version == 'jdk'
-
      - name: Install Git
        run: |
          Invoke-WebRequest 'https://github.com/git-for-windows/git/releases/download/v2.14.3.windows.1/Git-2.14.3-64-bit.exe' -OutFile 'C:\temp\git.exe'
@@ -227,10 +221,6 @@ jobs:
 
      - name: Set JAVA_HOME
        run: echo "JAVA_HOME=$(cygpath ${{ steps.setup-java11.outputs.path }})" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-     - name: Set JAVA_HOME
-       run: echo "JAVA_HOME=$(cygpath ${{ steps.setup-java17.outputs.path }})" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-       if: matrix.version == 'jdk'
 
      - name: Set JDK7_BOOT_DIR
        run: echo "JDK7_BOOT_DIR=$(cygpath ${{ steps.setup-java7.outputs.path }})" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,12 @@ jobs:
        with:
          java-version: 11
 
+     - uses: actions/setup-java@v1
+       id: setup-java17
+       with:
+         java-version: 17
+       if: matrix.version == 'jdk'
+
      - name: Install Git
        run: |
          Invoke-WebRequest 'https://github.com/git-for-windows/git/releases/download/v2.14.3.windows.1/Git-2.14.3-64-bit.exe' -OutFile 'C:\temp\git.exe'
@@ -221,6 +227,10 @@ jobs:
 
      - name: Set JAVA_HOME
        run: echo "JAVA_HOME=$(cygpath ${{ steps.setup-java11.outputs.path }})" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+     - name: Set JAVA_HOME
+       run: echo "JAVA_HOME=$(cygpath ${{ steps.setup-java17.outputs.path }})" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+       if: matrix.version == 'jdk'
 
      - name: Set JDK7_BOOT_DIR
        run: echo "JDK7_BOOT_DIR=$(cygpath ${{ steps.setup-java7.outputs.path }})" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
Since we can't yet download the latest 17 it means we can't build tip properly due to sealed classes support.  We will enable this after we release 17 ourselves and use setupjava-2 action