### PR TITLE
Change vendor from Eclipse Foundation to Eclipse Adoptium

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Alongside the built assets a metadata file will be created with info about the b
 
 ```json
 {
-    "vendor": "Eclipse Foundation",
+    "vendor": "Eclipse Adoptium",
     "os": "mac",
     "arch": "x64",
     "variant": "openj9",
@@ -336,7 +336,7 @@ Below are all of the keys contained in the metadata file and some example values
 ----
 
 - `vendor:`
-Example values: [`Eclipse Foundation`, `Alibaba`]
+Example values: [`Eclipse Adoptium`, `Alibaba`]
 
 This tag is used to identify the vendor of the JDK being built, this value is set in the [build.sh](https://github.com/adoptium/temurin-build/blob/805e76acbb8a994abc1fb4b7d582486d48117ee8/sbin/build.sh#L183) file and defaults to "Adoptium".
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -201,7 +201,7 @@ getOpenJdkVersion() {
 #
 # openjdk 11.0.12 2021-07-20
 # OpenJDK Runtime Environment Temurin-11.0.12+7 (build 11.0.12+7)
-# OpenJDK 64-Bit Server VM Temurin-11.0.12+7 (build 11.0.12+7, mixed mode)configureVersionStringParameter() {
+# OpenJDK 64-Bit Server VM Temurin-11.0.12+7 (build 11.0.12+7, mixed mode)
 
 configureVersionStringParameter() {
   stepIntoTheWorkingDirectory
@@ -254,7 +254,7 @@ configureVersionStringParameter() {
 
     if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]; then
 
-      addConfigureArg "--with-company-name=" "Eclipse\\ Adoptium"
+      addConfigureArg "--with-company-name=" "\"Eclipse Adoptium\""
 
       # No JFR support in AIX or zero builds (s390 or armv7l)
       if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "s390x" ] && [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" != "aix" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "armv7l" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -254,7 +254,7 @@ configureVersionStringParameter() {
 
     if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]; then
 
-      addConfigureArg "--with-company-name=" "Eclipse Adoptium"
+      addConfigureArg "--with-company-name=" "Eclipse\\ Adoptium"
 
       # No JFR support in AIX or zero builds (s390 or armv7l)
       if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "s390x" ] && [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" != "aix" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "armv7l" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -199,9 +199,10 @@ getOpenJdkVersion() {
 
 # Ensure that we produce builds with versions strings something like:
 #
-# openjdk version "1.8.0_131"
-# OpenJDK Runtime Environment (build 1.8.0-temurin-<user>_2017_04_17_17_21-b00)
-# OpenJDK 64-Bit Server VM (build 25.71-b00, mixed mode)
+# openjdk 11.0.12 2021-07-20
+# OpenJDK Runtime Environment Temurin-11.0.12+7 (build 11.0.12+7)
+# OpenJDK 64-Bit Server VM Temurin-11.0.12+7 (build 11.0.12+7, mixed mode)configureVersionStringParameter() {
+
 configureVersionStringParameter() {
   stepIntoTheWorkingDirectory
 
@@ -871,7 +872,7 @@ createNoticeFile() {
   local TYPE="${2}"
 
   # Only perform these steps for EF builds
-  if [[ "${BUILD_CONFIG[VENDOR]}" == "Eclipse Foundation" ]]; then
+  if [[ "${BUILD_CONFIG[VENDOR]}" == "Eclipse Adoptium" ]]; then
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]]; then
       HOME_DIR="${DIRECTORY}/Contents/home/"
     else
@@ -887,7 +888,9 @@ setPlistValueForMacOS() {
   local TYPE="${2}"
 
   # Only perform these steps for EF builds
-  if [[ "${BUILD_CONFIG[VENDOR]}" == "Eclipse Foundation" ]]; then
+  if [[ "${BUILD_CONFIG[VENDOR]}" == "Eclipse Adoptium" ]]; then
+    # SXA: Not changing these now as it may cause side effects
+    # May relate to signing. Also cannot contain spaces
     VENDOR_NAME="temurin"
     PACKAGE_NAME="Eclipse Temurin"
     MAJOR_VERSION="${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -253,7 +253,7 @@ configureVersionStringParameter() {
 
     if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]; then
 
-      addConfigureArg "--with-company-name=" "Temurin"
+      addConfigureArg "--with-company-name=" "Eclipse Adoptium"
 
       # No JFR support in AIX or zero builds (s390 or armv7l)
       if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "s390x" ] && [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" != "aix" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "armv7l" ]; then

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -549,7 +549,7 @@ function configDefaults() {
   BUILD_CONFIG[DISABLE_ADOPT_BRANCH_SAFETY]=false
 
   # Used in 'release' file for jdk8u
-  BUILD_CONFIG[VENDOR]=${BUILD_CONFIG[VENDOR]:-"Eclipse Foundation"}
+  BUILD_CONFIG[VENDOR]=${BUILD_CONFIG[VENDOR]:-"Eclipse Adoptium"}
 }
 
 # Declare the map of build configuration that we're going to use

--- a/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/VendorPropertiesTest.java
@@ -180,7 +180,7 @@ public class VendorPropertiesTest {
 
         @Override
         public void javaVendor(final String value) {
-            assertEquals(value, "Eclipse Foundation");
+            assertEquals(value, "Eclipse Adoptium");
         }
 
         @Override
@@ -201,7 +201,7 @@ public class VendorPropertiesTest {
 
         @Override
         public void javaVmVendor(final String value) {
-            assertTrue(value.equals("Eclipse Foundation") || value.equals("Eclipse OpenJ9"));
+            assertTrue(value.equals("Eclipse Adoptium") || value.equals("Eclipse OpenJ9"));
         }
 
         @Override


### PR DESCRIPTION
As discussed in the marketing group meeting and in the Adoptium Workgroup Steering Committee meetings this week. This should remove ambiguity to end users by clarifying that this is the "Adoptium" build.

Signed-off-by: Stewart X Addison <sxa@redhat.com>