### PR TITLE
Revert removal of Temurin name from JDK8 java -version output

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -254,7 +254,7 @@ configureVersionStringParameter() {
 
     if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]; then
 
-      addConfigureArg "--with-company-name=" "\"Eclipse Adoptium\""
+      addConfigureArg "--with-company-name=" "\"Temurin\""
 
       # No JFR support in AIX or zero builds (s390 or armv7l)
       if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "s390x" ] && [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" != "aix" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "armv7l" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -254,6 +254,7 @@ configureVersionStringParameter() {
 
     if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]; then
 
+      # NOTE: There maybe a behavioural difference with this config depending on the jdk8u source branch you're working with.
       addConfigureArg "--with-company-name=" "\"Temurin\""
 
       # No JFR support in AIX or zero builds (s390 or armv7l)


### PR DESCRIPTION
This partially reverts https://github.com/adoptium/temurin-build/pull/2705 and makes the version output say `(Temurin)` instead of `(Eclipse Adoptium)` to make it consistent with other versions and vendors

NOTE: Does not currently have the desired effect as this also causes `java.vendor` to become `Temurin` again on JDK8

Signed-off-by: Stewart X Addison <sxa@redhat.com>