### PR TITLE
fix macos aarch64 builds

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -58,7 +58,7 @@ else
     if [ "${ARCHITECTURE}" == "x64" ]; then
       # We can only target 10.9 on intel macs
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cxxflags=-mmacosx-version-min=10.9"
-    elif [ "${ARCHITECTURE}" == "arm64" ]; then
+    elif [ "${ARCHITECTURE}" == "aarch64" ]; then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=aarch64-apple-darwin"
     fi
   fi


### PR DESCRIPTION
This was broken when the architecture was renamed from `arm64` to `aarch64` in https://github.com/adoptium/ci-jenkins-pipelines/pull/147

Fixes: https://github.com/adoptium/temurin-build/issues/1922