### PR TITLE
skip building JRE's on JDK16+

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -213,7 +213,7 @@ processArgumentsforSpecificArchitectures() {
     if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
       make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true images"
     # Don't produce a JRE for JDK16 and above
-    else if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+    elif [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
       make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images"
     else
       make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images legacy-jre-image"
@@ -243,7 +243,7 @@ processArgumentsforSpecificArchitectures() {
     if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && isHotSpot; then
       jvm_variant=client
       make_args_for_any_platform="DEBUG_BINARIES=true images"
-    else if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+    elif [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
       # Don't produce a JRE for JDK16 and above
       jvm_variant=server,client
       make_args_for_any_platform="DEBUG_BINARIES=true images"

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -210,10 +210,13 @@ processArgumentsforSpecificArchitectures() {
     fi
 
     # This is to ensure consistency with the defaults defined in setMakeArgs()
-    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK8_CORE_VERSION}" ]; then
-      make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images legacy-jre-image"
-    else
+    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
       make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true images"
+    # Don't produce a JRE for JDK16 and above
+    else if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+      make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images"
+    else
+      make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images legacy-jre-image"
     fi
     ;;
 
@@ -239,6 +242,10 @@ processArgumentsforSpecificArchitectures() {
   "armv7l")
     if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && isHotSpot; then
       jvm_variant=client
+      make_args_for_any_platform="DEBUG_BINARIES=true images"
+    else if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+      # Don't produce a JRE for JDK16 and above
+      jvm_variant=server,client
       make_args_for_any_platform="DEBUG_BINARIES=true images"
     else
       jvm_variant=server,client
@@ -289,8 +296,22 @@ function setMakeArgs() {
 
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK8_CORE_VERSION}" ]; then
     case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
-    "darwin") BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images mac-legacy-jre-bundle"} ;;
-    *) BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images legacy-jre-image"} ;;
+    "darwin")
+      if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+        # Skip JRE on JDK16+
+        BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images"}
+      else
+        BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images mac-legacy-jre-bundle"}
+      fi
+      ;;
+    *)
+      if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+        # Skip JRE on JDK16+
+        BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images"}
+      else
+        BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images legacy-jre-image"}
+      fi
+      ;;
     esac
     # In order to build an exploded image, no other make targets can be used
     if [ "${BUILD_CONFIG[MAKE_EXPLODED]}" == "true" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1386,7 +1386,10 @@ mirrorToJRE() {
 
 addImageType() {
   echo -e IMAGE_TYPE=\"JDK\" >>"$PRODUCT_HOME/release"
-  echo -e IMAGE_TYPE=\"JRE\" >>"$JRE_HOME/release"
+  # Don't produce a JRE for JDK16 and above
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+    echo -e IMAGE_TYPE=\"JRE\" >>"$JRE_HOME/release"
+  fi
 }
 
 addInfoToJson(){

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1259,8 +1259,11 @@ addInfoToReleaseFile() {
     echo "ADDING J9 TAG"
     addJ9Tag
   fi
-  echo "MIRRORING TO JRE"
-  mirrorToJRE
+   # Don't produce a JRE for JDK16 and above
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+    echo "MIRRORING TO JRE"
+    mirrorToJRE
+  fi
   echo "ADDING IMAGE TYPE"
   addImageType
   echo "===RELEASE FILE GENERATED==="

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -739,16 +739,19 @@ removingUnnecessaryFiles() {
   rm -rf "${jdkTargetPath}" || true
   mv "${jdkPath}" "${jdkTargetPath}"
 
-  if [ -d "$(ls -d ${BUILD_CONFIG[JRE_PATH]})" ]; then
-    echo "moving $(ls -d ${BUILD_CONFIG[JRE_PATH]}) to ${jreTargetPath}"
-    rm -rf "${jreTargetPath}" || true
-    mv "$(ls -d ${BUILD_CONFIG[JRE_PATH]})" "${jreTargetPath}"
+# Don't produce a JRE for JDK16 and above
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+    if [ -d "$(ls -d ${BUILD_CONFIG[JRE_PATH]})" ]; then
+      echo "moving $(ls -d ${BUILD_CONFIG[JRE_PATH]}) to ${jreTargetPath}"
+      rm -rf "${jreTargetPath}" || true
+      mv "$(ls -d ${BUILD_CONFIG[JRE_PATH]})" "${jreTargetPath}"
 
-    case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
-    "darwin") dirToRemove="${jreTargetPath}/Contents/Home" ;;
-    *) dirToRemove="${jreTargetPath}" ;;
-    esac
-    rm -rf "${dirToRemove}"/demo || true
+      case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
+      "darwin") dirToRemove="${jreTargetPath}/Contents/Home" ;;
+      *) dirToRemove="${jreTargetPath}" ;;
+      esac
+      rm -rf "${dirToRemove}"/demo || true
+    fi
   fi
 
   # Test image - check if the config is set and directory exists
@@ -1187,26 +1190,35 @@ createOpenJDKTarArchive() {
 
 copyFreeFontForMacOS() {
   local jdkTargetPath=$(getJdkArchivePath)
-  local jreTargetPath=$(getJreArchivePath)
-
   makeACopyOfLibFreeFontForMacOSX "${jdkTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]}"
-  makeACopyOfLibFreeFontForMacOSX "${jreTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]}"
+
+  # Don't produce a JRE for JDK16 and above
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+    local jreTargetPath=$(getJreArchivePath)
+    makeACopyOfLibFreeFontForMacOSX "${jreTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]}"
+  fi
 }
 
 setPlistForMacOS() {
   local jdkTargetPath=$(getJdkArchivePath)
-  local jreTargetPath=$(getJreArchivePath)
-
   setPlistValueForMacOS "${jdkTargetPath}" "jdk"
-  setPlistValueForMacOS "${jreTargetPath}" "jre"
+
+  # Don't produce a JRE for JDK16 and above
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+    local jreTargetPath=$(getJreArchivePath)
+    setPlistValueForMacOS "${jreTargetPath}" "jre"
+  fi
 }
 
 addNoticeFile() {
   local jdkTargetPath=$(getJdkArchivePath)
-  local jreTargetPath=$(getJreArchivePath)
-
   createNoticeFile "${jdkTargetPath}" "jdk"
-  createNoticeFile "${jreTargetPath}" "jre"
+
+  # Don't produce a JRE for JDK16 and above
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+    local jreTargetPath=$(getJreArchivePath)
+    createNoticeFile "${jreTargetPath}" "jre"
+  fi
 }
 
 wipeOutOldTargetDir() {


### PR DESCRIPTION
We do not ship JRE's on JDK16+. This PR skips building them but can be overridden if another vendor is using our scripts