### PR TITLE
Update for jdk17u repository reference

### DIFF
--- a/sbin/NOTICE.template
+++ b/sbin/NOTICE.template
@@ -42,6 +42,8 @@ relevant to this content:
  * https://github.com/adoptium/jdk8u
  * https://github.com/adoptium/jdk11u
  * https://github.com/adoptium/jdk16u
+ * https://github.com/adoptium/jdk17u
+ * and so on
 
 ## Third-party Content
 


### PR DESCRIPTION
This NOTICE file may be used for JDK17 (or later) builds.