### PR TITLE
Fix macOS build info containing newline

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1325,7 +1325,7 @@ addBuildOS() {
   local buildVer="Unknown"
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]; then
     buildOS=$(sw_vers | sed -n 's/^ProductName:[[:blank:]]*//p')
-    buildVer=$(sw_vers | tail -n 2 | awk '{print $2}')
+    buildVer=$(sw_vers | tail -n 2 | awk '{print $2}' | tr '\n' '\0' | xargs -0)
   elif [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ]; then
     buildOS=$(uname -s)
     buildVer=$(uname -r)


### PR DESCRIPTION
Possibly due to changes in `awk`, current builds have the following content in the `release` file, which is hard to parse:
```
BUILD_INFO="OS: Mac OS X Version: 10.14.6
18G84"
```
This change fixes the shell command to no longer produce newlines, which should restore the normal nature of this entry. I was unable to test this change as it was reported to me by a user of one of my programs, and I don't have a Mac to verify on, but they ran the command that is now there and confirmed it does not produce a newline-separator anymore.