### PR TITLE
Actions: auto cancel builds if user pushes another commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [ master ]
 
+# Cancel existing runs if user makes another push
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_linux:
     name: Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ master ]
 
-# Cancel existing runs if user makes another push
+# Cancel existing runs if user makes another push.
 concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Currently, if a user pushes several commits to a PR the CI will try to build each commit. This wastes both time and resources.

This PR adds a task that will cancel any other builds for the same PR.