### PR TITLE
Point scripts to correct bootjdk17 directory on Mac

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -96,8 +96,8 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
     if [ -x "/Library/Java/JavaVirtualMachines/adoptopenjdk-${JDK_BOOT_VERSION}/Contents/Home/bin/javac" ]; then
       echo "Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/adoptopenjdk-${JDK_BOOT_VERSION}/Contents/Home"
       export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/adoptopenjdk-${JDK_BOOT_VERSION}/Contents/Home"
-    elif [[ ("$JDK_BOOT_VERSION" -ge 17) && ( -x "/Library/Java/JavaVirtualMachines/temurin-${$JDK_BOOT_VERSION}.jdk/Contents/Home/bin/javac") ]]; then
-        export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/temurin-${$JDK_BOOT_VERSION}.jdk/Contents/Home"
+    elif [[ ("$JDK_BOOT_VERSION" -ge 17) && ( -x "/Library/Java/JavaVirtualMachines/temurin-${JDK_BOOT_VERSION}.jdk/Contents/Home/bin/javac") ]]; then
+        export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/temurin-${JDK_BOOT_VERSION}.jdk/Contents/Home"
     elif [ "$JDK_BOOT_VERSION" -ge 8 ]; then # Adopt has no build pre-8
       mkdir -p "$bootDir"
       releaseType="ga"


### PR DESCRIPTION
ref https://adoptium.slack.com/archives/C53GHCXL4/p1633536423050000?thread_ts=1633443475.036300&cid=C53GHCXL4

The mac installer installs jdk17 into `/Library/Java/JavaVirtualMachines/temurin-17.jdk` while the build scripts anticipate `/Library/Java/JavaVirtualMachines/adoptopenjdk-*.jdk`, so I've made a special case for when the bootjdk is 17.

Im certain I have made the amendment in the correct place in the script, but please let me know if more needs to be added
