### PR TITLE
Add wget curl wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+*.iml
 .vscode/
 workspace
 **/.DS_Store

--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -16,9 +16,9 @@ getFile() {
     echo 'Usage: getFile https://example.com file_name'
     exit 1;
   elif command -v wget &> /dev/null; then
-    wget -q $1 -O $2
+    wget -q "$1" -O "$2"
   elif command -v curl &> /dev/null; then
-    curl -s $1 -o $2
+    curl -s "$1" -o "$2"
   else
     echo 'Please install wget or curl to continue'
     exit 1;

--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -10,9 +10,24 @@ JDK_VERSION=
 JDK_MAX=
 JDK_GA=
 
+getFile() {
+  if [ $# -ne 2 ]; then
+    echo "getFile takes 2 arguments, $# argument(s) given"
+    echo 'Usage: getFile https://example.com file_name'
+    exit 1;
+  elif command -v wget &> /dev/null; then
+    wget -q $1 -O $2
+  elif command -v curl &> /dev/null; then
+    curl -s $1 -o $2
+  else
+    echo 'Please install wget or curl to continue'
+    exit 1;
+  fi
+}
+
 # shellcheck disable=SC2002 # Disable UUOC error
 setJDKVars() {
-    wget -q https://api.adoptium.net/v3/info/available_releases
+    getFile https://api.adoptium.net/v3/info/available_releases available_releases
     JDK_MAX=$(awk -F: '/tip_version/{gsub("[, ]","",$2); print$2}' < available_releases)
     JDK_GA=$(awk -F: '/most_recent_feature_release/{gsub("[, ]","",$2); print$2}' < available_releases)
     rm available_releases
@@ -100,7 +115,7 @@ useEclipseOpenJ9DockerFiles()
 
     mkdir -p "$dockerfileDir"
     cd "$dockerfileDir" || { echo "Dockerfile directory ($dockerfileDir) was not found"; exit 3; }
-    wget https://raw.githubusercontent.com/eclipse-openj9/openj9/master/buildenv/docker/mkdocker.sh
+    getFile https://raw.githubusercontent.com/eclipse-openj9/openj9/master/buildenv/docker/mkdocker.sh mkdocker.sh
     chmod +x mkdocker.sh
     # Generate an Ubuntu1804 Dockerfile using mkdocker.sh
     "$dockerfileDir/mkdocker.sh" --dist=ubuntu --version=18 --print >> "$dockerfileDir/Dockerfile"

--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -20,9 +20,9 @@ getFile() {
     echo 'Usage: getFile https://example.com file_name'
     exit 1;
   elif command -v wget &> /dev/null; then
-    wget -q $1 -O $2
+    wget -q "$1" -O "$2"
   elif command -v curl &> /dev/null; then
-    curl -s $1 -o $2
+    curl -s "$1" -o "$2"
   else
     echo 'Please install wget or curl to continue'
     exit 1;

--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -14,9 +14,24 @@ JDK_VERSION=8
 JDK_MAX=
 JDK_GA=
 
+getFile() {
+  if [ $# -ne 2 ]; then
+    echo "getFile takes 2 arguments, $# argument(s) given"
+    echo 'Usage: getFile https://example.com file_name'
+    exit 1;
+  elif command -v wget &> /dev/null; then
+    wget -q $1 -O $2
+  elif command -v curl &> /dev/null; then
+    curl -s $1 -o $2
+  else
+    echo 'Please install wget or curl to continue'
+    exit 1;
+  fi
+}
+
 # shellcheck disable=SC2002 # Disable UUOC error
 setJDKVars() {
-  wget -q https://api.adoptium.net/v3/info/available_releases
+  getFile https://api.adoptium.net/v3/info/available_releases available_releases
   JDK_MAX=$(cat available_releases \
       | grep 'tip_version' \
       | cut -d':' -f 2 \


### PR DESCRIPTION
## Description
This pull request address the issue on #2771 and add a wget/curl wrapper on the `buildDocker.sh` and `dockerfile-generator.sh` so that it work out of the box on macOS, where `wget` is not available.

## Test
I tested by running it on macOS with curl, Ubuntu 20.04 with wget and on the master branch, and the Dockerfile generated is the same.

DCO 1.1 Signed-off-by: David Dadon