### PR TITLE
Fix Dockerfile generator for Java 11

### DIFF
--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -239,14 +239,24 @@ ENV CC=gcc-7 CXX=g++-7" >> "$DOCKERFILE_PATH"
 printDockerJDKs() {
   # JDK8 uses zulu-7 to as it's bootjdk
   if [ "${JDK_VERSION}" != 8 ] && [ "${JDK_VERSION}" != "${JDK_MAX}" ]; then
-    if [ ${COMMENTS} == true ]; then
+    if [ "${JDK_VERSION}" == 11 ]; then
+      if [ ${COMMENTS} == true ]; then
       echo "
-    # Extract JDK$((JDK_VERSION-1)) to use as a boot jdk" >> "$DOCKERFILE_PATH"
-    fi
-    printJDK $((JDK_VERSION-1))
-    echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/java /usr/bin/java" >> "$DOCKERFILE_PATH"
-    echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/javac /usr/bin/javac" >> "$DOCKERFILE_PATH"
-    echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
+      # JDK 10 is not available on the adoptium API, extract JDK 11 to use as a boot jdk" >> "$DOCKERFILE_PATH"
+      fi
+      printJDK $((JDK_VERSION))
+      echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION))/bin/java /usr/bin/java" >> "$DOCKERFILE_PATH"
+      echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION))/bin/javac /usr/bin/javac" >> "$DOCKERFILE_PATH"
+      echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION))/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
+    else
+      if [ ${COMMENTS} == true]; then
+      echo "
+      # Extract JDK$((JDK_VERSION-1)) to use as a boot jdk" >> "$DOCKERFILE_PATH"
+      fi
+      printJDK $((JDK_VERSION-1))
+      echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/java /usr/bin/java" >> "$DOCKERFILE_PATH"
+      echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/javac /usr/bin/javac" >> "$DOCKERFILE_PATH"
+      echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
   fi
 
   # Build 'jdk' with the most recent GA release
@@ -260,6 +270,7 @@ printDockerJDKs() {
     echo "RUN ln -sf /usr/lib/jvm/jdk${JDK_GA}/bin/javac /usr/bin/javac" >> "$DOCKERFILE_PATH"
     echo "RUN ln -sf /usr/lib/jvm/jdk${JDK_GA}/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
   fi
+fi
 
   # shellcheck disable=SC2086
   # if JDK_VERSION is 9, another jdk8 doesn't need to be extracted

--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -241,8 +241,8 @@ printDockerJDKs() {
   if [ "${JDK_VERSION}" != 8 ] && [ "${JDK_VERSION}" != "${JDK_MAX}" ]; then
     if [ "${JDK_VERSION}" == 11 ]; then
       if [ ${COMMENTS} == true ]; then
-      echo "
-      # JDK 10 is not available on the adoptium API, extract JDK 11 to use as a boot jdk" >> "$DOCKERFILE_PATH"
+        echo "
+        # JDK 10 is not available on the adoptium API, extract JDK 11 to use as a boot jdk" >> "$DOCKERFILE_PATH"
       fi
       printJDK $((JDK_VERSION))
       echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION))/bin/java /usr/bin/java" >> "$DOCKERFILE_PATH"
@@ -250,13 +250,14 @@ printDockerJDKs() {
       echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION))/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
     else
       if [ ${COMMENTS} == true ]; then
-      echo "
-      # Extract JDK$((JDK_VERSION-1)) to use as a boot jdk" >> "$DOCKERFILE_PATH"
+        echo "
+        # Extract JDK$((JDK_VERSION-1)) to use as a boot jdk" >> "$DOCKERFILE_PATH"
       fi
       printJDK $((JDK_VERSION-1))
       echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/java /usr/bin/java" >> "$DOCKERFILE_PATH"
       echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/javac /usr/bin/javac" >> "$DOCKERFILE_PATH"
       echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION-1))/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
+    fi
   fi
 
   # Build 'jdk' with the most recent GA release
@@ -270,7 +271,6 @@ printDockerJDKs() {
     echo "RUN ln -sf /usr/lib/jvm/jdk${JDK_GA}/bin/javac /usr/bin/javac" >> "$DOCKERFILE_PATH"
     echo "RUN ln -sf /usr/lib/jvm/jdk${JDK_GA}/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
   fi
-fi
 
   # shellcheck disable=SC2086
   # if JDK_VERSION is 9, another jdk8 doesn't need to be extracted

--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -290,7 +290,7 @@ RUN sh -c \"mkdir -p /usr/lib/jvm/jdk$JDKVersion && wget 'https://api.adoptium.n
 
 printGitCloneJenkinsPipelines(){
   echo "
-RUN git clone https://github.com/adoptium/temurin-build /openjdk/pipelines" >> "$DOCKERFILE_PATH"
+RUN git clone https://github.com/adoptium/ci-jenkins-pipelines /openjdk/pipelines" >> "$DOCKERFILE_PATH"
 }
 
 printCopyFolders(){

--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -277,12 +277,16 @@ printJDK() {
 RUN sh -c \"mkdir -p /usr/lib/jvm/jdk$JDKVersion && wget 'https://api.adoptium.net/v3/binary/latest/$JDKVersion/ga/linux/x64/jdk/hotspot/normal/adoptium?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk$JDKVersion --strip-components=1\"" >> "$DOCKERFILE_PATH"
 }
 
+printGitCloneJenkinsPipelines(){
+  echo "
+RUN git clone https://github.com/adoptium/temurin-build /openjdk/pipelines" >> "$DOCKERFILE_PATH"
+}
+
 printCopyFolders(){
   echo "
 COPY sbin /openjdk/sbin
 COPY security /openjdk/security
-COPY workspace/config /openjdk/config
-COPY pipelines /openjdk/pipelines" >> "$DOCKERFILE_PATH"
+COPY workspace/config /openjdk/config" >> "$DOCKERFILE_PATH"
 }
 
 printGitClone(){
@@ -345,6 +349,7 @@ if [ ${OPENJ9} == true ]; then
 fi
 
 printDockerJDKs
+printGitCloneJenkinsPipelines
 
 # If building the image straight away, it can't be assumed the folders to be copied are in place
 # Therefore create an image that instead git clones openjdk-build and a build can be started there

--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -249,7 +249,7 @@ printDockerJDKs() {
       echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION))/bin/javac /usr/bin/javac" >> "$DOCKERFILE_PATH"
       echo "RUN ln -sf /usr/lib/jvm/jdk$((JDK_VERSION))/bin/keytool /usr/bin/keytool" >> "$DOCKERFILE_PATH"
     else
-      if [ ${COMMENTS} == true]; then
+      if [ ${COMMENTS} == true ]; then
       echo "
       # Extract JDK$((JDK_VERSION-1)) to use as a boot jdk" >> "$DOCKERFILE_PATH"
       fi


### PR DESCRIPTION
## Description

This pull request address the issue #2776 by using Java 11 to build Java 11, instead of failing to get Java 10 from https://api.adoptium.net/v3/info/available_releases.


Additionally, Dockerfile now will git clone the jenkins pipeline instead of trying (and failing) to copy it.

## Test

I tested it by comparing Dockerfile generated for Java 11, 17 and 18 from master and this branch, 