### PR TITLE
Add support for on-demand JREs for JDK16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ clean out any 'bad' local git repo you already have.
 --create-debug-image
 create a debug-image archive with the debug symbols.
 
+--create-jre-image
+create the legacy JRE image in addition to the JDK image.
+
 -d, --destination <path>
 specify the location for the built binary, e.g. /path/.
 This is typically used in conjunction with -T to create a custom path

--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -213,6 +213,13 @@ export BUILD_ARGS="${BUILD_ARGS} --use-jep319-certs"
 # Enable debug images for all platforms
 export BUILD_ARGS="${BUILD_ARGS} --create-debug-image"
 
+# JRE images are not produced for JDK16 and above
+# as per https://github.com/adoptium/adoptium-support/issues/333
+# Enable legacy JRE images for all platforms and versions older than 16
+if [ "${JAVA_FEATURE_VERSION}" -lt 16 ]; then
+  export BUILD_ARGS="${BUILD_ARGS} --create-jre-image"
+fi
+
 echo "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args ${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
 
 # Convert all speech marks in config args to make them safe to pass in.

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -214,8 +214,8 @@ processArgumentsforSpecificArchitectures() {
     # This is to ensure consistency with the defaults defined in setMakeArgs()
     if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
       make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true images"
-    # Don't produce a JRE for JDK16 and above
-    elif [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+    # Don't produce a JRE
+    elif [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "false" ]; then
       make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images"
     else
       make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images legacy-jre-image"
@@ -245,8 +245,8 @@ processArgumentsforSpecificArchitectures() {
     if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && isHotSpot; then
       jvm_variant=client
       make_args_for_any_platform="DEBUG_BINARIES=true images"
-    elif [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
-      # Don't produce a JRE for JDK16 and above
+    elif [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "false" ]; then
+      # Don't produce a JRE
       jvm_variant=server,client
       make_args_for_any_platform="DEBUG_BINARIES=true images"
     else
@@ -299,15 +299,15 @@ function setMakeArgs() {
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK8_CORE_VERSION}" ]; then
     case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
     "darwin")
-      if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
-        # Skip JRE on JDK16+
+      if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "false" ]; then
+        # Skip JRE
         BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images"}
       else
         BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images mac-legacy-jre-bundle"}
       fi
       ;;
     *)
-      if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 16 ]; then
+      if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "false" ]; then
         # Skip JRE on JDK16+
         BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images"}
       else

--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -70,6 +70,9 @@ specify any custom user configuration arguments.
 .BR \-\-clean-git-repo
 clean out any 'bad' local git repo you already have.
 .TP
+.BR \-\-create-jre-image
+create the legacy JRE image in addition to the JDK image.
+.TP
 .BR \-\-create-source-archive
 create an archive of the sources which got used to build OpenJDK
 .TP

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -753,8 +753,8 @@ removingUnnecessaryFiles() {
   rm -rf "${jdkTargetPath}" || true
   mv "${jdkPath}" "${jdkTargetPath}"
 
-# Don't produce a JRE for JDK16 and above
-  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+  if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "true" ]; then
+    # Produce a JRE
     if [ -d "$(ls -d ${BUILD_CONFIG[JRE_PATH]})" ]; then
       echo "moving $(ls -d ${BUILD_CONFIG[JRE_PATH]}) to ${jreTargetPath}"
       rm -rf "${jreTargetPath}" || true
@@ -1284,8 +1284,7 @@ copyFreeFontForMacOS() {
   local jdkTargetPath=$(getJdkArchivePath)
   makeACopyOfLibFreeFontForMacOSX "${jdkTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]}"
 
-  # Don't produce a JRE for JDK16 and above
-  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+  if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "true" ]; then
     local jreTargetPath=$(getJreArchivePath)
     makeACopyOfLibFreeFontForMacOSX "${jreTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]}"
   fi
@@ -1295,8 +1294,7 @@ setPlistForMacOS() {
   local jdkTargetPath=$(getJdkArchivePath)
   setPlistValueForMacOS "${jdkTargetPath}" "jdk"
 
-  # Don't produce a JRE for JDK16 and above
-  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+  if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "true" ]; then
     local jreTargetPath=$(getJreArchivePath)
     setPlistValueForMacOS "${jreTargetPath}" "jre"
   fi
@@ -1306,8 +1304,7 @@ addNoticeFile() {
   local jdkTargetPath=$(getJdkArchivePath)
   createNoticeFile "${jdkTargetPath}" "jdk"
 
-  # Don't produce a JRE for JDK16 and above
-  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+  if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "true" ]; then
     local jreTargetPath=$(getJreArchivePath)
     createNoticeFile "${jreTargetPath}" "jre"
   fi
@@ -1363,8 +1360,8 @@ addInfoToReleaseFile() {
     echo "ADDING J9 TAG"
     addJ9Tag
   fi
-   # Don't produce a JRE for JDK16 and above
-  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+
+  if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "true" ]; then
     echo "MIRRORING TO JRE"
     mirrorToJRE
   fi
@@ -1490,8 +1487,8 @@ mirrorToJRE() {
 
 addImageType() {
   echo -e IMAGE_TYPE=\"JDK\" >>"$PRODUCT_HOME/release"
-  # Don't produce a JRE for JDK16 and above
-  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 16 ]; then
+
+  if [ "${BUILD_CONFIG[CREATE_JRE_IMAGE]}" == "true" ]; then
     echo -e IMAGE_TYPE=\"JRE\" >>"$JRE_HOME/release"
   fi
 }

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -48,6 +48,7 @@ COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG
 COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG
 COPY_TO_HOST
 CREATE_DEBUG_IMAGE
+CREATE_JRE_IMAGE
 CREATE_SOURCE_ARCHIVE
 CUSTOM_CACERTS
 CROSSCOMPILE
@@ -235,6 +236,9 @@ function parseConfigurationArguments() {
 
         "--create-debug-image" )
         BUILD_CONFIG[CREATE_DEBUG_IMAGE]="true";;
+
+        "--create-jre-image" )
+        BUILD_CONFIG[CREATE_JRE_IMAGE]=true;;
 
         "--create-source-archive" )
         BUILD_CONFIG[CREATE_SOURCE_ARCHIVE]=true;;
@@ -451,6 +455,9 @@ function configDefaults() {
 
   # The default behavior of whether we want to create a separate debug symbols archive
   BUILD_CONFIG[CREATE_DEBUG_IMAGE]="false"
+
+  # The default behavior of whether we want to create the legacy JRE
+  BUILD_CONFIG[CREATE_JRE_IMAGE]="false"
 
   # The default behavior of whether we want to create a separate source archive
   BUILD_CONFIG[CREATE_SOURCE_ARCHIVE]="false"


### PR DESCRIPTION
Add a new argument to the build scripts: --create-jre-image.
A JRE image is produced when this argument is set. It is optional for
JDK16 and above.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>