### PR TITLE
Avoid using github proxy for downloading dragonwell submodules

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -277,6 +277,8 @@ updateDragonwellSources() {
     else
       target_scm="${BUILD_CONFIG[BRANCH]}"
     fi
+    # Download directly from github and not the proxy for Adoptium machine performance
+    perl -p -i -e 's/github.com.cnpmjs.org/github.com/g' get_source_dragonwell.sh
     if [ "${BUILD_CONFIG[RELEASE]}" == "false" ]; then
       bash get_source_dragonwell.sh --site github --branch "${target_scm}"
     else


### PR DESCRIPTION
For performance reasons it is significantly faster to use github directly from the Adoptium Equinix machines.

Signed-off-by: Stewart X Addison <sxa@redhat.com>