### PR TITLE
Enable jdk-19+ reproducible build options

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -132,6 +132,11 @@ then
     # OpenJ9 only supports building jdk-11 with jdk-11
     JDK_BOOT_VERSION="11"
   fi
+  if [ "${JAVA_FEATURE_VERSION}" == "19" ]; then
+    # To support reproducible-builds the jar/jmod --date option is required
+    # which is only available from jdk-19
+    JDK_BOOT_VERSION="19"
+  fi
 fi
 echo "Required boot JDK version: ${JDK_BOOT_VERSION}"
 

--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -134,7 +134,7 @@ then
   fi
   if [ "${JAVA_FEATURE_VERSION}" == "19" ]; then
     # To support reproducible-builds the jar/jmod --date option is required
-    # which is only available from jdk-19
+    # which is only available from jdk-19 so we cannot bootstrap with JDK18
     JDK_BOOT_VERSION="19"
   fi
 fi

--- a/build-farm/set-platform-specific-configurations.sh
+++ b/build-farm/set-platform-specific-configurations.sh
@@ -24,6 +24,23 @@ then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-warnings-as-errors"
 fi
 
+# jdk-19 and above support reproducible builds
+if [[ "${JAVA_FEATURE_VERSION}" -ge 19 ]]
+then
+    # Enable reproducible builds implicitly with --with-source-date
+    if [ "${RELEASE}" == "true" ]
+    then
+        # Use release date
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-source-date=version"
+    else
+        # Use build date
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-source-date=updated"
+    fi
+
+    # Ensure reproducible binary with a unique build user identifier
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-user=adoptium"
+fi
+
 export VARIANT_ARG="--build-variant ${VARIANT}"
 
 # If a user file doesn't exist, pull from an online source. To always pull from an online source, ensure platform config files have been deleted from your local clone.

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -435,8 +435,13 @@ configureCommandParameters() {
   addConfigureArgIfValueIsNotEmpty "--with-jvm-variants=" "${BUILD_CONFIG[JVM_VARIANT]}"
 
   if [ "${BUILD_CONFIG[CUSTOM_CACERTS]}" = "true" ] ; then
-    echo "Configure custom cacerts file security/cacerts"
-    addConfigureArgIfValueIsNotEmpty "--with-cacerts-file=" "$SCRIPT_DIR/../security/cacerts"
+    if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge "19" ]]; then
+      echo "Configure custom cacerts src security/certs"
+      addConfigureArgIfValueIsNotEmpty "--with-cacerts-src=" "$SCRIPT_DIR/../security/certs"
+    else
+      echo "Configure custom cacerts file security/cacerts"
+      addConfigureArgIfValueIsNotEmpty "--with-cacerts-file=" "$SCRIPT_DIR/../security/cacerts"
+    fi
   fi
 
   # Finally, we add any configure arguments the user has specified on the command line.

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -552,7 +552,12 @@ checkingAndDownloadingFreeType() {
 prepareMozillaCacerts() {
     echo "Generating cacerts from Mozilla's bundle"
     cd "$SCRIPT_DIR/../security"
-    time ./mk-cacerts.sh --keytool "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/keytool"
+    if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge "19" ]]; then
+      # jdk-19+ build uses JDK make tool to load keystore for reproducible builds
+      time ./mk-cacerts.sh --nokeystore
+    else
+      time ./mk-cacerts.sh --keytool "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/keytool"
+    fi
 }
 
 # Download all of the dependencies for OpenJDK (Alsa, FreeType, etc.)


### PR DESCRIPTION
This PR enables "reproducible build" support for jdk-19+ builds by enabling:
- --with-source-date option enables openjdk make reproducible build option
- --with-build-user=adoptium ensure determinstic jvm build user
- --with-cacerts option to pass the mozilla cacerts folder into the openjdk build keystore tool which is determinsitic

Signed-off-by: Andrew Leonard <anleonar@redhat.com>