### PR TITLE
Enable building with GCC 10.3 for JDK18 and above on Linux (Excluding OpenJ9)

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -188,17 +188,15 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION
   export CXX=/usr/local/gcc9/bin/g++-9.3
   # Enable GCC 10 for Java 18+ for repeatable builds, but not for our supported releases
   # Ref https://github.com/adoptium/temurin-build/issues/2787
-elif [ "$JAVA_FEATURE_VERSION" -gt 17 ] && [ "${VARIANT}" != "${BUILD_VARIANT_OPENJ9}" ]; then
-  if [ -r /usr/local/gcc10/bin/gcc-10.3 ]; then
-    export PATH=/usr/local/gcc10/bin:$PATH
-    [ -r /usr/local/gcc10/bin/gcc-10.3 ] && export  CC=/usr/local/gcc10/bin/gcc-10.3
-    [ -r /usr/local/gcc10/bin/g++-10.3 ] && export CXX=/usr/local/gcc10/bin/g++-10.3
-    export LD_LIBRARY_PATH=/usr/local/gcc10/lib64:/usr/local/gcc10/lib
-  elif [ -r /usr/bin/gcc-10 ]; then
-    [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
-    [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
-  fi
-# Continue to use GCC 7 if present for JDK<=17
+elif [ "$JAVA_FEATURE_VERSION" -gt 17 ] && [ "${VARIANT}" != "${BUILD_VARIANT_OPENJ9}" ] && [ -r /usr/local/gcc10/bin/gcc-10.3 ]; then
+  export PATH=/usr/local/gcc10/bin:$PATH
+  [ -r /usr/local/gcc10/bin/gcc-10.3 ] && export  CC=/usr/local/gcc10/bin/gcc-10.3
+  [ -r /usr/local/gcc10/bin/g++-10.3 ] && export CXX=/usr/local/gcc10/bin/g++-10.3
+  export LD_LIBRARY_PATH=/usr/local/gcc10/lib64:/usr/local/gcc10/lib
+elif [ "$JAVA_FEATURE_VERSION" -gt 17 ] && [ "${VARIANT}" != "${BUILD_VARIANT_OPENJ9}" ] && [ -r /usr/bin/gcc-10 ]; then
+  [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
+  [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
+# Continue to use GCC 7 if present for JDK<=17 and where 10 does not exist
 elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
   export PATH=/usr/local/gcc/bin:$PATH
   [ -r /usr/local/gcc/bin/gcc-7.5 ] && export  CC=/usr/local/gcc/bin/gcc-7.5

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -181,16 +181,31 @@ if [ $executedJavaVersion -ne 0 ]; then
 fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ] && [ "${ARCHITECTURE}" == "aarch64" ]; then
+  # GCC9 rather than 10 requested by Alibaba for now
+  # Ref https://github.com/adoptium/temurin-build/issues/2250#issuecomment-732958466
   export PATH=/usr/local/gcc9/bin:$PATH
   export CC=/usr/local/gcc9/bin/gcc-9.3
   export CXX=/usr/local/gcc9/bin/g++-9.3
+  # Enable GCC 10 for Java 18+ for repeatable builds, but not for our supported releases
+  # Ref https://github.com/adoptium/temurin-build/issues/2787
+elif [ "$JAVA_FEATURE_VERSION" -gt 17 ] && [ "${VARIANT}" != "${BUILD_VARIANT_OPENJ9}" ]; then
+  if [ -r /usr/local/gcc10/bin/gcc-10.3 ]; then
+    export PATH=/usr/local/gcc10/bin:$PATH
+    [ -r /usr/local/gcc10/bin/gcc-10.3 ] && export  CC=/usr/local/gcc10/bin/gcc-10.3
+    [ -r /usr/local/gcc10/bin/g++-10.3 ] && export CXX=/usr/local/gcc10/bin/g++-10.3
+    export LD_LIBRARY_PATH=/usr/local/gcc10/lib64:/usr/local/gcc10/lib
+  elif [ -r /usr/bin/gcc-10 ]; then
+    [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
+    [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
+  fi
+# Continue to use GCC 7 if present for JDK<=17
 elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
   export PATH=/usr/local/gcc/bin:$PATH
-  [ -r /usr/local/gcc/bin/gcc-7.5 ] && export CC=/usr/local/gcc/bin/gcc-7.5
+  [ -r /usr/local/gcc/bin/gcc-7.5 ] && export  CC=/usr/local/gcc/bin/gcc-7.5
   [ -r /usr/local/gcc/bin/g++-7.5 ] && export CXX=/usr/local/gcc/bin/g++-7.5
   export LD_LIBRARY_PATH=/usr/local/gcc/lib64:/usr/local/gcc/lib
 elif [ -r /usr/bin/gcc-7 ]; then
-  [ -r /usr/bin/gcc-7 ] && export CC=/usr/bin/gcc-7
+  [ -r /usr/bin/gcc-7 ] && export  CC=/usr/bin/gcc-7
   [ -r /usr/bin/g++-7 ] && export CXX=/usr/bin/g++-7
 fi
 


### PR DESCRIPTION
Can be implemented now that https://github.com/adoptium/infrastructure/pull/2420 has been merged
Fixes https://github.com/adoptium/temurin-build/issues/2787 (Although for now not including JDK17)
