### PR TITLE
Remove check that moves minor to tags in variant JSON

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1558,10 +1558,7 @@ addVariantVersionToJson(){
     local minor=$(echo "$variantJson" | awk -F[.] '{print $2}')
     local security=$(echo "$variantJson" | awk -F[.] '{print $3}')
     local tags=$(echo "$variantJson" | awk -F[.] '{print $4}')
-    if [[ $(echo "$variantJson" | tr -cd '.' | wc -c) -lt 3 ]]; then # Precaution for when OpenJ9 releases a 1.0.0 version
-      tags="$minor"
-      minor=""
-    fi
+
     echo -n "${major:-"0"}" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/variant_version/major.txt"
     echo -n "${minor:-"0"}" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/variant_version/minor.txt"
     echo -n "${security:-"0"}" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/variant_version/security.txt"


### PR DESCRIPTION
This "precaution" `if` has been there since it was authored.
I can't understand why it is there. The code seems to work
without it. It seems to unintentionally be moving those
values for every non-milestone release. That is, the code
works for milestones only but for releases it moves minor
to tags.

eg. 0.29.0-m1 becomes 0, 29, 0, m1 which is correct
but 0.29.0 becomes 0, 0, 0, 29 which is incorrect

Related #2077

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>