### PR TITLE
Enable OpenJ9 CUDA support if the SDK is installed on aarch64

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -218,15 +218,15 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
 then
   # OpenJ9 fetches the latest OpenSSL in their get_source.sh
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
-
-  if [ "${ARCHITECTURE}" == "ppc64le" ] || [ "${ARCHITECTURE}" == "x64" ]
+  if [ "${ARCHITECTURE}" == "aarch64" ]; then
+    echo PROBABLE JETSON NANO DEVELOPMENT ENVIRONMENT - Enabling CUDA ...
+    CUDA_HOME=/usr/local/cuda-10.2
+  else
+    CUDA_HOME=/usr/local/cuda-9.0
+  fi
+  if [ -f $CUDA_HOME/include/cuda.h ]
   then
-    CUDA_VERSION=9.0
-    CUDA_HOME=/usr/local/cuda-$CUDA_VERSION
-    if [ -f $CUDA_HOME/include/cuda.h ]
-    then
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-cuda --with-cuda=$CUDA_HOME"
-    fi
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-cuda --with-cuda=$CUDA_HOME"
   fi
 fi
 

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -219,7 +219,7 @@ then
   # OpenJ9 fetches the latest OpenSSL in their get_source.sh
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
   if [ "${ARCHITECTURE}" == "aarch64" ]; then
-    echo PROBABLE JETSON NANO DEVELOPMENT ENVIRONMENT - Enabling CUDA ...
+    # Potentially a JetSon Nano dev environment so look here
     CUDA_HOME=/usr/local/cuda-10.2
   else
     CUDA_HOME=/usr/local/cuda-9.0


### PR DESCRIPTION
We don't enable this as a matter of course, since our cloud machines do not have the CUDA development kit installed, but for anyone that has the CUDA 10.2 toolkit installed on a device such as the Jetson Nano ([thread](https://forums.developer.nvidia.com/t/cuda-toolkit-for-jetson-nano/122671)), this will enable the CUDA support to be built into OpenJ9.

Signed-off-by: Stewart X Addison <sxa@redhat.com>