### PR TITLE
Add qemu into build process for OpenJ9 RISC-V cross-compiles

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -285,6 +285,16 @@ if [ "${ARCHITECTURE}" == "riscv64" ] && [ "${NATIVE_API_ARCH}" != "riscv64" ]; 
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     # shellcheck disable=SC2001
     CONFIGURE_ARGS_FOR_ANY_PLATFORM=$(echo "$CONFIGURE_ARGS_FOR_ANY_PLATFORM" | sed "s,with-openssl=[^ ]*,with-openssl=${RISCV_SYSROOT}/usr,g")
+    if ! which qemu-riscv64-static; then
+      # don't download it if we already have it from a previous build
+      if [ ! -x "$WORKSPACE/qemu-riscv64-static" ]; then
+        echo Download qemu-riscv64-static as it is required for the OpenJ9 cross build ...
+        curl https://ci.adoptopenjdk.net/userContent/riscv/qemu-riscv64-static.xz | xz -d > "$WORKSPACE/qemu-riscv64-static" && \
+        chmod 755 "$WORKSPACE/qemu-riscv64-static"
+      fi
+      export PATH="$PATH:$WORKSPACE" && \
+      qemu-riscv64-static --version
+    fi
   fi
 
   if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then


### PR DESCRIPTION
May add this into the playbooks in future, but for now I'm going to download dynamically during the build. Required to execute `constgen`. Should fix https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-riscv64-openj9/