### PR TITLE
`release` file in root of JDK8 tarball should have `JVM_VARIANT=Hotspot`

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1456,7 +1456,11 @@ addFullVersion() { # Adds the full version including build number i.e. 11.0.9+5-
 
 addJVMVariant() {
   # shellcheck disable=SC2086
-  echo -e JVM_VARIANT=\"${BUILD_CONFIG[BUILD_VARIANT]^}\" >>release
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ] || [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
+    echo -e JVM_VARIANT=\"Hotspot\" >>release
+  else
+    echo -e JVM_VARIANT=\"${BUILD_CONFIG[BUILD_VARIANT]^}\" >>release
+  fi
 }
 
 addBuildSHA() { # git SHA of the build repository i.e. openjdk-build


### PR DESCRIPTION
Currently has `JVM_VARIANT="Temurin"` which is not what we want.

Fixes https://github.com/adoptium/temurin-build/issues/2862