### PR TITLE
Integrate CycloneDX SBOM API into build.sh

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -111,8 +111,9 @@
                 </jar>
         </target>
 
-          <target name="run">
+        <target name="run">
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--createNewSBOM"/>
                   <arg value="--name"/>
                   <arg value="Temurin"/>
@@ -123,6 +124,7 @@
                 </java> 
                 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
                   <arg value="JDK-info"/>
@@ -130,6 +132,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="JDK-info"/>
@@ -141,6 +144,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                   <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="JDK-info"/>
@@ -152,6 +156,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                   <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="JDK-info"/>
@@ -163,6 +168,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="JDK-info"/>
@@ -174,6 +180,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
                   <arg value="Temurin Build"/>
@@ -181,6 +188,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="Temurin Build"/>
@@ -192,6 +200,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="Temurin Build"/>
@@ -203,6 +212,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
                   <arg value="make-arguments"/>
@@ -212,6 +222,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="make-arguments"/>
@@ -223,6 +234,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="make-arguments"/>
@@ -234,6 +246,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
                   <arg value="configure_arguments"/>
@@ -243,6 +256,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="configure_arguments"/>
@@ -254,6 +268,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
                   <arg value="Temurin build scripts/source"/>
@@ -261,6 +276,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="Temurin build scripts/source"/>
@@ -272,6 +288,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="Temurin build scripts/source"/>
@@ -283,6 +300,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
                   <arg value="docker container built"/>
@@ -292,6 +310,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="docker container built"/>
@@ -303,6 +322,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
                   <arg value="Built binary java-version string"/>
@@ -310,6 +330,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
                   <arg value="Built binary java-version string"/>
@@ -321,6 +342,7 @@
                   <arg value="testSBOM.json"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addExternalReference"/>
                   <arg value="--url"/>
                   <arg value="https://github.com/adoptium/jdk17/commit/a5afad28437"/>
@@ -332,6 +354,7 @@
                   <arg value="testSBOM.json"/>
                 </java> 
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addExternalReference"/>
                   <arg value="--url"/>
                   <arg value="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-1.1.6.tar.bz2"/>
@@ -342,7 +365,8 @@
                   <arg value="--jsonFile"/>
                   <arg value="testSBOM.json"/>
                 </java> 
-               <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
                   <arg value="--addMetadata"/>
                   <arg value="--metadataName"/>
                   <arg value="Eclipse Adoptium"/>

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -35,6 +35,8 @@ import java.util.List;
  */
 public final class TemurinGenSBOM {
 
+    private static boolean verbose = false;
+
     private TemurinGenSBOM() {
     }
     /**
@@ -87,6 +89,8 @@ public final class TemurinGenSBOM {
                 cmd = "addExternalReference";
             } else if (args[i].equals("--addComponentExtRef")) {
                 cmd = "addComponentExternalReference";
+            } else if (args[i].equals("--verbose")) {
+                verbose = true;
             }
         }
         switch (cmd) {
@@ -221,7 +225,11 @@ public final class TemurinGenSBOM {
     static void writeJSONfile(final Bom bom, final String fileName) {          // Creates testJson.json file
         FileWriter file;
         String json = generateBomJson(bom);
-        System.out.println("SBOM: " + json);
+
+        if (verbose) {
+            System.out.println("SBOM: " + json);
+        }
+
         try {
             file = new FileWriter(fileName);
             file.write(json);

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -689,8 +689,14 @@ generateSBoM() {
   # Add scmRef JDK Component Property
   addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "scmRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
 
+  # Add OpenJDK source ref commit JDK Component Property
+  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "openjdkSourceCommit" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"
+
   # Add buildRef JDK Component Property
   addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "buildRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
+
+  # Add builtConfig JDK Component Property
+  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "builtConfig" "${BUILD_CONFIG[WORKSPACE_DIR]}/config/built_config.cfg"
 
   # Add full_version_output JDK Component Property
   addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "full_version_output" "${fullVerOutput}"
@@ -712,6 +718,12 @@ generateSBoM() {
 
   # Add ALSA 3rd party component
   addSBOMComponentFromFile "${javaHome}" "${classpath}" "${sbomJson}" "ALSA" "dependency_version_alsa" "url" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_version_alsa.txt"
+
+  # Add FreeType 3rd party component
+  addSBOMComponentFromFile "${javaHome}" "${classpath}" "${sbomJson}" "FreeType" "dependency_version_freetype" "url" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_version_freetype.txt"
+
+  # Add FreeMarker 3rd party component
+  addSBOMComponentFromFile "${javaHome}" "${classpath}" "${sbomJson}" "FreeMarker" "dependency_version_freemarker" "url" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_version_freemarker.txt"
 
   # Print SBOM json
   echo "CycloneDX SBOM:"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -668,12 +668,119 @@ generateSBoM() {
     classpath="${classpath//jar:/jar;}"
   fi
 
-  # Run app to generate SBoM
+  # Run a series of SBOM API commands to generate the required SBOM
+  local sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
+  # Clean any old json
+  rm -f $sbomJson
 
-  # Examples.. 
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --create         temurin_sbom.json --name "Temurin SBOM" --version "1.2.3" --type "application" --author "Adoptium"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --add_component  temurin_sbom.json --name "openjdk" --version "1.0.0" --hash "abcdefg123456"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --add_dependency temurin_sbom.json --name "gcc" --version "8.5.0"
+  JAVA_LOC="$PRODUCT_HOME/bin/java"
+  local fullVer=$($JAVA_LOC -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r')
+  local fullVerOutput=$($JAVA_LOC -version 2>&1)
+
+  # Create initial SBOM json
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+
+  # Add Metadata object
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+
+  # Add JDK Component
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"
+
+  # Add scmRef JDK Component Property
+  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "scmRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
+
+  # Add buildRef JDK Component Property
+  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "buildRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
+
+  # Add full_version_output JDK Component Property
+  addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "full_version_output" "${fullVerOutput}"
+
+  # Add makejdk_any_platform_args JDK Component Property
+  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "makejdk_any_platform_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/config/makejdk-any-platform.args"
+
+  # Add make_command_args JDK Component Property
+  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
+
+  # Add OS
+  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS_KERNEL" "${BUILD_CONFIG[OS_KERNEL_NAME]^}"
+
+  # Add ARCHITECTURE
+  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS_ARCHITECTURE" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
+
+  # Add VARIANT
+  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "VARIANT" "${BUILD_CONFIG[BUILD_VARIANT]^}"
+
+  # Add ALSA 3rd party component
+  addSBOMComponentFromFile "${javaHome}" "${classpath}" "${sbomJson}" "ALSA" "dependency_version_alsa" "url" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_version_alsa.txt"
+
+  # Print SBOM json
+  echo "CycloneDX SBOM:"
+  cat  "${sbomJson}"
+  echo ""
+}
+
+# Add the given Property name & value to the SBOM Metadata
+addSBOMMetadataProperty() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  local name="${4}"
+  local value="${5}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadataProp --jsonFile "${jsonFile}" --name "${name}" --value "${value}"
+}
+
+# If the given property file exists, then add the given Property name with the given file contents value to the SBOM Metadata
+addSBOMMetadataPropertyFromFile() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  local name="${4}"
+  local propFile="${5}"
+  if [ -e "${propFile}" ]; then
+      local value=$(cat "${propFile}")
+      "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadataProp --jsonFile "${jsonFile}" --name "${name}" --value "${value}"
+  fi
+}
+
+# If the given property file exists, then add the given Component and Property with the given file contents value
+addSBOMComponentFromFile() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  local compName="${4}"
+  local description="${5}"
+  local name="${6}"
+  local propFile="${7}"
+  if [ -e "${propFile}" ]; then
+      local value=$(cat "${propFile}")
+      "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent     --jsonFile "${jsonFile}" --compName "${compName}" --description "${description}"
+      "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponentProp --jsonFile "${jsonFile}" --compName "${compName}" --name "${name}" --value "${value}"
+  fi
+}
+
+# Add the given Property name & value to the given SBOM Component
+addSBOMComponentProperty() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  local compName="${4}"
+  local name="${5}"
+  local value="${6}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponentProp --jsonFile "${jsonFile}" --compName "${compName}" --name "${name}" --value "${value}"
+}
+
+# If the given property file exists, then add the given Property name with the given file contents value to the given SBOM Component
+addSBOMComponentPropertyFromFile() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  local compName="${4}"
+  local name="${5}"
+  local propFile="${6}"
+  if [ -e "${propFile}" ]; then
+      local value=$(cat "${propFile}")
+      "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponentProp --jsonFile "${jsonFile}" --compName "${compName}" --name "${name}" --value "${value}"
+  fi
 }
 
 getGradleJavaHome() {
@@ -1633,6 +1740,10 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   printJavaVersionString
   addInfoToReleaseFile
   addInfoToJson
+  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
+    buildCyclonedxLib
+    generateSBoM
+  fi
   removingUnnecessaryFiles
   copyFreeFontForMacOS
   setPlistForMacOS
@@ -1660,16 +1771,15 @@ if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" != "true" ]]; then
   printJavaVersionString
   addInfoToReleaseFile
   addInfoToJson
+  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
+    buildCyclonedxLib
+    generateSBoM
+  fi
   removingUnnecessaryFiles
   copyFreeFontForMacOS
   setPlistForMacOS
   addNoticeFile
   createOpenJDKTarArchive
-fi
-
-if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
-  buildCyclonedxLib
-  generateSBoM
 fi
 
 echo "build.sh : $(date +%T) : All done!"


### PR DESCRIPTION
Integrate the new CycloneDX Java API plugin into the build-scripts bill of materials generation.

This PR creates the SBOM file: ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json

A 2nd PR for ci-jenkins-pipelines will create a new Artifact from sbom.json.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>