### PR TITLE
Appropriately name MacOS bootjdk directories

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -79,11 +79,9 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
   # instead of BOOT_JDK_VARIABLE (no '$').
   export "${BOOT_JDK_VARIABLE}"="$bootDir/Contents/Home"
   if [ ! -x "$bootDir/Contents/Home/bin/javac" ]; then
-    if [ -x "/Library/Java/JavaVirtualMachines/adoptopenjdk-${JDK_BOOT_VERSION}/Contents/Home/bin/javac" ]; then
-      echo "Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/adoptopenjdk-${JDK_BOOT_VERSION}/Contents/Home"
-      export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/adoptopenjdk-${JDK_BOOT_VERSION}/Contents/Home"
-    elif [[ ("$JDK_BOOT_VERSION" -ge 17) && ( -x "/Library/Java/JavaVirtualMachines/temurin-${JDK_BOOT_VERSION}.jdk/Contents/Home/bin/javac") ]]; then
-        export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/temurin-${JDK_BOOT_VERSION}.jdk/Contents/Home"
+    if [ -x "/Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home/bin/javac" ]; then
+      echo "Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home"
+      export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home"
     elif [ "$JDK_BOOT_VERSION" -ge 8 ]; then # Adopt has no build pre-8
       mkdir -p "$bootDir"
       releaseType="ga"

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -79,6 +79,7 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
   # instead of BOOT_JDK_VARIABLE (no '$').
   export "${BOOT_JDK_VARIABLE}"="$bootDir/Contents/Home"
   if [ ! -x "$bootDir/Contents/Home/bin/javac" ]; then
+    # To support multiple vendor names we set a jdk-* symlink pointing to the actual boot JDK
     if [ -x "/Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home/bin/javac" ]; then
       echo "Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home"
       export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home"


### PR DESCRIPTION
ref https://github.com/adoptium/infrastructure/pull/2498

MacOS bootjdks install into either `/Library/Java/JavaVirtualMachines/temurin-*` or  `/Library/Java/JavaVirtualMachines/adoptopenjdk-*`. After the linked pr is merged, the build scripts can instead look into `/Library/Java/JavaVirtualMachines/jdk-* ` which will be a symlink to either `temurin-*` or `adoptopenjdk-*`

Merge after release, and after the linked infra pr is merged and after such changes have been made to build and test MacOS machines