### PR TITLE
Use full xcode for MacOS/aarch64 JDK11

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -30,8 +30,8 @@ then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
   fi
 else
-  if [[ "$JAVA_FEATURE_VERSION" -ge 17 ]]; then
-    # JDK17 requires metal (included in full xcode)
+  if [[ "$JAVA_FEATURE_VERSION" -ge 17 ]] || [[ "${ARCHITECTURE}" == "aarch64" ]]; then
+    # JDK17 requires metal (included in full xcode) as does JDK11 on aarch64
     XCODE_SWITCH_PATH="/Applications/Xcode.app"
   else
     # Command line tools used from JDK9-JDK16


### PR DESCRIPTION
It probably makes sense to use full Xcode for JDK11 on both MacOS architectures, but I was definitely getting build failures when using just the command line tools on aarch64.

Will likely be superceded by the changes in https://github.com/adoptium/temurin-build/pull/2876 at some point.

Signed-off-by: Stewart X Addison <sxa@redhat.com>