### PR TITLE
Update compiler version for jdk11+ on AIX.

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -118,11 +118,13 @@ fi
 
 if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then
   export LANG=C
-  if [ "$JAVA_FEATURE_VERSION" -ge 13 ]; then
+  if [ "$JAVA_FEATURE_VERSION" -ne 12 ]; then
+    # for jdk 11 & 13+
     export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:$PATH
     export CC=xlclang
     export CXX=xlclang++
   else
+    # for jdk 12
     export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH
   fi
 fi

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -118,15 +118,9 @@ fi
 
 if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then
   export LANG=C
-  if [ "$JAVA_FEATURE_VERSION" -ne 12 ]; then
-    # for jdk 11 & 13+
-    export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:$PATH
-    export CC=xlclang
-    export CXX=xlclang++
-  else
-    # for jdk 12
-    export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH
-  fi
+  export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:$PATH
+  export CC=xlclang
+  export CXX=xlclang++
 fi
 
 # J9 JDK14 builds seem to be chewing up more RAM than the others, so restrict it


### PR DESCRIPTION
Future builds of jdk11u will require xlc 16.1. This PR updates the version used to build those jdk versions.

https://github.com/adoptium/temurin-build/issues/2882

DCO 1.1 Signed-off-by: Tyler Steele