### PR TITLE
Fix: fail build.sh if archive not produced by createArchive()

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1409,10 +1409,19 @@ createArchive() {
   createOpenJDKArchive "${repoLocation}" "OpenJDK"
   archive="${PWD}/OpenJDK${archiveExtension}"
 
+  archiveTarget=${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/${targetName}
+
   echo "Your final archive was created at ${archive}"
 
   echo "Moving the artifact to ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}"
-  mv "${archive}" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/${targetName}"
+  mv "${archive}" "${archiveTarget}"
+
+  if [ -f "$archiveTarget" ] && [ -s "$archiveTarget" ] ; then
+    echo "archive done."
+  else
+    echo "[ERROR] ${targetName} failed to be archived"
+    exit 1
+  fi
 }
 
 # Create a Tar ball

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -129,7 +129,7 @@ createOpenJDKArchive()
   if which pigz > /dev/null 2>&1; then
     COMPRESS=pigz
   fi
-  echo "Archiving the build OpenJDK image and compressing with $COMPRESS"
+  echo "Archiving and compressing with $COMPRESS"
 
   EXT=$(getArchiveExtension)
 


### PR DESCRIPTION
Check archive result if targetfile is created and empty, otherwise exit 1 from createArchive()

Ref: https://github.com/adoptium/temurin-build/issues/2261