### PR TITLE
fix: Dragonwell builds fail due to incorrect version

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -164,7 +164,7 @@ getOpenJdkVersion() {
         local minorNum="$(cut -d'.' -f 2 <"${dragonwellVerFile}")"
         local updateNum="$(cut -d'.' -f 3 <"${dragonwellVerFile}")"
         # special handling for dragonwell version
-        local buildNum="$(cut -d'.' -f 5 <"${dragonwellVerFile}" | cut -d'-' -f 2)"
+        local buildNum="$(cut -d'.' -f 5 <"${dragonwellVerFile}" | cut -d'-' -f 1)"
         version="jdk-11.${minorNum}.${updateNum}+${buildNum}"
       fi
     else

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -163,7 +163,8 @@ getOpenJdkVersion() {
       else
         local minorNum="$(cut -d'.' -f 2 <"${dragonwellVerFile}")"
         local updateNum="$(cut -d'.' -f 3 <"${dragonwellVerFile}")"
-        local buildNum="$(cut -d'.' -f 5 <"${dragonwellVerFile}")"
+        # special handling for dragonwell version
+        local buildNum="$(cut -d'.' -f 5 <"${dragonwellVerFile}" | cut -d'-' -f 2)"
         version="jdk-11.${minorNum}.${updateNum}+${buildNum}"
       fi
     else


### PR DESCRIPTION
	- to handle version in format e.g 11.0.14.10.0-GA
	- keep smae logic in jdk8 without change

Ref: https://github.com/adoptium/temurin-build/issues/2889