### PR TITLE
Force make to use SHELL=/bin/bash on Solaris

### DIFF
--- a/build-farm/platform-specific-configurations/solaris.sh
+++ b/build-farm/platform-specific-configurations/solaris.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
-export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+export BUILD_ARGS="${BUILD_ARGS} --skip-freetype --make-args SHELL=/bin/bash"
 
 if [ "${ARCHITECTURE}" == "x64" ]; then
   export CUPS="--with-cups=/opt/sfw/cups"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/2894. Supercedes https://github.com/adoptium/ci-jenkins-pipelines/pull/283

I believe this will set `BUILD_ARGS` to the right thing in the pipelines - https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-x64-hotspot/795/ seems to be running happily with this in place:

```
"BUILD_ARGS": "--make-args SHELL=/bin/bash",
```
Signed-off-by: Stewart X Addison <sxa@redhat.com>
