### PR TITLE
Replace 'grep -E' with 'egrep' for Solaris compatibility

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2155,SC1091
+# shellcheck disable=SC2155,SC1091,SC2196
 
 ################################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -58,9 +58,9 @@ checkoutAndCloneOpenJDKGitRepo() {
     # eg. origin https://github.com/alibaba/dragonwell8.git (fetch)
     # eg. origin https://github.com/feilongjiang/bishengjdk-11-mirror.git (fetch)
     if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_DRAGONWELL}" ] || [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
-      git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep -E "${BUILD_CONFIG[REPOSITORY]}.git|${BUILD_CONFIG[REPOSITORY]}\s"
+      git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | egrep "${BUILD_CONFIG[REPOSITORY]}.git|${BUILD_CONFIG[REPOSITORY]}\s"
     else
-      git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | grep -E "${BUILD_CONFIG[REPOSITORY]}.git|${BUILD_CONFIG[REPOSITORY]}\s"
+      git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | egrep "${BUILD_CONFIG[REPOSITORY]}.git|${BUILD_CONFIG[REPOSITORY]}\s"
     fi
     local isValidGitRepo=$?
     set -e
@@ -354,7 +354,7 @@ checkFingerprint() {
   echo "$verify"
 
   # grep out and trim fingerprint from line of the form "Primary key fingerprint: 58E0 C111 E39F 5408 C5D3  EC76 C1A6 0EAC E707 FDA5"
-  local fingerprint=$(echo "$verify" | grep "Primary key fingerprint" | grep -E -o "([0-9A-F]{4} ? ?){10}" | head -n 1)
+  local fingerprint=$(echo "$verify" | grep "Primary key fingerprint" | egrep -o "([0-9A-F]{4} ? ?){10}" | head -n 1)
 
   # Remove whitespace from finger print as different versions of gpg may or may not add spaces to the fingerprint
   # specifically gpg on Ubuntu 16.04 produces:
@@ -611,7 +611,7 @@ function moveTmpToWorkspaceLocation() {
 
 relocateToTmpIfNeeded() {
   if [ "${BUILD_CONFIG[TMP_SPACE_BUILD]}" == "true" ]; then
-    jobName=$(echo "${JOB_NAME:-build-dir}" | grep -E -o "[^/]+$")
+    jobName=$(echo "${JOB_NAME:-build-dir}" | egrep -o "[^/]+$")
     local tmpdir="/tmp/openjdk-${jobName}"
     mkdir -p "$tmpdir"
 


### PR DESCRIPTION
`grep -E` is not supported by the default Solaris grep, and `egrep` should offer equivalent functionality everywhere.

(NOTE to committers: This does NOT need to be merged before the current release so it should wait until afterwards, however reviews are welcome)

Check in VPC at https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1414/ but we should probably glance at the output and verify that this hasn't caused any functional changes.

Fixes this in the build logs:
```
19:06:03  grep: illegal option -- E
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>