### PR TITLE
mk-cacerts: Use more portable syntax for converting to lower case

### DIFF
--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -90,8 +90,7 @@ for FILE in certs/*.crt; do
     else
         # Remove/translate characters not valid in a filename
         ALIAS_NO_INVALID="${TRIMMED_SUBJECT//[ :()]/_}"
-        ALIAS_NO_SPECIAL=$(echo "${ALIAS_NO_INVALID}" | tr -cd 'a-zA-Z,_')
-        ALIAS="${ALIAS_NO_SPECIAL,,}"
+        ALIAS=$(echo "${ALIAS_NO_INVALID}" | tr -cd 'a-zA-Z,_' | tr A-Z a-z)
     fi
 
     if [ "$NO_KEYSTORE" = false ] ; then


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/2902