### PR TITLE
feat: enable --create-sbom in pipeline to create CycloneDX SBOM

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -236,11 +236,11 @@ if [ "${JAVA_FEATURE_VERSION}" -lt 16 ]; then
   export BUILD_ARGS="${BUILD_ARGS} --create-jre-image"
 fi
 
-echo "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args ${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
+echo "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --create-sbom --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args ${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
 
 # Convert all speech marks in config args to make them safe to pass in.
 # These will be converted back into speech marks shortly before we use them, in build.sh.
 CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM//\"/temporary_speech_mark_placeholder}"
 
 # shellcheck disable=SC2086
-bash -c "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
+bash -c "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --create-sbom --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -31,6 +31,7 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+
 # shellcheck source=sbin/prepareWorkspace.sh
 source "$SCRIPT_DIR/prepareWorkspace.sh"
 
@@ -643,8 +644,8 @@ buildCyclonedxLib() {
     exit 2
   fi
 
-  JAVA_HOME=${javaHome} ant -f "${WORKSPACE}/cyclonedx-lib/build.xml" clean
-  JAVA_HOME=${javaHome} ant -f "${WORKSPACE}/cyclonedx-lib/build.xml" build
+  JAVA_HOME=${javaHome} ant -f "${SCRIPT_DIR}/cyclonedx-lib/build.xml" clean
+  JAVA_HOME=${javaHome} ant -f "${SCRIPT_DIR}/cyclonedx-lib/build.xml" build
 }
 
 # Generate the SBoM
@@ -663,7 +664,7 @@ generateSBoM() {
   fi
 
   # classpath to run CycloneDX java app TemurinGenSBOM
-  classpath="${WORKSPACE}/cyclonedx-lib/build/jar/temurin-gen-sbom.jar:${WORKSPACE}/cyclonedx-lib/build/jar/cyclonedx-core-java.jar:${WORKSPACE}/cyclonedx-lib/build/jar/jackson-core.jar:${WORKSPACE}/cyclonedx-lib/build/jar/jackson-dataformat-xml.jar:${WORKSPACE}/cyclonedx-lib/build/jar/jackson-databind.jar:${WORKSPACE}/cyclonedx-lib/build/jar/jackson-annotations.jar:${WORKSPACE}/cyclonedx-lib/build/jar/json-schema.jar:${WORKSPACE}/cyclonedx-lib/build/jar/commons-codec.jar:${WORKSPACE}/cyclonedx-lib/build/jar/commons-io.jar:${WORKSPACE}/cyclonedx-lib/build/jar/github-package-url.jar"
+  classpath="${SCRIPT_DIR}/cyclonedx-lib/build/jar/temurin-gen-sbom.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/cyclonedx-core-java.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-core.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-dataformat-xml.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-databind.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-annotations.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/json-schema.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/commons-codec.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/commons-io.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/github-package-url.jar"
 
   if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" =~ .*cygwin.* ]]; then
     classpath="${classpath//jar:/jar;}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -45,6 +45,7 @@ source "$SCRIPT_DIR/common/constants.sh"
 source "$SCRIPT_DIR/common/common.sh"
 
 export LIB_DIR=$(crossPlatformRealPath "${SCRIPT_DIR}/../pipelines/")
+export CYCLONEDB_DIR="${SCRIPT_DIR}/../cyclonedx-lib"
 
 export jreTargetPath
 export CONFIGURE_ARGS=""
@@ -644,8 +645,8 @@ buildCyclonedxLib() {
     exit 2
   fi
 
-  JAVA_HOME=${javaHome} ant -f "${SCRIPT_DIR}/cyclonedx-lib/build.xml" clean
-  JAVA_HOME=${javaHome} ant -f "${SCRIPT_DIR}/cyclonedx-lib/build.xml" build
+  JAVA_HOME=${javaHome} ant -f "${CYCLONEDB_DIR}/build.xml" clean
+  JAVA_HOME=${javaHome} ant -f "${CYCLONEDB_DIR}/build.xml" build
 }
 
 # Generate the SBoM
@@ -664,7 +665,7 @@ generateSBoM() {
   fi
 
   # classpath to run CycloneDX java app TemurinGenSBOM
-  classpath="${SCRIPT_DIR}/cyclonedx-lib/build/jar/temurin-gen-sbom.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/cyclonedx-core-java.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-core.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-dataformat-xml.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-databind.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/jackson-annotations.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/json-schema.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/commons-codec.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/commons-io.jar:${SCRIPT_DIR}/cyclonedx-lib/build/jar/github-package-url.jar"
+  classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
 
   if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" =~ .*cygwin.* ]]; then
     classpath="${classpath//jar:/jar;}"


### PR DESCRIPTION
enable flag `--create-sbom` to call buildCyclonedxLib() and generateSBoM()

this will be a default behavior for all build. 
it would be better to set in the ci-jenkins-pipeline as an extra flag for BUILD_CONFIGURATION then pass to temurin-build, so we can enable different jdk version or even os/arch per needs