### PR TITLE
fix: ant build Sbom on Windows

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -22,9 +22,9 @@
 
         <!-- Dependency versions -->
         <property name="cyclonedx-core-java-version" value="7.1.4"/>
-        <property name="jackson-core-version" value="2.8.7"/>
-        <property name="jackson-annotations-version" value="2.8.7"/>
-        <property name="jackson-databind-version" value="2.8.7"/>
+        <property name="jackson-core-version" value="2.13.3"/>
+        <property name="jackson-annotations-version" value="2.13.3"/>
+        <property name="jackson-databind-version" value="2.13.3"/>
         <property name="json-schema-version" value="1.0.58"/>
         <property name="commons-codec-version" value="1.15"/>
         <property name="commons-io-version" value="2.11.0"/>

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -21,7 +21,7 @@
 -->
 
         <!-- Dependency versions -->
-        <property name="cyclonedx-core-java-version" value="7.1.0"/>
+        <property name="cyclonedx-core-java-version" value="7.1.4"/>
         <property name="jackson-version" value="2.12.4"/>
         <property name="json-schema-version" value="1.0.58"/>
         <property name="commons-codec-version" value="1.15"/>

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -98,8 +98,8 @@
 
         <target name="compile">
                 <mkdir dir="build/classes"/>
-                <javac srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar"/>
-                <javac debug="true" debuglevel="lines,vars,source" srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar"/>
+                <javac srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar" includeantruntime="false"/>
+                <javac debug="true" debuglevel="lines,vars,source" srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar" includeantruntime="false"/>
         </target>
 
         <target name="jar">

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -22,7 +22,9 @@
 
         <!-- Dependency versions -->
         <property name="cyclonedx-core-java-version" value="7.1.4"/>
-        <property name="jackson-version" value="2.12.4"/>
+        <property name="jackson-core-version" value="2.8.7"/>
+        <property name="jackson-annotations-version" value="2.8.7"/>
+        <property name="jackson-databind-version" value="2.8.7"/>
         <property name="json-schema-version" value="1.0.58"/>
         <property name="commons-codec-version" value="1.15"/>
         <property name="commons-io-version" value="2.11.0"/>
@@ -49,23 +51,23 @@
 	</target>
 
         <target name="download-jackson-core" unless="jackson-core_available">
-                <echo message="Downloading jackson-core version ${jackson-version}"/>
-                <download-file destdir="build/jar" destfile="jackson-core.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/core/jackson-core/${jackson-version}/jackson-core-${jackson-version}.jar"/>
+                <echo message="Downloading jackson-core version ${jackson-core-version}"/>
+                <download-file destdir="build/jar" destfile="jackson-core.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/core/jackson-core/${jackson-core-version}/jackson-core-${jackson-core-version}.jar"/>
         </target>
 
         <target name="download-jackson-dataformat-xml" unless="jackson-core_available">
-                <echo message="Downloading jackson-dataformat-xml version ${jackson-version}"/>
-                <download-file destdir="build/jar" destfile="jackson-dataformat-xml.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/dataformat/jackson-dataformat-xml/${jackson-version}/jackson-dataformat-xml-${jackson-version}.jar"/>
+                <echo message="Downloading jackson-dataformat-xml version ${jackson-databind-version}"/>
+                <download-file destdir="build/jar" destfile="jackson-dataformat-xml.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/dataformat/jackson-dataformat-xml/${jackson-databind-version}/jackson-dataformat-xml-${jackson-databind-version}.jar"/>
         </target>
 
         <target name="download-jackson-databind" unless="jackson-databind_available">
-                <echo message="Downloading jackson-databind version ${jackson-version}"/>
-                <download-file destdir="build/jar" destfile="jackson-databind.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/core/jackson-databind/${jackson-version}/jackson-databind-${jackson-version}.jar"/>
+                <echo message="Downloading jackson-databind version ${jackson-databind-version}"/>
+                <download-file destdir="build/jar" destfile="jackson-databind.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/core/jackson-databind/${jackson-databind-version}/jackson-databind-${jackson-databind-version}.jar"/>
         </target>
 
         <target name="download-jackson-annotations" unless="jackson-annotations_available">
-                <echo message="Downloading jackson-annotations version ${jackson-version}"/>
-                <download-file destdir="build/jar" destfile="jackson-annotations.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/core/jackson-annotations/${jackson-version}/jackson-annotations-${jackson-version}.jar"/>
+                <echo message="Downloading jackson-annotations version ${jackson-annotations-version}"/>
+                <download-file destdir="build/jar" destfile="jackson-annotations.jar" srcurl="https://search.maven.org/classic/remotecontent?filepath=com/fasterxml/jackson/core/jackson-annotations/${jackson-annotations-version}/jackson-annotations-${jackson-annotations-version}.jar"/>
         </target>
 
         <target name="download-json-schema" unless="json-schema_available">

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -237,6 +237,20 @@ public final class TemurinGenSBOM {
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        if (verbose) {
+            System.out.println("DEBUG sbom.json START: ");
+            FileReader reader = new FileReader(fileName);
+            try {
+                int i;
+                while((i = reader.read()) != -1) {
+                    System.out.print((char)i);
+                }
+           } finally {
+                reader.close();
+                System.out.println("DEBUG sbom.json DONE");
+           }
+        }
     }
 
     static Bom readJSONfile(final String fileName) { 	                               // Returns parse bom

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -101,7 +101,7 @@ public final class TemurinGenSBOM {
                 break;
 
             case "addMetadata":                              // Adds Metadata Component --> name
-                bom = addMetadata(name, fileName);
+                bom = addMetadata(name, version, fileName);
                 writeJSONfile(bom, fileName);
                 break;
 
@@ -145,10 +145,19 @@ public final class TemurinGenSBOM {
         bom.addComponent(comp);
         return bom;
     }
-    static Bom addMetadata(final String name, final String fileName) {          // Method to store metadata -->  name
-        Bom bom = readJSONfile(fileName);
+    static Bom addMetadata(final String name, final String version, final String fileName) {          // Method to store metadata -->  name
+        Bom bom = new Bom(); // readJSONfile(fileName);
         Metadata meta = new Metadata();
         Component comp = new Component();
+        if (bom == null){
+
+            comp.setName(name);
+            comp.setVersion(version);
+            comp.setType(Component.Type.FRAMEWORK);
+            comp.setGroup("Eclipse Temurin");
+            comp.setAuthor("Vendor: Eclipse");
+            bom.addComponent(comp);
+        }
         comp.setName(name);
         comp.setType(Component.Type.FRAMEWORK);
         OrganizationalEntity org = new OrganizationalEntity();

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -16,6 +16,7 @@ package temurin.sbom;
 
 import org.cyclonedx.BomGeneratorFactory;
 import org.cyclonedx.CycloneDxSchema;
+// import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.model.Property;
@@ -138,9 +139,9 @@ public final class TemurinGenSBOM {
         Component comp = new Component();
         comp.setName(name);
         comp.setVersion(version);
-        comp.setType(Component.Type.APPLICATION);
+        comp.setType(Component.Type.FRAMEWORK);
         comp.setGroup("Eclipse Temurin");
-        comp.setAuthor("Vendor: Adoptium");
+        comp.setAuthor("Vendor: Eclipse");
         bom.addComponent(comp);
         return bom;
     }
@@ -149,7 +150,7 @@ public final class TemurinGenSBOM {
         Metadata meta = new Metadata();
         Component comp = new Component();
         comp.setName(name);
-        comp.setType(Component.Type.APPLICATION);
+        comp.setType(Component.Type.FRAMEWORK);
         OrganizationalEntity org = new OrganizationalEntity();
         org.setName("Eclipse Foundation");
         org.setUrls(Collections.singletonList("https://www.eclipse.org/"));
@@ -217,7 +218,7 @@ public final class TemurinGenSBOM {
     }
 
     static String generateBomJson(final Bom bom) {
-        BomJsonGenerator bomGen = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_13, bom);
+        BomJsonGenerator bomGen = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);
         if(verbose) {
             if(bom == null){
                 System.out.println("bom is Null");
@@ -272,7 +273,8 @@ public final class TemurinGenSBOM {
             bom = parser.parse(reader);
         } catch (Exception e) {
             e.printStackTrace();
+        } finally{
+           return bom;
         }
-        return bom;
     }
 }

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -218,6 +218,14 @@ public final class TemurinGenSBOM {
 
     static String generateBomJson(final Bom bom) {
         BomJsonGenerator bomGen = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_13, bom);
+        if(verbose) {
+            if(bom == null){
+                System.out.println("bom is Null");
+            }
+            if(bomGen == null) {
+                System.out.println("bomGen is Null");
+            }
+        }
         String json = bomGen.toJsonString();
         return json;
     }

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -240,14 +240,17 @@ public final class TemurinGenSBOM {
 
         if (verbose) {
             System.out.println("DEBUG sbom.json START: ");
-            FileReader reader = new FileReader(fileName);
+            FileReader reader = null;
             try {
+                reader = new FileReader(fileName);
                 int i;
                 while((i = reader.read()) != -1) {
                     System.out.print((char)i);
                 }
-           } finally {
                 reader.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
                 System.out.println("DEBUG sbom.json DONE");
            }
         }

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -16,7 +16,6 @@ package temurin.sbom;
 
 import org.cyclonedx.BomGeneratorFactory;
 import org.cyclonedx.CycloneDxSchema;
-// import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.model.Property;
@@ -101,7 +100,7 @@ public final class TemurinGenSBOM {
                 break;
 
             case "addMetadata":                              // Adds Metadata Component --> name
-                bom = addMetadata(name, version, fileName);
+                bom = addMetadata(name, fileName);
                 writeJSONfile(bom, fileName);
                 break;
 
@@ -145,21 +144,10 @@ public final class TemurinGenSBOM {
         bom.addComponent(comp);
         return bom;
     }
-    static Bom addMetadata(final String name, final String version, final String fileName) {          // Method to store metadata -->  name
-        Bom bom = new Bom(); // readJSONfile(fileName);
+    static Bom addMetadata(final String name, final String fileName) {          // Method to store metadata -->  name
+        Bom bom = readJSONfile(fileName);
         Metadata meta = new Metadata();
         Component comp = new Component();
-        if (bom == null){
-
-            comp.setName(name);
-            comp.setVersion(version);
-            comp.setType(Component.Type.FRAMEWORK);
-            comp.setGroup("Eclipse Temurin");
-            comp.setAuthor("Vendor: Eclipse");
-            bom.addComponent(comp);
-        }
-        comp.setName(name);
-        comp.setType(Component.Type.FRAMEWORK);
         OrganizationalEntity org = new OrganizationalEntity();
         org.setName("Eclipse Foundation");
         org.setUrls(Collections.singletonList("https://www.eclipse.org/"));
@@ -227,59 +215,21 @@ public final class TemurinGenSBOM {
     }
 
     static String generateBomJson(final Bom bom) {
+        // Use schema v14: https://cyclonedx.org/schema/bom-1.4.schema.json
         BomJsonGenerator bomGen = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);
-        if(verbose) {
-            if(bom == null){
-                System.out.println("bom is Null");
-            }
-            if(bomGen == null) {
-                System.out.println("bomGen is Null");
-            }
-        }
         String json = bomGen.toJsonString();
-        if(verbose) {
-            if (json != "") {
-                System.out.println("SBOM0: " + json);
-            } else if (json == null) {
-                System.out.println("SBOM0 is null");
-            } else {
-                System.out.println("SBOM0 is emtpy string");
-            }
-        }                     
         return json;
     }
 
     static void writeJSONfile(final Bom bom, final String fileName) {          // Creates testJson.json file
         FileWriter file;
         String json = generateBomJson(bom);
-
-        if (verbose) {
-            System.out.println("SBOM: " + json);
-        }
-
         try {
             file = new FileWriter(fileName);
             file.write(json);
             file.close();
         } catch (Exception e) {
             e.printStackTrace();
-        }
-
-        if (verbose) {
-            System.out.println("DEBUG sbom.json START: ");
-            FileReader reader = null;
-            try {
-                reader = new FileReader(fileName);
-                int i;
-                while((i = reader.read()) != -1) {
-                    System.out.print((char)i);
-                }
-                reader.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            } finally {
-                System.out.println("DEBUG sbom.json DONE");
-           }
         }
     }
 
@@ -291,7 +241,7 @@ public final class TemurinGenSBOM {
             bom = parser.parse(reader);
         } catch (Exception e) {
             e.printStackTrace();
-        } finally{
+        } finally {
            return bom;
         }
     }

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -228,6 +228,15 @@ public final class TemurinGenSBOM {
             }
         }
         String json = bomGen.toJsonString();
+        if(verbose) {
+            if (json != "") {
+                System.out.println("SBOM0: " + json);
+            } else if (json == null) {
+                System.out.println("SBOM0 is null");
+            } else {
+                System.out.println("SBOM0 is emtpy string");
+            }
+        }                     
         return json;
     }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -678,14 +678,14 @@ generateSBoM() {
     classpath=$(cygpath -w "${classpath}")
     sbomJson=$(cygpath -w "${sbomJson}")
   fi
-  
+
   # Clean any old json
-  rm -f $sbomJson
+  rm -f "${sbomJson}"
   
   # Run a series of SBOM API commands to generate the required SBOM
 
   echo "DEBUG START:"
-  echo $sbomJson
+  echo "${sbomJson}"
   echo "DEBUG DONE!"
 
   JAVA_LOC="$PRODUCT_HOME/bin/java"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -684,21 +684,24 @@ generateSBoM() {
     done
   fi
 
-  echo "DEBUG START:"
-  echo $classpath
-  echo "DEBUG DONE!"
-
   # Run a series of SBOM API commands to generate the required SBOM
   local sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
   # Clean any old json
   rm -f $sbomJson
+
+  echo "DEBUG START:"
+  echo $sbomJson
+  echo "DEBUG DONE!"
 
   JAVA_LOC="$PRODUCT_HOME/bin/java"
   local fullVer=$($JAVA_LOC -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r')
   local fullVerOutput=$($JAVA_LOC -version 2>&1)
 
   # Create initial SBOM json
+  echo "DEBUG START:"
+  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+  echo "DEBUG DONE!"
 
   # Add Metadata object
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -674,9 +674,13 @@ generateSBoM() {
   classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
 
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" "${CYCLONEDB_DIR}/build/jar/jackson-core.jar" "${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar" "${CYCLONEDB_DIR}/build/jar/jackson-databind.jar" "${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar" "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar";
+    classpath=""
+    for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" \
+      "${CYCLONEDB_DIR}/build/jar/jackson-core.jar" "${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar" \
+      "${CYCLONEDB_DIR}/build/jar/jackson-databind.jar" "${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar" \
+      "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar";
     do
-      classpath+=$(cygpath -m "${jarfile}")";"
+      classpath+=$(cygpath -w "${jarfile}")";"
     done
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -677,6 +677,10 @@ generateSBoM() {
     classpath="${classpath//jar:/jar;}"
   fi
 
+  echo "DEBUG START:"
+  echo $classpath
+  echo "DEBUG DONE!"
+
   # Run a series of SBOM API commands to generate the required SBOM
   local sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
   # Clean any old json

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -672,22 +672,17 @@ generateSBoM() {
 
   # classpath to run CycloneDX java app TemurinGenSBOM
   classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
-
+  sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
+  # handle for windows cygwin path
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    classpath=""
-    for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" \
-      "${CYCLONEDB_DIR}/build/jar/jackson-core.jar" "${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar" \
-      "${CYCLONEDB_DIR}/build/jar/jackson-databind.jar" "${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar" \
-      "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar";
-    do
-      classpath+=$(cygpath -w "${jarfile}")";"
-    done
+    classpath=$(cygpath -w "${classpath}")
+    sbomJson=$(cygpath -w "${sbomJson}")
   fi
-
-  # Run a series of SBOM API commands to generate the required SBOM
-  local sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
+  
   # Clean any old json
   rm -f $sbomJson
+  
+  # Run a series of SBOM API commands to generate the required SBOM
 
   echo "DEBUG START:"
   echo $sbomJson

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -689,11 +689,6 @@ generateSBoM() {
   rm -f "${sbomJson}"
   
   # Run a series of SBOM API commands to generate the required SBOM
-
-  echo "DEBUG START:"
-  echo "${sbomJson}"
-  echo "DEBUG DONE!"
-
   JAVA_LOC="$PRODUCT_HOME/bin/java"
   local fullVer=$($JAVA_LOC -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r')
   local fullVerOutput=$($JAVA_LOC -version 2>&1)
@@ -702,10 +697,14 @@ generateSBoM() {
   echo "DEBUG START:"
   echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
-  echo "DEBUG DONE!"
+
+  local cont=$(cat "${sbomJson}")
+  echo "Content of ${sbomJson}:\n${cont}"
 
   # Add Metadata object
+  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+  echo "DEBUG DONE!"
 
   # Add JDK Component
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -673,7 +673,6 @@ generateSBoM() {
   # classpath to run CycloneDX java app TemurinGenSBOM
   classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
   sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
-  local java="${javaHome}/bin/java"
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     classpath=""
     for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" \
@@ -684,8 +683,7 @@ generateSBoM() {
       classpath+=$(cygpath -w "${jarfile}")";"
     done
     sbomJson=$(cygpath -w "${sbomJson}")
-    java="${javaHome}\bin\java"
-  fi 
+  fi
 
   # Clean any old json
   rm -f "${sbomJson}"
@@ -695,23 +693,21 @@ generateSBoM() {
   local fullVer=$($JAVA_LOC -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r')
   local fullVerOutput=$($JAVA_LOC -version 2>&1)
 
-
-
   # Create initial SBOM json
   echo "DEBUG START:"
-  echo "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
-  "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
 
   local cont=$(cat "${sbomJson}")
   echo "Content of ${sbomJson}:\n${cont}"
 
   # Add Metadata object
-  echo "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
-  "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
   echo "DEBUG DONE!"
 
   # Add JDK Component
-  "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"
 
   # Add scmRef JDK Component Property
   addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "scmRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -673,6 +673,7 @@ generateSBoM() {
   # classpath to run CycloneDX java app TemurinGenSBOM
   classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
   sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
+  local java="${javaHome}/bin/java"
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     classpath=""
     for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" \
@@ -683,7 +684,8 @@ generateSBoM() {
       classpath+=$(cygpath -w "${jarfile}")";"
     done
     sbomJson=$(cygpath -w "${sbomJson}")
-  fi
+    java="${javaHome}\bin\java"
+  fi 
 
   # Clean any old json
   rm -f "${sbomJson}"
@@ -693,21 +695,23 @@ generateSBoM() {
   local fullVer=$($JAVA_LOC -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r')
   local fullVerOutput=$($JAVA_LOC -version 2>&1)
 
+
+
   # Create initial SBOM json
   echo "DEBUG START:"
-  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+  echo "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+  "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
 
   local cont=$(cat "${sbomJson}")
   echo "Content of ${sbomJson}:\n${cont}"
 
   # Add Metadata object
-  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+  echo "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+  "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
   echo "DEBUG DONE!"
 
   # Add JDK Component
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"
+  "${java}" -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"
 
   # Add scmRef JDK Component Property
   addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "scmRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -673,9 +673,15 @@ generateSBoM() {
   # classpath to run CycloneDX java app TemurinGenSBOM
   classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
   sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
-  # handle for windows cygwin path
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    classpath=$(cygpath -w "${classpath}")
+    classpath=""
+    for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" \
+      "${CYCLONEDB_DIR}/build/jar/jackson-core.jar" "${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar" \
+      "${CYCLONEDB_DIR}/build/jar/jackson-databind.jar" "${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar" \
+      "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar";
+    do
+      classpath+=$(cygpath -w "${jarfile}")";"
+    done
     sbomJson=$(cygpath -w "${sbomJson}")
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -645,8 +645,14 @@ buildCyclonedxLib() {
     exit 2
   fi
 
-  JAVA_HOME=${javaHome} ant -f "${CYCLONEDB_DIR}/build.xml" clean
-  JAVA_HOME=${javaHome} ant -f "${CYCLONEDB_DIR}/build.xml" build
+  # Make Ant aware of cygwin path
+  if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
+    ANTBUILDFILE=$(cygpath -m ${CYCLONEDB_DIR}/build.xml)
+  else
+    ANTBUILDFILE="${CYCLONEDB_DIR}/build.xml"
+  fi
+  JAVA_HOME=${javaHome} ant -f "${ANTBUILDFILE}" clean
+  JAVA_HOME=${javaHome} ant -f "${ANTBUILDFILE}" build
 }
 
 # Generate the SBoM

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -673,8 +673,11 @@ generateSBoM() {
   # classpath to run CycloneDX java app TemurinGenSBOM
   classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
 
-  if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" =~ .*cygwin.* ]]; then
-    classpath="${classpath//jar:/jar;}"
+  if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
+    for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" "${CYCLONEDB_DIR}/build/jar/jackson-core.jar" "${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar" "${CYCLONEDB_DIR}/build/jar/jackson-databind.jar" "${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar" "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar";
+    do
+      classpath+=$(cygpath -m "${jarfile}")";"
+    done
   fi
 
   echo "DEBUG START:"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -647,7 +647,7 @@ buildCyclonedxLib() {
 
   # Make Ant aware of cygwin path
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    ANTBUILDFILE=$(cygpath -m ${CYCLONEDB_DIR}/build.xml)
+    ANTBUILDFILE=$(cygpath -m "${CYCLONEDB_DIR}/build.xml")
   else
     ANTBUILDFILE="${CYCLONEDB_DIR}/build.xml"
   fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -689,24 +689,17 @@ generateSBoM() {
 
   # Clean any old json
   rm -f "${sbomJson}"
-  
+
   # Run a series of SBOM API commands to generate the required SBOM
   JAVA_LOC="$PRODUCT_HOME/bin/java"
   local fullVer=$($JAVA_LOC -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r')
   local fullVerOutput=$($JAVA_LOC -version 2>&1)
 
   # Create initial SBOM json
-  echo "DEBUG START:"
-  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
 
-  local cont=$(cat "${sbomJson}")
-  echo "Content of ${sbomJson}:\n${cont}"
-
   # Add Metadata object
-  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
-  echo "DEBUG DONE!"
 
   # Add JDK Component
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -683,6 +683,7 @@ generateSBoM() {
       classpath+=$(cygpath -w "${jarfile}")";"
     done
     sbomJson=$(cygpath -w "${sbomJson}")
+    javaHome=$(cygpath -w "${javaHome}")
   fi
 
   # Clean any old json

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -696,15 +696,15 @@ generateSBoM() {
 
   # Create initial SBOM json
   echo "DEBUG START:"
-  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --createNewSBOM --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}" --version "$fullVer"
 
   local cont=$(cat "${sbomJson}")
   echo "Content of ${sbomJson}:\n${cont}"
 
   # Add Metadata object
-  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+  echo "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --verbose --addMetadata --jsonFile "$sbomJson" --name "${BUILD_CONFIG[BUILD_VARIANT]^}"
   echo "DEBUG DONE!"
 
   # Add JDK Component

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -678,7 +678,8 @@ generateSBoM() {
     for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" \
       "${CYCLONEDB_DIR}/build/jar/jackson-core.jar" "${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar" \
       "${CYCLONEDB_DIR}/build/jar/jackson-databind.jar" "${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar" \
-      "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar";
+      "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar" \
+      "${CYCLONEDB_DIR}/build/jar/github-package-url.jar" ;
     do
       classpath+=$(cygpath -w "${jarfile}")";"
     done


### PR DESCRIPTION
Fix:
- Ant does not recognize cygwin path, add logic check if it is running on Windows
  https://ant.apache.org/manual/platform.html
  running test: https://ci.adoptopenjdk.net/view/Failing%20Temurin%20jobs/job/build-scripts/job/jobs/job/jdk/job/jdk-windows-x64-temurin/82/console with debug info enabled
- uplift cyclondx-core and jackson SDK to latest version
- uplift to new schema to use FRAMEWORK than APPLICATION
- update to use eclipse than adoptium as vendor

Test on
[non-win](https://ci.adoptopenjdk.net/view/Failing%20Temurin%20jobs/job/build-scripts/job/jobs/job/jdk/job/jdk-linux-x64-temurin/168/)   => works
[win](https://ci.adoptopenjdk.net/view/Failing%20Temurin%20jobs/job/build-scripts/job/jobs/job/jdk/job/jdk-windows-x86-32-temurin/58/console) => failed in build jdk because the nightly new code from jdk
on final commit


Fixes: https://github.com/adoptium/temurin-build/issues/2927