### PR TITLE
Revert "feat: enable SBOM as default behavior"

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -467,8 +467,8 @@ function configDefaults() {
   # The default behavior of whether we want to create the legacy JRE
   BUILD_CONFIG[CREATE_JRE_IMAGE]="false"
 
-  # Set default value to "true. If we do not want this behavior, we can update buildArg per each config file instead
-  BUILD_CONFIG[CREATE_SBOM]="true"
+  # Do not create an SBOM by default
+  BUILD_CONFIG[CREATE_SBOM]="false"
 
   # The default behavior of whether we want to create a separate source archive
   BUILD_CONFIG[CREATE_SOURCE_ARCHIVE]="false"


### PR DESCRIPTION
Reverts adoptium/temurin-build#2926

Since we still have problem on Windows and AIX, till they are fixed, we cannot turn this as default feature, thus revert commit and fall back to add flag in [config groovy files ](https://github.com/adoptium/ci-jenkins-pipelines/pull/297)