### PR TITLE
Revert "Revert "feat: enable SBOM as default behavior"

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -467,8 +467,8 @@ function configDefaults() {
   # The default behavior of whether we want to create the legacy JRE
   BUILD_CONFIG[CREATE_JRE_IMAGE]="false"
 
-  # Do not create an SBOM by default
-  BUILD_CONFIG[CREATE_SBOM]="false"
+  # Set default value to "true. If we do not want this behavior, we can update buildArg per each config file instead
+  BUILD_CONFIG[CREATE_SBOM]="true"
 
   # The default behavior of whether we want to create a separate source archive
   BUILD_CONFIG[CREATE_SOURCE_ARCHIVE]="false"


### PR DESCRIPTION
This reverts commit 8d87dd642382b72337ee48e6b74c98cf1f234c89.
- windows is working with --create-sbom
- re-enable default to "true" again
Ref: https://github.com/adoptium/temurin-build/issues/2900