### PR TITLE
fix: missing JAVA_HOME set for Solaris build when call sbom

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -640,6 +640,8 @@ buildCyclonedxLib() {
     javaHome=${JDK8_BOOT_DIR}
   elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then
     javaHome=${JDK11_BOOT_DIR}
+  elif [ ${JDK_BOOT_DIR+x} ] && [ -d "${JDK_BOOT_DIR}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
+    javaHome=${JDK_BOOT_DIR}
   else
     echo "Unable to find a suitable JAVA_HOME to build the cyclonedx-lib"
     exit 2


### PR DESCRIPTION
Fixes: #2942