### PR TITLE
fix: missing JAVA_HOME value when run cyclondbx build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,17 @@ jobs:
        run: echo "JDK7_BOOT_DIR=$(cygpath "${{ steps.setup-java7.outputs.path }}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
        if: matrix.version == 'jdk8u'
 
+     - name: Hold ANT_HOME value (from GH) to ANT_HOME2
+       run: echo "ANT_HOME_ORIGIN=${env:ANT_HOME}" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
+     - name: Export ANT to PATH(GITHUB_ENV)
+       run: echo "ANT_HOME=$(cygpath "${env:ANT_HOME}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
+     - name: Append ANT_HOME to PATH
+       run: |
+        "${env:ANT_HOME}/bin" >> ${env:GITHUB_PATH}
+       shell: pwsh
+
      - name: Build Windows
        run: |
          bash build-farm/make-adopt-build-farm.sh
@@ -277,6 +288,10 @@ jobs:
        run: |
          $imageroot=$(find "${HOME}/${{matrix.version}}-${{matrix.os}}-${{matrix.variant}}" -name release -type f)
          echo "TEST_JDK_HOME=$(dirname "${imageroot}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
+     - name: Reset ANT_HOME from ANT_HOME_ORIGIN for smoke test
+       run: echo "ANT_HOME=${env:ANT_HOME_ORIGIN}" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
      - name: Smoke test
        uses: adoptium/run-aqa@v1
        with:

--- a/build-farm/platform-specific-configurations/solaris.sh
+++ b/build-farm/platform-specific-configurations/solaris.sh
@@ -28,6 +28,22 @@ elif [ "${ARCHITECTURE}" == "sparcv9" ]; then
   export CUPS="--with-cups=/opt/csw/lib/ --with-cups-include=/usr/local/cups-1.5.4-src"
   export FREETYPE="--with-freetype=/usr/local/"
   export MEMORY=16000
+  ####sepcial handling for jdk8 build "ant" which must use jdk8+
+  ######overwrite JDK${JDK_BOOT_VERSION}_BOOT_DIR where was set in make-adopt-build-farm.sh
+  ######to always use /usr/bin/java
+  BOOT_JDK_VARIABLE="JDK${JDK_BOOT_VERSION}_BOOT_DIR"
+  export "${BOOT_JDK_VARIABLE}"="/usr" # set to the value where in ansible we config as java 8 default path
+  # shellcheck disable=SC2155
+  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+  "$JDK_BOOT_DIR/bin/java" -version > /dev/null 2>&1
+  executedJavaVersion=$?
+  if [ $executedJavaVersion -ne 0 ]; then
+      echo "Failed to obtain or find a valid boot jdk"
+      exit 1
+  fi
+  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+  echo "Reset Boot jdk directory: ${JDK_BOOT_DIR}:"
 fi
 
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} ${CUPS} ${FREETYPE} --with-memory-size=${MEMORY}"
@@ -37,3 +53,4 @@ export PATH=/opt/solarisstudio12.3/bin/:/opt/csw/bin/:/usr/ccs/bin:$PATH:/usr/sf
 export LC_ALL=C
 export HOTSPOT_DISABLE_DTRACE_PROBES=true
 export ENFORCE_CC_COMPILER_REV=5.12
+

--- a/build-farm/sign-releases.sh
+++ b/build-farm/sign-releases.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 ################################################################################
 
+set -eu
 
 BUILD_ARGS=${BUILD_ARGS:-""}
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -40,6 +41,7 @@ do
   case "${file}" in
     *debugimage*) echo "Skipping ${file} because it's a debug image" ;;
     *testimage*) echo "Skipping ${file} because it's a test image" ;;
+    *sbom*) echo "Skipping ${file} because it's an sbom archive" ;; 
     *)
       echo "signing ${file}"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -616,8 +616,10 @@ createOpenJDKFailureLogsArchive() {
     createArchive "${adoptLogArchiveDir}" "${makeFailureLogsName}"
 }
 
-# Build the CycloneDX Java library and app used for SBoM generation
-buildCyclonedxLib() {
+# Setup JAVA env to run "ant task"
+# cannot use ${BUILD_CONFIG[JDK_BOOT_DIR]} becuase for jdk8 build, it set to jdk7 which wont work with "ant" version
+# cannot use ${JDK_BOOT_DIR} because it overwritten to BUILD_CONFIG index, e.g 33
+setupAntEnv() {
   local javaHome=""
 
   if [ ${JAVA_HOME+x} ] && [ -d "${JAVA_HOME}" ]; then
@@ -626,48 +628,48 @@ buildCyclonedxLib() {
     javaHome=${JDK8_BOOT_DIR}
   elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then
     javaHome=${JDK11_BOOT_DIR}
-  elif [ ${JDK_BOOT_DIR+x} ] && [ -d "${JDK_BOOT_DIR}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
-    javaHome=${JDK_BOOT_DIR}
   else
-    echo "Unable to find a suitable JAVA_HOME to build the cyclonedx-lib"
+    echo "Unable to find a suitable JAVA_HOME to build the cyclonedx-lib, see debug below:"
+    echo "JAVA_HOME: ${JAVA_HOME}"
+    ls -lat "${JAVA_HOME}"
+    echo "JDK8_BOOT_DIR: ${JDK8_BOOT_DIR}"
+    ls -lat "${JDK8_BOOT_DIR}"
+    echo "JDK11_BOOT_DIR: ${JDK11_BOOT_DIR}"
+    ls -lat "${JDK11_BOOT_DIR}"
+    echo "JAVA_HOME: ${JAVA_HOME}"
     exit 2
   fi
+  echo "${javaHome}"
+}
 
+# Build the CycloneDX Java library and app used for SBoM generation
+buildCyclonedxLib() {
+  local javaHome="${1}"
   # Make Ant aware of cygwin path
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     ANTBUILDFILE=$(cygpath -m "${CYCLONEDB_DIR}/build.xml")
   else
     ANTBUILDFILE="${CYCLONEDB_DIR}/build.xml"
   fi
+  echo "JAVA_HOME=${javaHome} ant -f ${ANTBUILDFILE} clean build"
   JAVA_HOME=${javaHome} ant -f "${ANTBUILDFILE}" clean
   JAVA_HOME=${javaHome} ant -f "${ANTBUILDFILE}" build
 }
 
 # Generate the SBoM
 generateSBoM() {
-  local javaHome=""
-
-  if [ ${JAVA_HOME+x} ] && [ -d "${JAVA_HOME}" ]; then
-    javaHome=${JAVA_HOME}
-  elif [ ${JDK8_BOOT_DIR+x} ] && [ -d "${JDK8_BOOT_DIR}" ]; then
-    javaHome=${JDK8_BOOT_DIR}
-  elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then
-    javaHome=${JDK11_BOOT_DIR}
-  else
-    echo "Unable to find a suitable JAVA_HOME to run the TemurinGenSBOM app"
-    exit 2
-  fi
-
+  local javaHome="${1}"
   # classpath to run CycloneDX java app TemurinGenSBOM
-  classpath="${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar:${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar:${CYCLONEDB_DIR}/build/jar/jackson-core.jar:${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar:${CYCLONEDB_DIR}/build/jar/jackson-databind.jar:${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar:${CYCLONEDB_DIR}/build/jar/json-schema.jar:${CYCLONEDB_DIR}/build/jar/commons-codec.jar:${CYCLONEDB_DIR}/build/jar/commons-io.jar:${CYCLONEDB_DIR}/build/jar/github-package-url.jar"
+  CYCLONEDB_JAR_DIR="${CYCLONEDB_DIR}/build/jar"
+  classpath="${CYCLONEDB_JAR_DIR}/temurin-gen-sbom.jar:${CYCLONEDB_JAR_DIR}/cyclonedx-core-java.jar:${CYCLONEDB_JAR_DIR}/jackson-core.jar:${CYCLONEDB_JAR_DIR}/jackson-dataformat-xml.jar:${CYCLONEDB_JAR_DIR}/jackson-databind.jar:${CYCLONEDB_JAR_DIR}/jackson-annotations.jar:${CYCLONEDB_JAR_DIR}/json-schema.jar:${CYCLONEDB_JAR_DIR}/commons-codec.jar:${CYCLONEDB_JAR_DIR}/commons-io.jar:${CYCLONEDB_JAR_DIR}/github-package-url.jar"
   sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     classpath=""
-    for jarfile in "${CYCLONEDB_DIR}/build/jar/temurin-gen-sbom.jar" "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" \
-      "${CYCLONEDB_DIR}/build/jar/jackson-core.jar" "${CYCLONEDB_DIR}/build/jar/jackson-dataformat-xml.jar" \
-      "${CYCLONEDB_DIR}/build/jar/jackson-databind.jar" "${CYCLONEDB_DIR}/build/jar/jackson-annotations.jar" \
-      "${CYCLONEDB_DIR}/build/jar/json-schema.jar" "${CYCLONEDB_DIR}/build/jar/commons-codec.jar" "${CYCLONEDB_DIR}/build/jar/commons-io.jar" \
-      "${CYCLONEDB_DIR}/build/jar/github-package-url.jar" ;
+    for jarfile in "${CYCLONEDB_JAR_DIR}/temurin-gen-sbom.jar" "${CYCLONEDB_JAR_DIR}/cyclonedx-core-java.jar" \
+      "${CYCLONEDB_JAR_DIR}/jackson-core.jar" "${CYCLONEDB_JAR_DIR}/jackson-dataformat-xml.jar" \
+      "${CYCLONEDB_JAR_DIR}/jackson-databind.jar" "${CYCLONEDB_JAR_DIR}/jackson-annotations.jar" \
+      "${CYCLONEDB_JAR_DIR}/json-schema.jar" "${CYCLONEDB_JAR_DIR}/commons-codec.jar" "${CYCLONEDB_JAR_DIR}/commons-io.jar" \
+      "${CYCLONEDB_JAR_DIR}/github-package-url.jar" ;
     do
       classpath+=$(cygpath -w "${jarfile}")";"
     done
@@ -1784,7 +1786,6 @@ fixJavaHomeUnderDocker
 cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
 
 parseArguments "$@"
-
 if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   buildTemplatedFile
   executeTemplatedFile
@@ -1792,8 +1793,11 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   addInfoToReleaseFile
   addInfoToJson
   if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
-    buildCyclonedxLib
-    generateSBoM
+    javaHome="$(setupAntEnv)"
+    echo "javaHome: ${javaHome}"
+    buildCyclonedxLib "${javaHome}"
+    generateSBoM "${javaHome}"
+    unset javaHome
   fi
   cleanAndMoveArchiveFiles
   copyFreeFontForMacOS
@@ -1823,8 +1827,11 @@ if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" != "true" ]]; then
   addInfoToReleaseFile
   addInfoToJson
   if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
-    buildCyclonedxLib
-    generateSBoM
+    javaHome="$(setupAntEnv)"
+    echo "javaHome: ${javaHome}"
+    buildCyclonedxLib "${javaHome}"
+    generateSBoM "${javaHome}"
+    unset javaHome
   fi
   cleanAndMoveArchiveFiles
   copyFreeFontForMacOS


### PR DESCRIPTION
- use the same way in the platform specific script to add change for solaris
- in ansible we point installed java to /usr/bin/java so it is safe to use /usr as JAVA_HOME on solaris
- move the set JAVA_HOME into a function call and add some debug info when it fails

some detail info:

`17:21:51  Exception in thread "main" java.lang.UnsupportedClassVersionError: org/apache/tools/ant/launch/Launcher : Unsupported major.minor version 52.0
17:21:51  	at java.lang.ClassLoader.defineClass1(Native Method)
17:21:51  	at java.lang.ClassLoader.defineClass(ClassLoader.java:800)
17:21:51  	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
17:21:51  	at java.net.URLClassLoader.defineClass(URLClassLoader.java:449)
17:21:51  	at java.net.URLClassLoader.access$100(URLClassLoader.java:71)
17:21:51  	at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
17:21:51  	at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
17:21:51  	at java.security.AccessController.doPrivileged(Native Method)
17:21:51  	at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
17:21:51  	at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
17:21:51  	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
17:21:51  	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
17:21:51  	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:482)`
https://ant.apache.org/:
The Apache Ant team currently maintains two lines of development. The 1.9.x releases require Java5 at runtime and 1.10.x requires Java8 at runtime. Both lines are based off of Ant 1.9.7 and the 1.9.x releases are mostly bug fix releases while additional new features are developed for 1.10.x. We recommend using 1.10.x unless you are required to use versions of Java prior to Java8 during the build process.

so for jdk8, we cannot use boot jdk,(which is jdk7) because ant we installed is 1.10.5 which need jdk8+
