### PR TITLE
fix: sbom.json archive

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -942,8 +942,8 @@ getStaticLibsArchivePath() {
 }
 
 getSbomArchivePath(){
-  local jdkArchivePath=$(getJdkArchivePath)
-  echo "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
+  # cannot use absolute path because the check in createOpenJDKArchive()
+  echo "../../../../../target/metadata/sbom.json"
 }
 
 # Clean up
@@ -1430,7 +1430,6 @@ createArchive() {
   targetName=$2
 
   archiveExtension=$(getArchiveExtension)
-
   createOpenJDKArchive "${repoLocation}" "OpenJDK"
   archive="${PWD}/OpenJDK${archiveExtension}"
 
@@ -1497,10 +1496,9 @@ createOpenJDKTarArchive() {
     echo "OpenJDK static libs archive file name will be ${staticLibsImageName}."
     createArchive "${staticLibsImageTargetPath}" "${staticLibsImageName}"
   fi
+  echo "OpenJDK SBOM file is ${sbomFilePath}."
   if [ -f "${sbomFilePath}" ]; then
-    echo "OpenJDK SBOM file is ${sbomFilePath}."
     local sbomTargetName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-sbom}")
-    echo "createArchive ${sbomFilePath} ${sbomTargetName}"
     createArchive "${sbomFilePath}" "${sbomTargetName}"
   fi
   # for macOS system, code sign directory before creating tar.gz file

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -943,7 +943,7 @@ getStaticLibsArchivePath() {
 
 getSbomArchivePath(){
   local jdkArchivePath=$(getJdkArchivePath)
-  echo "${jdkArchivePath}/metadata/sbom.json"
+  echo "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
 }
 
 # Clean up
@@ -1456,7 +1456,7 @@ createOpenJDKTarArchive() {
   local testImageTargetPath=$(getTestImageArchivePath)
   local debugImageTargetPath=$(getDebugImageArchivePath)
   local staticLibsImageTargetPath=$(getStaticLibsArchivePath)
-  local sbomTargetPath=$(getSbomArchivePath)
+  local sbomFilePath=$(getSbomArchivePath)
 
   echo "OpenJDK JDK path will be ${jdkTargetPath}. JRE path will be ${jreTargetPath}"
 
@@ -1497,10 +1497,11 @@ createOpenJDKTarArchive() {
     echo "OpenJDK static libs archive file name will be ${staticLibsImageName}."
     createArchive "${staticLibsImageTargetPath}" "${staticLibsImageName}"
   fi
-  if [ -d "${sbomTargetPath}" ]; then
-    echo "OpenJDK SBOM path will be ${sbomTargetPath}."
-    local sbomName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-sbom}")
-    createArchive "${sbomTargetPath}" "${sbomName}"
+  if [ -f "${sbomFilePath}" ]; then
+    echo "OpenJDK SBOM file is ${sbomFilePath}."
+    local sbomTargetName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-sbom}")
+    echo "createArchive ${sbomFilePath} ${sbomTargetName}"
+    createArchive "${sbomFilePath}" "${sbomTargetName}"
   fi
   # for macOS system, code sign directory before creating tar.gz file
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then


### PR DESCRIPTION
- fix check on file not dir
- fix path, cannot be absolute
- rename variable to be more meaningful
-
test run log: (without stripping debug)
https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk/job/jdk-linux-x64-temurin/176/console
```
18:13:34  DEBUG OpenJDK SBOM file is ../../../../../target/metadata/sbom.json.
18:13:34  -rw-r--r-- 1 jenkins jenkins 6016 May 26 16:02 ../../../../../target/metadata/sbom.json
18:13:34  DEBUG content /home/jenkins/workspace/build-scripts/jobs/jdk/jdk-linux-x64-temurin/workspace
18:13:34  total 24
18:13:34  drwxr-xr-x  3 jenkins jenkins 4096 May 26 16:02 target
18:13:34  drwxr-xr-x  4 jenkins jenkins 4096 May 26 15:58 build
18:13:34  drwxr-xr-x  2 jenkins jenkins 4096 May 26 15:57 config
18:13:34  drwxr-xr-x  2 jenkins jenkins 4096 May 26 15:55 libs
18:13:34  drwxr-xr-x  6 jenkins jenkins 4096 May 26 15:55 .
18:13:34  drwxrwxr-x 13 jenkins jenkins 4096 May 26 15:55 ..
18:13:34  OpenJDK SBOM file is ../../../../../target/metadata/sbom.json.
18:13:34  createArchive ../../../../../target/metadata/sbom.json OpenJDK-sbom_x64_linux_hotspot_2022-05-26-16-05.tar.gz
18:13:34  DEBUG createOpenJDKArchive ../../../../../target/metadata/sbom.json OpenJDK
18:13:34  Archiving and compressing with pigz
18:13:34  DEBUG tar -cf - --owner=root --group=root ../../../../../target/metadata/sbom.json/ | GZIP=-9 pigz -c > OpenJDK.tar.gz
18:13:34  tar: Removing leading `../../../../../' from member names
18:13:34  
18:13:34  real	0m0.005s
18:13:34  user	0m0.007s
18:13:34  sys	0m0.000s
18:13:34  Your archive was created as /home/jenkins/workspace/build-scripts/jobs/jdk/jdk-linux-x64-temurin/workspace/build/src/build/linux-x86_64-server-release/images/OpenJDK.tar.gz
18:13:34  Moving the artifact to location /home/jenkins/workspace/build-scripts/jobs/jdk/jdk-linux-x64-temurin/workspace/target//OpenJDK-sbom_x64_linux_hotspot_2022-05-26-16-05.tar.gz
18:13:34  archive done.
```
Fixes: https://github.com/adoptium/temurin-build/issues/2900