### PR TITLE
fix: add ANT_HOME to PATH and export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,7 +287,7 @@ jobs:
          echo "TEST_JDK_HOME=$(dirname "${imageroot}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
      - name: Unset ANT_HOME for smoke test
-       run: echo "ANT_HOME=''" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+       run: echo "ANT_HOME=" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
      - name: Smoke test
        uses: adoptium/run-aqa@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,14 @@ jobs:
        run: echo "JDK7_BOOT_DIR=$(cygpath "${{ steps.setup-java7.outputs.path }}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
        if: matrix.version == 'jdk8u'
 
+     - name: Export ANT to PATH(GITHUB_ENV)
+       run: echo "ANT_HOME=$(cygpath "${env:ANT_HOME}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
+     - name: Append ANT_HOME to PATH
+       run: |
+        "${env:ANT_HOME}/bin" >> ${env:GITHUB_PATH}
+       shell: pwsh
+
      - name: Build Windows
        run: |
          bash build-farm/make-adopt-build-farm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,6 +285,10 @@ jobs:
        run: |
          $imageroot=$(find "${HOME}/${{matrix.version}}-${{matrix.os}}-${{matrix.variant}}" -name release -type f)
          echo "TEST_JDK_HOME=$(dirname "${imageroot}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
+     - name: Unset ANT_HOME for smoke test
+       run: echo "ANT_HOME=''" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
      - name: Smoke test
        uses: adoptium/run-aqa@v1
        with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,9 @@ jobs:
        run: echo "JDK7_BOOT_DIR=$(cygpath "${{ steps.setup-java7.outputs.path }}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
        if: matrix.version == 'jdk8u'
 
+     - name: Hold ANT_HOME value (from GH) to ANT_HOME2
+       run: echo "ANT_HOME_ORIGIN=${env:ANT_HOME}" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+
      - name: Export ANT to PATH(GITHUB_ENV)
        run: echo "ANT_HOME=$(cygpath "${env:ANT_HOME}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
@@ -286,8 +289,8 @@ jobs:
          $imageroot=$(find "${HOME}/${{matrix.version}}-${{matrix.os}}-${{matrix.variant}}" -name release -type f)
          echo "TEST_JDK_HOME=$(dirname "${imageroot}")" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
-     - name: Unset ANT_HOME for smoke test
-       run: echo "ANT_HOME=" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+     - name: Reset ANT_HOME from ANT_HOME_ORIGIN for smoke test
+       run: echo "ANT_HOME=${env:ANT_HOME_ORIGIN}" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
 
      - name: Smoke test
        uses: adoptium/run-aqa@v1


### PR DESCRIPTION
	- we set ANT_HOME in ansible for VM but not in GH action, we need to append it as env variable to GITHUB_ENV (which is a file , sourced by GH step)
	- windows-2019 pre-instealld ant, no need install again
	- after temurin-build we need to reset ANT_HOME back to its old value which is  used in run-aqa to run "ant" also build_tests.xml need it to find resource
	 
test run log:
https://github.com/adoptium/temurin-build/runs/6635265682?check_suite_focus=true