### PR TITLE
Update sbom archiving for just sbom.json and fix sign_release sbom and exception handling

### DIFF
--- a/build-farm/sign-releases.sh
+++ b/build-farm/sign-releases.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 ################################################################################
 
+set -eu
 
 BUILD_ARGS=${BUILD_ARGS:-""}
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -40,6 +41,7 @@ do
   case "${file}" in
     *debugimage*) echo "Skipping ${file} because it's a debug image" ;;
     *testimage*) echo "Skipping ${file} because it's a test image" ;;
+    *sbom*) echo "Skipping ${file} because it's an sbom archive" ;; 
     *)
       echo "signing ${file}"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -942,7 +942,7 @@ cleanAndMoveArchiveFiles() {
   local staticLibsImageTargetPath=$(getStaticLibsArchivePath)
   local sbomTargetPath=$(getSbomArchivePath)
 
-  echo "Moving archive content to target archive paths and cleaning unecessary files..."
+  echo "Moving archive content to target archive paths and cleaning unnecessary files..."
 
   stepIntoTheWorkingDirectory
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1494,9 +1494,11 @@ createOpenJDKTarArchive() {
     createArchive "${staticLibsImageTargetPath}" "${staticLibsImageName}"
   fi
   if [ -d "${sbomTargetPath}" ]; then
-    echo "OpenJDK SBOM path will be ${sbomTargetPath}."
-    local sbomTargetName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-sbom}")
-    createArchive "${sbomTargetPath}" "${sbomTargetName}"
+    # SBOM archive artifact as json file
+    local sbomTargetName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-sbom}.json")
+    local sbomArchiveTarget=${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/${sbomTargetName}
+    echo "OpenJDK SBOM will be ${sbomTargetName}."
+    cp "${sbomTargetPath}/sbom.json" "${sbomArchiveTarget}"
   fi
   # for macOS system, code sign directory before creating tar.gz file
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -928,19 +928,21 @@ getStaticLibsArchivePath() {
 }
 
 getSbomArchivePath(){
-  # cannot use absolute path because the check in createOpenJDKArchive()
-  echo "../../../../../target/metadata/sbom.json"
+  local jdkArchivePath=$(getJdkArchivePath)
+  echo "${jdkArchivePath}-sbom"
 }
 
-# Clean up
-removingUnnecessaryFiles() {
+# This function moves the archive files to their intended archive paths
+# and cleans unneeded files
+cleanAndMoveArchiveFiles() {
   local jdkTargetPath=$(getJdkArchivePath)
   local jreTargetPath=$(getJreArchivePath)
   local testImageTargetPath=$(getTestImageArchivePath)
   local debugImageTargetPath=$(getDebugImageArchivePath)
   local staticLibsImageTargetPath=$(getStaticLibsArchivePath)
+  local sbomTargetPath=$(getSbomArchivePath)
 
-  echo "Removing unnecessary files now..."
+  echo "Moving archive content to target archive paths and cleaning unecessary files..."
 
   stepIntoTheWorkingDirectory
 
@@ -974,6 +976,15 @@ removingUnnecessaryFiles() {
     echo "moving ${testImagePath} to ${testImageTargetPath}"
     rm -rf "${testImageTargetPath}" || true
     mv "${testImagePath}" "${testImageTargetPath}"
+  fi
+
+  # If creating SBOM, move it to the target Sbom archive path
+  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
+    local sbomJson="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/sbom.json"
+    echo "moving ${sbomJson} to ${sbomTargetPath}/sbom.json"
+    rm -rf "${sbomTargetPath}" || true
+    mkdir "${sbomTargetPath}"
+    mv "${sbomJson}" "${sbomTargetPath}"
   fi
 
   # Static libs image - check if the directory exists
@@ -1352,7 +1363,7 @@ getFirstTagFromOpenJDKGitRepo() {
 
   # Save current directory of caller so we can return to that directory at the end of this function.
   # Some callers are not in the git repo root, but instead build/*/images directory like the archive functions
-  # and any function called after removingUnnecessaryFiles().
+  # and any function called after cleanAndMoveArchiveFiles().
   local savePwd="${PWD}"
 
   # Change to openjdk git repo root to find build tag.
@@ -1441,7 +1452,7 @@ createOpenJDKTarArchive() {
   local testImageTargetPath=$(getTestImageArchivePath)
   local debugImageTargetPath=$(getDebugImageArchivePath)
   local staticLibsImageTargetPath=$(getStaticLibsArchivePath)
-  local sbomFilePath=$(getSbomArchivePath)
+  local sbomTargetPath=$(getSbomArchivePath)
 
   echo "OpenJDK JDK path will be ${jdkTargetPath}. JRE path will be ${jreTargetPath}"
 
@@ -1482,10 +1493,10 @@ createOpenJDKTarArchive() {
     echo "OpenJDK static libs archive file name will be ${staticLibsImageName}."
     createArchive "${staticLibsImageTargetPath}" "${staticLibsImageName}"
   fi
-  echo "OpenJDK SBOM file is ${sbomFilePath}."
-  if [ -f "${sbomFilePath}" ]; then
+  if [ -d "${sbomTargetPath}" ]; then
+    echo "OpenJDK SBOM path will be ${sbomTargetPath}."
     local sbomTargetName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-sbom}")
-    createArchive "${sbomFilePath}" "${sbomTargetName}"
+    createArchive "${sbomTargetPath}" "${sbomTargetName}"
   fi
   # for macOS system, code sign directory before creating tar.gz file
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ] && [ -n "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then
@@ -1781,7 +1792,7 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     buildCyclonedxLib
     generateSBoM
   fi
-  removingUnnecessaryFiles
+  cleanAndMoveArchiveFiles
   copyFreeFontForMacOS
   setPlistForMacOS
   addNoticeFile
@@ -1812,7 +1823,7 @@ if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" != "true" ]]; then
     buildCyclonedxLib
     generateSBoM
   fi
-  removingUnnecessaryFiles
+  cleanAndMoveArchiveFiles
   copyFreeFontForMacOS
   setPlistForMacOS
   addNoticeFile

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1494,8 +1494,9 @@ createOpenJDKTarArchive() {
     createArchive "${staticLibsImageTargetPath}" "${staticLibsImageName}"
   fi
   if [ -d "${sbomTargetPath}" ]; then
-    # SBOM archive artifact as json file
+    # SBOM archive artifact as a .json file
     local sbomTargetName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-sbom}.json")
+    sbomTargetName="${sbomTargetName//\.tar\.gz/}"
     local sbomArchiveTarget=${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/${sbomTargetName}
     echo "OpenJDK SBOM will be ${sbomTargetName}."
     cp "${sbomTargetPath}/sbom.json" "${sbomArchiveTarget}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1088,7 +1088,7 @@ cleanAndMoveArchiveFiles() {
     deleteDebugSymbols
   fi
 
-  echo "Finished removing unnecessary files from ${jdkTargetPath}"
+  echo "Finished cleaning and moving archive files from ${jdkTargetPath}"
 }
 
 deleteDebugSymbols() {


### PR DESCRIPTION
This PR fixes: https://github.com/adoptium/temurin-build/issues/2952

Fixes:
1. Modified SBOM archiving to archive plain sbom.json as a artifact rather than tar.gz
2. Update sign-release.sh to not to try signing an sbom archive
3. Add set -eu to sign.sh so exceptions/failures are not ignored. Currently a failure to sign an executeable will be ignored.
4. Update sign.sh to check if not files found to sign, preventing http 500 failure on Mac.
