### PR TITLE
Correct CycloneDX JDK_BOOT_DIR variable reference for JAVA_HOME

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -626,7 +626,7 @@ buildCyclonedxLib() {
     javaHome=${JDK8_BOOT_DIR}
   elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then
     javaHome=${JDK11_BOOT_DIR}
-  elif [ ${BUILD_CONFIG[JDK_BOOT_DIR]+x} && [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
+  elif [ ${BUILD_CONFIG[JDK_BOOT_DIR]+x} ] && [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
     javaHome="${BUILD_CONFIG[JDK_BOOT_DIR]}"
   else
     echo "Unable to find a suitable JAVA_HOME to build the cyclonedx-lib"
@@ -653,7 +653,7 @@ generateSBoM() {
     javaHome=${JDK8_BOOT_DIR}
   elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then
     javaHome=${JDK11_BOOT_DIR}
-  elif [ ${BUILD_CONFIG[JDK_BOOT_DIR]+x} && [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
+  elif [ ${BUILD_CONFIG[JDK_BOOT_DIR]+x} ] && [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
     javaHome="${BUILD_CONFIG[JDK_BOOT_DIR]}"
   else
     echo "Unable to find a suitable JAVA_HOME to run the TemurinGenSBOM app"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -626,8 +626,8 @@ buildCyclonedxLib() {
     javaHome=${JDK8_BOOT_DIR}
   elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then
     javaHome=${JDK11_BOOT_DIR}
-  elif [ ${JDK_BOOT_DIR+x} ] && [ -d "${JDK_BOOT_DIR}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
-    javaHome=${JDK_BOOT_DIR}
+  elif [ ${BUILD_CONFIG[JDK_BOOT_DIR]+x} && [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
+    javaHome="${BUILD_CONFIG[JDK_BOOT_DIR]}"
   else
     echo "Unable to find a suitable JAVA_HOME to build the cyclonedx-lib"
     exit 2
@@ -653,6 +653,8 @@ generateSBoM() {
     javaHome=${JDK8_BOOT_DIR}
   elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then
     javaHome=${JDK11_BOOT_DIR}
+  elif [ ${BUILD_CONFIG[JDK_BOOT_DIR]+x} && [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
+    javaHome="${BUILD_CONFIG[JDK_BOOT_DIR]}"
   else
     echo "Unable to find a suitable JAVA_HOME to run the TemurinGenSBOM app"
     exit 2


### PR DESCRIPTION
JDK_BOOT_DIR variable is not present in sbin/build.sh shell as it was only set in the make-adopt-build-farm.sh shell.
The BUILD_CONFIG[JDK_BOOT_DIR] variable contains the value passed from the make-adopt-build-farm.sh shell.
