### PR TITLE
windows: bump JDK8u x64 build to use VS2017

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,9 @@ jobs:
          version: [jdk8u, jdk11u, jdk17u]
          variant: [temurin]
 
+     env:
+      VS2017_URL: "https://github.com/akashche/msvs_2017_installer_bootstrap/raw/master/vs_community__7955ddbf8a9b49dda0f8d18876e93bd2.exe"
+
      steps:
      - name: Restore cygwin packages from cache
        id: cygwin
@@ -215,6 +218,37 @@ jobs:
        with:
          distribution: 'temurin'
          java-version: 11
+
+     - name: Restore Visual Studio 2017 from cache
+       id: vs2017
+       uses: actions/cache@v2
+       with:
+         path: ~/vs2017.exe
+         key: vs2017
+
+     - name: Uninstall WinSDKs
+       run: >
+         Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
+         'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"
+         --remove Microsoft.VisualStudio.Component.Windows10SDK.18362
+         --remove Microsoft.VisualStudio.Component.Windows10SDK.19041
+         --remove Microsoft.VisualStudio.Component.Windows10SDK.20348
+         --remove Microsoft.VisualStudio.Component.Windows10SDK.22000
+         --quiet'
+
+     - name: Download Visual Studio 2017
+       run: |
+         curl -L "$env:VS2017_URL" -o "$HOME/$env:VS2017_FILENAME"
+       if: steps.vs2017.outputs.cache-hit != 'true'
+
+     - name: Install Visual Studio 2017
+       run: >
+         Start-Process -FilePath "$HOME\$env:VS2017_FILENAME" -Wait -NoNewWindow -ArgumentList
+         'install --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.15.Release
+         --add Microsoft.VisualStudio.Workload.NativeDesktop
+         --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+         --add Microsoft.VisualStudio.Component.Windows10SDK.17763
+         --quiet --wait'
 
      - name: Install Git
        run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
        fail-fast: false
        matrix:
          os: [windows-2019]
-         version: [jdk8u, jdk11u, jdk17u]
+         version: [jdk8u, jdk11u, jdk17u, jdk]
          variant: [temurin]
 
      env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,12 +221,14 @@ jobs:
 
      - name: Restore Visual Studio 2017 from cache
        id: vs2017
+       if: matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
        uses: actions/cache@v2
        with:
          path: ~/vs2017.exe
          key: vs2017
 
      - name: Uninstall WinSDKs
+       if: matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
        run: >
          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
          'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"
@@ -238,12 +240,13 @@ jobs:
 
      - name: Download Visual Studio 2017
        run: |
-         curl -L "$env:VS2017_URL" -o "$HOME/$env:VS2017_FILENAME"
-       if: steps.vs2017.outputs.cache-hit != 'true'
+         curl -L "$env:VS2017_URL" -o "$HOME/vs2017.exe"
+       if: steps.vs2017.outputs.cache-hit != 'true' && matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
 
      - name: Install Visual Studio 2017
+       if: matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
        run: >
-         Start-Process -FilePath "$HOME\$env:VS2017_FILENAME" -Wait -NoNewWindow -ArgumentList
+         Start-Process -FilePath "$HOME\vs2017.exe" -Wait -NoNewWindow -ArgumentList
          'install --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.15.Release
          --add Microsoft.VisualStudio.Workload.NativeDesktop
          --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
        fail-fast: false
        matrix:
          os: [windows-2019]
-         version: [jdk]
+         version: [jdk8u, jdk11u, jdk17u]
          variant: [temurin]
 
      steps:
@@ -203,15 +203,17 @@ jobs:
          Invoke-WebRequest -UseBasicParsing 'https://cygwin.com/setup-x86_64.exe' -OutFile 'C:\temp\cygwin.exe'
          Start-Process -Wait -FilePath 'C:\temp\cygwin.exe' -ArgumentList '--packages autoconf,automake,bsdtar,cpio,curl,gcc-core,git,gnupg,grep,libtool,make,mingw64-x86_64-gcc-core,perl,rsync,unzip,wget,zip --quiet-mode --download --local-install --delete-orphans --site https://mirrors.kernel.org/sourceware/cygwin/ --local-package-dir C:\cygwin_packages --root C:\cygwin64'
 
-     - uses: actions/setup-java@v1
+     - uses: actions/setup-java@v3
        id: setup-java7
        with:
+         distribution: 'zulu'
          java-version: 7
        if: matrix.version == 'jdk8u'
 
-     - uses: actions/setup-java@v1
+     - uses: actions/setup-java@v3
        id: setup-java11
        with:
+         distribution: 'temurin'
          java-version: 11
 
      - name: Install Git
@@ -221,11 +223,6 @@ jobs:
 
      - name: Set PATH
        run: echo "C:\cygwin64\bin;C:\Program Files\Git\bin;" | Out-File -FilePath "$env:GITHUB_PATH" -Encoding utf8 -Append
-
-     - name: Install Visual Studio 2013
-       run: |
-         choco install visualstudiocommunity2013
-       if: matrix.version == 'jdk8u'
 
      - name: Cygwin git configuration
        shell: bash

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -206,7 +206,7 @@ then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
-      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.8.1"
+      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
     elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
     then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -206,7 +206,7 @@ then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
-      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
+      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.8.1"
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
     elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
     then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -202,28 +202,15 @@ then
     # NASM required for OpenSSL support as per #604
     export PATH="/cygdrive/c/Program Files/LLVM/bin:/usr/bin:/cygdrive/c/openjdk/nasm-$OPENJ9_NASM_VERSION:$PATH"
   else
-    TOOLCHAIN_VERSION="2013"
+    TOOLCHAIN_VERSION="2017"
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
-    elif [ "${JAVA_TO_BUILD}" == "${JDK9_VERSION}" ]
-    then
-      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
-    elif [ "${JAVA_TO_BUILD}" == "${JDK10_VERSION}" ]
-    then
-      export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
-    elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
-    then
-      TOOLCHAIN_VERSION="2017"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
     then
       TOOLCHAIN_VERSION="2019"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     fi
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -140,7 +140,7 @@ patchFreetypeWindows() {
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
     rm "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"
     # Copy the replacement freetype.vcxproj file from the .github directory
-    cp .github/workflows/freetype.vcxproj "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"
+    cp "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.github/workflows/freetype.vcxproj" "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"
   fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -135,6 +135,15 @@ getOpenJDKUpdateAndBuildVersion() {
   cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
 }
 
+patchFreetypeWindows() {
+  # Allows freetype to be built for JDK8u (see https://github.com/openjdk/jdk8u-dev/pull/3#issuecomment-1087677766)
+  if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
+    rm "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"
+    # Copy the replacement freetype.vcxproj file from the .github directory
+    cp .github/workflows/freetype.vcxproj "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"
+  fi
+}
+
 getOpenJdkVersion() {
   local version
 
@@ -1814,6 +1823,9 @@ configureWorkspace
 
 echo "build.sh : $(date +%T) : Initiating build ..."
 getOpenJDKUpdateAndBuildVersion
+if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
+  patchFreetypeWindows
+fi
 configureCommandParameters
 buildTemplatedFile
 executeTemplatedFile


### PR DESCRIPTION
Switches the JDK8u x64 build to use VS2017 (same as the version tested in the OpenJDK codebase https://github.com/adoptium/jdk8u/blob/master/.github/workflows/submit.yml#L864-L876)

Also bumps freetype to 2.8.1 (required to be built with VS2017)