### PR TITLE
windows: only apply JDK8 freetype patch on x64

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -136,7 +136,7 @@ getOpenJDKUpdateAndBuildVersion() {
 }
 
 patchFreetypeWindows() {
-  # Allows freetype to be built for JDK8u (see https://github.com/openjdk/jdk8u-dev/pull/3#issuecomment-1087677766)
+  # Allows freetype to be built for JDK8u with Visual Studio 2017 (see https://github.com/openjdk/jdk8u-dev/pull/3#issuecomment-1087677766)
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${ARCHITECTURE}" = "x64" ]; then
     rm "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"
     # Copy the replacement freetype.vcxproj file from the .github directory

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -137,7 +137,7 @@ getOpenJDKUpdateAndBuildVersion() {
 
 patchFreetypeWindows() {
   # Allows freetype to be built for JDK8u (see https://github.com/openjdk/jdk8u-dev/pull/3#issuecomment-1087677766)
-  if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
+  if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${ARCHITECTURE}" = "x64" ]; then
     rm "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"
     # Copy the replacement freetype.vcxproj file from the .github directory
     cp "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.github/workflows/freetype.vcxproj" "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype/builds/windows/vc2010/freetype.vcxproj"


### PR DESCRIPTION
The x86 Windows JDK8 build is currently broken since my Freetype PR was merged. This PR removes the patch for x86 builds. This is related to the visual studio version still being 2013 for Windows x86.