### PR TITLE
cleanup: do not genereate component property "scmRef"

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -699,7 +699,7 @@ generateSBoM() {
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent --jsonFile "$sbomJson" --compName "JDK" --description "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"
 
   # Add scmRef JDK Component Property
-  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "scmRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
+  # addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "scmRef" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
 
   # Add OpenJDK source ref commit JDK Component Property
   addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "openjdkSourceCommit" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"


### PR DESCRIPTION
	- scmRef is the short SHA1 of source code commit on openjdk
	- it is duplicated as in "openjdkSourceCommit" which as fullpath
what we have now in sbom.json is like:
``` 
"components" : [
    {
      "author" : "Vendor: Eclipse",
      "group" : "Eclipse Temurin",
      "name" : "Temurin",
      "version" : "19-beta+27-202206180317",
      "type" : "framework"
    },
    {
      "name" : "JDK",
      "description" : "Temurin JDK Component",
      "properties" : [
        {
          "name" : "scmRef",
          "value" : "73b1da30674"
        },
        {
          "name" : "openjdkSourceCommit",
          "value" : "https://github.com/adoptium/jdk19/commit/73b1da30674"
        },
        {
          "name" : "buildRef",
          "value" : "https://github.com/adoptium/temurin-build/commit/6762709"
        },
`
``` 

Ref: https://github.com/adoptium/temurin-build/issues/2983