### PR TITLE
fix: use OS_FULL_VERSION than OS_KERNEL in sbom to include more

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -719,8 +719,8 @@ generateSBoM() {
   # Add make_command_args JDK Component Property
   addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "JDK" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
 
-  # Add OS
-  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS_KERNEL" "${BUILD_CONFIG[OS_KERNEL_NAME]^}"
+  # Add OS full version (Kernel is covered in the first field)
+  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS_FULL_VERSION" "${BUILD_CONFIG[OS_FULL_VERSION]^}"
 
   # Add ARCHITECTURE
   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS_ARCHITECTURE" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"


### PR DESCRIPTION
from conversation: https://adoptium.slack.com/archives/C09NW3L2J/p1655804491202619?thread_ts=1655802669.491939&cid=C09NW3L2J
we only store os kernal which does not help much for alpine, centos, rhel etc 


Ref: https://github.com/adoptium/temurin-build/issues/2983