### PR TITLE
build: switch Windows JDK11 builds to use VS2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,14 +221,14 @@ jobs:
 
      - name: Restore Visual Studio 2017 from cache
        id: vs2017
-       if: matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
+       if: matrix.version == 'jdk8u'
        uses: actions/cache@v2
        with:
          path: ~/vs2017.exe
          key: vs2017
 
      - name: Uninstall WinSDKs
-       if: matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
+       if: matrix.version == 'jdk8u'
        run: >
          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
          'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"
@@ -241,10 +241,10 @@ jobs:
      - name: Download Visual Studio 2017
        run: |
          curl -L "$env:VS2017_URL" -o "$HOME/vs2017.exe"
-       if: steps.vs2017.outputs.cache-hit != 'true' && matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
+       if: steps.vs2017.outputs.cache-hit != 'true' && matrix.version == 'jdk8u'
 
      - name: Install Visual Studio 2017
-       if: matrix.version == 'jdk8u' || matrix.version == 'jdk11u'
+       if: matrix.version == 'jdk8u'
        run: >
          Start-Process -FilePath "$HOME\vs2017.exe" -Wait -NoNewWindow -ArgumentList
          'install --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.15.Release

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -54,7 +54,8 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
       esac
       releaseType="ga"
       vendor="eclipse"
-      apiUrlTemplate="https://api.adoptium.net/v3/binary/latest/\${JDK_BOOT_VERSION}/\${releaseType}/windows/\${downloadArch}/jdk/hotspot/normal/\${vendor}"
+      api="adoptium"
+      apiUrlTemplate="https://api.\${api}.net/v3/binary/latest/\${JDK_BOOT_VERSION}/\${releaseType}/windows/\${downloadArch}/jdk/hotspot/normal/\${vendor}"
       apiURL=$(eval echo ${apiUrlTemplate})
       echo "Downloading GA release of boot JDK version ${JDK_BOOT_VERSION} from ${apiURL}"
       # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
@@ -84,6 +85,7 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
           releaseType="ga"
           # shellcheck disable=SC2034
           vendor="adoptopenjdk"
+          api="adoptopenjdk"
           apiURL=$(eval echo ${apiUrlTemplate})
           echo "Attempting to download GA release of boot JDK version ${JDK_BOOT_VERSION} from ${apiURL}"
           wget -q "${apiURL}" -O openjdk.zip

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -85,6 +85,7 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
           releaseType="ga"
           # shellcheck disable=SC2034
           vendor="adoptopenjdk"
+          # shellcheck disable=SC2034
           api="adoptopenjdk"
           apiURL=$(eval echo ${apiUrlTemplate})
           echo "Attempting to download GA release of boot JDK version ${JDK_BOOT_VERSION} from ${apiURL}"

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -136,11 +136,7 @@ then
       TOOLCHAIN_VERSION="2013"
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
-    elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
-    then
-      TOOLCHAIN_VERSION="2017"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
-    elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
+    elif [ "$JAVA_FEATURE_VERSION" -ge 11 ]
     then
       TOOLCHAIN_VERSION="2019"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
@@ -208,7 +204,7 @@ then
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.8.1"
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
-    elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
+    elif [ "$JAVA_FEATURE_VERSION" -ge 11 ]
     then
       TOOLCHAIN_VERSION="2019"
     fi


### PR DESCRIPTION
The Visual Studio 2019 backport is now complete for JDK11 which means we should be able to start building using VS2019