### PR TITLE
feat: always add sbom component, for those not have values set to "N.A"

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -775,11 +775,13 @@ addSBOMComponentFromFile() {
   local description="${5}"
   local name="${6}"
   local propFile="${7}"
+  # always create component in sbom
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent     --jsonFile "${jsonFile}" --compName "${compName}" --description "${description}"
+  value = "N.A" # default set to "N.A" as value for variant does not have $propFile generated in prepareWorkspace.sh
   if [ -e "${propFile}" ]; then
-      local value=$(cat "${propFile}")
-      "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent     --jsonFile "${jsonFile}" --compName "${compName}" --description "${description}"
-      "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponentProp --jsonFile "${jsonFile}" --compName "${compName}" --name "${name}" --value "${value}"
+      value=$(cat "${propFile}")
   fi
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponentProp --jsonFile "${jsonFile}" --compName "${compName}" --name "${name}" --value "${value}"
 }
 
 # Add the given Property name & value to the given SBOM Component

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -777,7 +777,7 @@ addSBOMComponentFromFile() {
   local propFile="${7}"
   # always create component in sbom
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addComponent     --jsonFile "${jsonFile}" --compName "${compName}" --description "${description}"
-  value = "N.A" # default set to "N.A" as value for variant does not have $propFile generated in prepareWorkspace.sh
+  value="N.A" # default set to "N.A" as value for variant does not have $propFile generated in prepareWorkspace.sh
   if [ -e "${propFile}" ]; then
       value=$(cat "${propFile}")
   fi


### PR DESCRIPTION
	- e.g freemarker is used by openj9 but not temurin