### PR TITLE
aix: Remove /tmp/sh-np.* before building

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -15,8 +15,16 @@
 # limitations under the License.
 ################################################################################
 
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Clear out /tmp/sh-np files if we're running in jenkins to avoid
+# "ambiguous redirect" pipe failures. This will be ok with only one executor
+# See https://github.com/adoptium/infrastructure/issues/929
+if [ "$(whoami)" = "jenkins" ] && [ -n "$WORKSPACE" ]; then
+   echo "There are $(/usr/bin/find /tmp \( -user jenkins -a -name sh-np.\* \) | wc -l) sh-np files owned by jenkins in /tmp that I am going to remove..."
+   /usr/bin/find /tmp \( -user jenkins -a -name sh-np.\* \) | xargs rm -f
+fi
+
 
 # AIX default ulimit is frequently less than we need to clone the LTS JDK repositories
 FILESIZELIMIT=$(ulimit)


### PR DESCRIPTION
We are still seeing problems with errors in /tmp/ on AIX systems (Specifically build-osuosl-aix71*1)
This will clear out all such entries on AIX when running under jenkins (username=jenkins and `WORKSPACE` is defined).
Broadly copies what is in the crontab on the machines

Ref: https://github.com/adoptium/infrastructure/issues/929