### PR TITLE
reduce RAM usage during build on Linux systems with <4GB

### DIFF
--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -19,6 +19,12 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
+# Solves issues seen on 4GB HC4 systems with two large ld processes
+if [ "$(awk '/^MemTotal:/{print$2}' < /proc/meminfo)" -lt "5000000" ]
+then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-Wl,--no-keep-memory"
+fi
+
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -76,6 +76,12 @@ then
   export LANG=C
 fi
 
+# Solves issues seen on 4GB HC4 systems with two large ld processes
+if [ "$(awk '/^MemTotal:/{print$2}' < /proc/meminfo)" -lt "5000000" ]
+then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-Wl,--no-keep-memory"
+fi
+
 if [ "${ARCHITECTURE}" == "arm" ]
 then
   if lscpu | grep aarch64; then


### PR DESCRIPTION
I've had issues on one of my 4GB aarch64 systems with two `ld` processes being started to perform linking of the final `libjvm` in parallel which use over 1.5Gb each and ultimately result in the system going heavily into swap and not completing in a reasonable amount of time. This change - which will only take effect on low memory systems - will use the option ([man page here](https://sourceware.org/binutils/docs-2.38/ld.html)) which will reduce the memory usage of the `ld` command at the expense of some performance (which is why I am not enabling it by default)

[Side notes: https://wiki.debian.org/ReduceBuildMemoryOverhead mentions other `ld` options that might reduce memory further, but the one in this PR should have enough of an effect]

Signed-off-by: Stewart X Addison <sxa@redhat.com>