### PR TITLE
fix: do not have both --enable-ccache and --disable-ccache set and only RELEASE type has --disable-ccache

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -240,8 +240,11 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
   fi
 fi
 
-if which ccache 2> /dev/null; then
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
+if [ "$(which ccache 2> /dev/null)" ]; then
+  # enabled reproducible build with --disable-ccache, should not set --enable-ccache
+  if [[ "${JAVA_FEATURE_VERSION}" -lt 17 || "${JAVA_FEATURE_VERSION}" -eq 18 ]]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
+  fi
 fi
 
 # Handle cross compilation environment for RISC-V

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -241,10 +241,7 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
 fi
 
 if [ "$(which ccache 2> /dev/null)" ]; then
-  # enabled reproducible build with --disable-ccache, should not set --enable-ccache
-  if [[ "${JAVA_FEATURE_VERSION}" -lt 17 || "${JAVA_FEATURE_VERSION}" -eq 18 ]]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
-  fi
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
 fi
 
 # Handle cross compilation environment for RISC-V

--- a/build-farm/set-platform-specific-configurations.sh
+++ b/build-farm/set-platform-specific-configurations.sh
@@ -24,26 +24,6 @@ then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-warnings-as-errors"
 fi
 
-# jdk-17 and jdk-19+ support reproducible builds
-if [[ "${JAVA_FEATURE_VERSION}" -ge 19 || "${JAVA_FEATURE_VERSION}" -eq 17 ]]
-then
-    # Enable reproducible builds implicitly with --with-source-date
-    if [ "${RELEASE}" == "true" ]
-    then
-        # Use release date
-        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-source-date=version"
-    else
-        # Use build date
-        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-source-date=updated"
-    fi
-
-    # Ensure reproducible binary with a unique build user identifier
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-user=adoptium"
-
-    # Disable CCache with --disable-ccache
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
-fi
-
 export VARIANT_ARG="--build-variant ${VARIANT}"
 
 # If a user file doesn't exist, pull from an online source. To always pull from an online source, ensure platform config files have been deleted from your local clone.
@@ -118,3 +98,20 @@ else
     echo "[SUCCESS] Executing local file at ${PLATFORM_CONFIG_FILEPATH}"
 fi
 source "${PLATFORM_CONFIG_FILEPATH}"
+
+# jdk-17 and jdk-19+ support reproducible builds
+if [[ "${JAVA_FEATURE_VERSION}" -ge 19 || "${JAVA_FEATURE_VERSION}" -eq 17 ]]
+then
+    # Enable reproducible builds implicitly with --with-source-date
+    if [ "${RELEASE}" == "true" ]
+    then
+        # Use release date and disable CCache( remove --enable-ccache if exist)
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM//--enable-ccache/} --with-source-date=version --disable-ccache"
+    else
+        # Use build date
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-source-date=updated"
+    fi
+
+    # Ensure reproducible binary with a unique build user identifier
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-user=adoptium"
+fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -372,10 +372,7 @@ configureVersionStringParameter() {
 # Construct all of the 'configure' parameters
 buildingTheRestOfTheConfigParameters() {
   if [ -n "$(which ccache)" ]; then
-    # enabled reproducible build with --disable-ccache, should not set --enable-ccache
-    if [[ "${JAVA_FEATURE_VERSION}" -lt 17 || "${JAVA_FEATURE_VERSION}" -eq 18 ]]; then
-      addConfigureArg "--enable-ccache" ""
-    fi
+    addConfigureArg "--enable-ccache" ""
   fi
 
   # Point-in-time dependency for openj9 only

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -372,7 +372,10 @@ configureVersionStringParameter() {
 # Construct all of the 'configure' parameters
 buildingTheRestOfTheConfigParameters() {
   if [ -n "$(which ccache)" ]; then
-    addConfigureArg "--enable-ccache" ""
+    # enabled reproducible build with --disable-ccache, should not set --enable-ccache
+    if [[ "${JAVA_FEATURE_VERSION}" -lt 17 || "${JAVA_FEATURE_VERSION}" -eq 18 ]]; then
+      addConfigureArg "--enable-ccache" ""
+    fi
   fi
 
   # Point-in-time dependency for openj9 only


### PR DESCRIPTION
In our current build, after add "--disable-ccache" some jobs showing:
`Completed configuring the version string parameter, config args are now:  --with-vendor-name="Eclipse Adoptium" --with-vendor-url=https://adoptium.net/ --with-vendor-bug-url=https://github.com/adoptium/adoptium-support/issues --with-vendor-vm-bug-url=https://github.com/adoptium/adoptium-support/issues --without-version-opt --without-version-pre --with-version-build=7 --with-vendor-version-string=Temurin-17.0.4+7 --with-boot-jdk=/usr/lib/jvm/jdk-16 --with-debug-level=release --with-native-debug-symbols=external --with-jvm-variants=server,client --with-cacerts-file=/home/jenkins/workspace/build-scripts/jobs/jdk17u/jdk17u-linux-arm-temurin/sbin/../security/cacerts --with-jobs=80  --disable-warnings-as-errors --with-source-date=version --with-build-user=adoptium --disable-ccache --target=armv7l-unknown-linux-gnueabihf --host=armv7l-unknown-linux-gnueabihf --disable-warnings-as-errors --enable-ccache --enable-dtrace`  from https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk17u/job/jdk17u-linux-arm-temurin/71/consoleFull which has both flags set

1. move setting for reproducible part after source ${PLATFORM_CONFIG_FILEPATH}.sh
2. remove --enable-ccache when adding --disable-ccache
3. only use --disable-ccache for RELEASE type

Fixes: https://github.com/adoptium/temurin-build/issues/2973