### PR TITLE
fix: move set "--enable-ccache" from build.sh to platform specific script

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -38,6 +38,9 @@ else
     XCODE_SWITCH_PATH="/";
   fi
   export PATH="/Users/jenkins/ccache-3.2.4:$PATH"
+  if [ -n "$(which ccache)" ]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
+  fi
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
   else

--- a/build-farm/platform-specific-configurations/solaris.sh
+++ b/build-farm/platform-specific-configurations/solaris.sh
@@ -37,3 +37,7 @@ export PATH=/opt/solarisstudio12.3/bin/:/opt/csw/bin/:/usr/ccs/bin:$PATH:/usr/sf
 export LC_ALL=C
 export HOTSPOT_DISABLE_DTRACE_PROBES=true
 export ENFORCE_CC_COMPILER_REV=5.12
+
+if [ -n "$(which ccache)" ]; then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
+fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -371,10 +371,6 @@ configureVersionStringParameter() {
 
 # Construct all of the 'configure' parameters
 buildingTheRestOfTheConfigParameters() {
-  if [ -n "$(which ccache)" ]; then
-    addConfigureArg "--enable-ccache" ""
-  fi
-
   # Point-in-time dependency for openj9 only
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]]; then
     addConfigureArg "--with-freemarker-jar=" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/freemarker-${FREEMARKER_LIB_VERSION}/freemarker.jar"


### PR DESCRIPTION
- final "--disable-ccache" is called after these scripts to filter out "--enable-ccache"

Ref: https://github.com/adoptium/temurin-build/pull/3022/files#r914642300
Ref: https://github.com/adoptium/temurin-build/issues/2973