### PR TITLE
Correct mk-cacerts.sh nokeystore alias file renaming to be unique

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -474,7 +474,7 @@ configureCommandParameters() {
   addConfigureArgIfValueIsNotEmpty "--with-jvm-variants=" "${BUILD_CONFIG[JVM_VARIANT]}"
 
   if [ "${BUILD_CONFIG[CUSTOM_CACERTS]}" = "true" ] ; then
-    if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge "19" ]]; then
+    if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge "17" ]]; then
       echo "Configure custom cacerts src security/certs"
       addConfigureArgIfValueIsNotEmpty "--with-cacerts-src=" "$SCRIPT_DIR/../security/certs"
     else

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -531,8 +531,8 @@ checkingAndDownloadingFreeType() {
 prepareMozillaCacerts() {
     echo "Generating cacerts from Mozilla's bundle"
     cd "$SCRIPT_DIR/../security"
-    if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge "19" ]]; then
-      # jdk-19+ build uses JDK make tool to load keystore for reproducible builds
+    if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge "17" ]]; then
+      # jdk-17+ build uses JDK make tool GenerateCacerts to load keystore for reproducible builds
       time ./mk-cacerts.sh --nokeystore
     else
       time ./mk-cacerts.sh --keytool "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/keytool"

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -121,8 +121,8 @@ for FILE in certs/*.crt; do
 done
 
 if [ "$NO_KEYSTORE" = false ] ; then
-    num_certs=$("$KEYTOOL" -v -list -storepass changeit -keystore cacerts | grep "Alias name:" | wc -l)
+    num_certs=$("$KEYTOOL" -v -list -storepass changeit -keystore cacerts | grep -c "Alias name:")
 else
-    num_certs=$(ls certs | wc -l)
+    num_certs=$(find certs/* | wc -l)
 fi
 echo "Number of certs processed: $num_certs"

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -85,18 +85,16 @@ IMPORTED=('null')
 for FILE in certs/*.crt; do
     SUBJECT=$(openssl x509 -subject -noout -in "$FILE")
     TRIMMED_SUBJECT="${SUBJECT#*subject= /}"
-    if [ "$NO_KEYSTORE" = false ] ; then
-        ALIAS="${TRIMMED_SUBJECT//\//,}"
-    else
-        # Remove/translate characters not valid in a filename
-        ALIAS_NO_INVALID="${TRIMMED_SUBJECT//[ :()]/_}"
-        ALIAS=$(echo "${ALIAS_NO_INVALID}" | tr -cd 'a-zA-Z,_' | tr A-Z a-z)
-    fi
+    ALIAS="${TRIMMED_SUBJECT//\//,}"
 
-    if [ "$NO_KEYSTORE" = false ] ; then
-         if printf '%s\n' "${IMPORTED[@]}" | grep "${ALIAS}"; then
-            echo "Skipping certificate with alias: $ALIAS as it already exists"
-        else
+    if printf '%s\n' "${IMPORTED[@]}" | grep "${ALIAS}"; then
+        echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"
+        if [ "$NO_KEYSTORE" = true ] ; then
+            # Remove duplicate $FILE so it is not imported using OpenJDK GenerateCacerts
+            rm $FILE
+        fi
+    else
+        if [ "$NO_KEYSTORE" = false ] ; then
             echo "Processing certificate with alias: $ALIAS"
             "$KEYTOOL" -noprompt \
             -import \
@@ -105,11 +103,19 @@ for FILE in certs/*.crt; do
             -file "$FILE" \
             -keystore "cacerts" \
             -storepass "changeit"
-
-            IMPORTED+=("${ALIAS}")
+        else
+            # Importing using OpenJDK GenerateCacerts, so must ensure alias is a valid filename
+            ALIAS_NO_INVALID="${ALIAS//[ :()]/_}"
+            ALIAS_FILENAME=$(echo "${ALIAS_NO_INVALID}" | tr -cd '0-9a-zA-Z,_' | tr A-Z a-z)
+            echo "Renaming $FILE to certs/$ALIAS_FILENAME"
+            if test -f "certs/$ALIAS_FILENAME"; then
+                echo "ERROR: Certificate alias file already exists certs/$ALIAS_FILENAME"
+                echo "security/mk-cacerts.sh needs ALIAS_FILENAME filter updating to make unique"
+                exit 1
+            fi
+            mv "$FILE" "certs/$ALIAS_FILENAME"
         fi
-    else
-         echo "Renaming $FILE to certs/$ALIAS"
-         mv "$FILE" "certs/$ALIAS"
+
+        IMPORTED+=("${ALIAS}")
     fi
 done

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -87,7 +87,7 @@ for FILE in certs/*.crt; do
     TRIMMED_SUBJECT="${SUBJECT#*subject= /}"
     ALIAS="${TRIMMED_SUBJECT//\//,}"
 
-    if printf '%s\n' "${IMPORTED[@]}" | grep "${ALIAS}"; then
+    if printf '%s\n' "${IMPORTED[@]}" | grep "temurin_${ALIAS}_temurin"; then
         echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"
         if [ "$NO_KEYSTORE" = true ] ; then
             # Remove duplicate $FILE so it is not imported using OpenJDK GenerateCacerts
@@ -116,6 +116,6 @@ for FILE in certs/*.crt; do
             mv "$FILE" "certs/$ALIAS_FILENAME"
         fi
 
-        IMPORTED+=("${ALIAS}")
+        IMPORTED+=("temurin_${ALIAS}_temurin")
     fi
 done

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -91,7 +91,7 @@ for FILE in certs/*.crt; do
         echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"
         if [ "$NO_KEYSTORE" = true ] ; then
             # Remove duplicate $FILE so it is not imported using OpenJDK GenerateCacerts
-            rm $FILE
+            rm "$FILE"
         fi
     else
         if [ "$NO_KEYSTORE" = false ] ; then
@@ -106,7 +106,7 @@ for FILE in certs/*.crt; do
         else
             # Importing using OpenJDK GenerateCacerts, so must ensure alias is a valid filename
             ALIAS_NO_INVALID="${ALIAS//[ :()]/_}"
-            ALIAS_FILENAME=$(echo "${ALIAS_NO_INVALID}" | tr -cd '0-9a-zA-Z,_' | tr A-Z a-z)
+            ALIAS_FILENAME=$(echo "${ALIAS_NO_INVALID}" | tr -cd '0-9a-zA-Z,_' | tr '[:upper:]' '[:lower:]')
             echo "Renaming $FILE to certs/$ALIAS_FILENAME"
             if test -f "certs/$ALIAS_FILENAME"; then
                 echo "ERROR: Certificate alias file already exists certs/$ALIAS_FILENAME"

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -119,3 +119,10 @@ for FILE in certs/*.crt; do
         IMPORTED+=("temurin_${ALIAS}_temurin")
     fi
 done
+
+if [ "$NO_KEYSTORE" = false ] ; then
+    num_certs=$("$KEYTOOL" -v -list -storepass changeit -keystore cacerts | grep "Alias name:" | wc -l)
+else
+    num_certs=$(ls certs | wc -l)
+fi
+echo "Number of certs processed: $num_certs"


### PR DESCRIPTION
Fixes https://github.com/adoptium/adoptium-support/issues/540

The nokeystore logic for reproducible cacerts creation had a uniqueness bug in the cert file renaming
for input to openjdk GenerateCacerts tool. The logic was removing digits from the alias which then resulted in
some aliases mapping to the same filename.

Corrected the alias file name uniqueness and updated logic to mirror both generation methods, and also verify
a cert filename clash does not occur.

Also corrected an existing bug with the detection of duplicate aliases, which was actually causing
certificate: "QuoVadis Root CA 3" to be missing as it is a substring of "QuoVadis Root CA 3 G3"

Corrected the invocation of mk-cacerts.sh with --nokeystore to be jdk-17+. --with-cacerts-src is backported to jdk17,18,19

Signed-off-by: Andrew Leonard <anleonar@redhat.com>