### PR TITLE
fix: post check on certs

### DIFF
--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -127,8 +127,10 @@ echo "Number of certs processed: $num_certs"
 
 # post verification: (nr.(mk-ca-bundle.pl) - nr.(already imported file) == (nr. (current files in certs folder)) || (nr. (alias in cacerts))
 certNum="$((certNum-alreadyExistsCounter))"
+num_certs="$(echo -e "${num_certs}" | tr -d '[:space:]')"
 if [ "$certNum" != "$num_certs" ]; then
     echo "Number of cert from mk-ca-bundle.pl: $certNum"
     echo "Number imported to $KEYTOOL: $num_certs"
+    echo "Mismatch number of certificates"
     exit 1
 fi


### PR DESCRIPTION
seems this only happened on Mac

fix in: 
https://ci.adoptopenjdk.net/view/Failing%20Temurin%20jobs/job/build-scripts/job/jobs/job/jdk19/job/jdk19-mac-aarch64-temurin/25/console

error in:
https://ci.adoptopenjdk.net/view/Failing%20Temurin%20jobs/job/build-scripts/job/jobs/job/jdk19/job/jdk19-mac-aarch64-temurin/23/console