### PR TITLE
freetype: skip unnecessary download on JDK11+

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -435,13 +435,13 @@ configureFreetypeLocation() {
       local freetypeDir="${BUILD_CONFIG[FREETYPE_DIRECTORY]}"
       if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
         case "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" in
-        jdk8* | jdk9* | jdk10*) addConfigureArg "--with-freetype-src=" "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype" ;;
-        *) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled} ;;
+          jdk8* | jdk9* | jdk10*) addConfigureArg "--with-freetype-src=" "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype" ;;
+          *) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled} ;;
         esac
       else
         case "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" in
-        jdk8* | jdk9* | jdk10*) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-"${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedfreetype"} ;;
-        *) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled} ;;
+          jdk8* | jdk9* | jdk10*) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-"${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedfreetype"} ;;
+          *) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled} ;;
         esac
       fi
 

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -568,14 +568,19 @@ downloadingRequiredDependencies() {
   fi
 
   if [[ "${BUILD_CONFIG[FREETYPE]}" == "true" ]]; then
-    if [ -z "${BUILD_CONFIG[FREETYPE_DIRECTORY]}" ]; then
-      echo "Checking and download FreeType Font dependency"
-      checkingAndDownloadingFreeType
-    else
-      echo ""
-      echo "---> Skipping the process of checking and downloading the FreeType Font dependency, a pre-built version provided at ${BUILD_CONFIG[FREETYPE_DIRECTORY]} <---"
-      echo ""
-    fi
+    case "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" in
+      jdk8* | jdk9* | jdk10*)
+        if [ -z "${BUILD_CONFIG[FREETYPE_DIRECTORY]}" ]; then
+          echo "Checking and download FreeType Font dependency"
+          checkingAndDownloadingFreeType
+        else
+          echo ""
+          echo "---> Skipping the process of checking and downloading the FreeType Font dependency, a pre-built version provided at ${BUILD_CONFIG[FREETYPE_DIRECTORY]} <---"
+          echo ""
+        fi
+      ;;
+      *) echo "Using bundled Freetype" ;;
+    esac
   else
     echo "Skipping Freetype"
   fi


### PR DESCRIPTION
Ever since https://github.com/adoptium/temurin-build/pull/421/ was merged, we no longer use the downloaded version of freetype for JDK11+ (instead opting for the bundled version). This PR completely removes the unnecessary download of the freetype tarball.