### PR TITLE
Set configure arg --with-hotspot-build-time for reproducible jdk17+ non-release builds

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -107,7 +107,7 @@ configureReproducibleBuildParameter() {
 
           # Specify --with-hotspot-build-time to ensure dual pass builds like MacOS use same time
           # Get current ISO-8601 datetime
-          isGnuCompatDate=$(date --version 2>&1 | grep "GNU\|BusyBox")
+          isGnuCompatDate=$(date --version 2>&1 | grep "GNU\|BusyBox" || true)
           if [ "x${isGnuCompatDate}" != "x" ]
           then
               hotspotBuildTime=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -104,6 +104,17 @@ configureReproducibleBuildParameter() {
       else
           # Use build date
           addConfigureArg "--with-source-date=" "updated"
+
+          # Specify --with-hotspot-build-time to ensure dual pass builds like MacOS use same time
+          # Get current ISO-8601 datetime
+          isGnuCompatDate=$(date --version 2>&1 | grep "GNU\|BusyBox")
+          if [ "x${isGnuCompatDate}" != "x" ]
+          then
+              hotspotBuildTime=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")
+          else
+              hotspotBuildTime=$(date -u -j +"%Y-%m-%dT%H:%M:%SZ")
+          fi
+          addConfigureArg "--with-hotspot-build-time=" "${hotspotBuildTime}"
       fi
       # Ensure reproducible binary with a unique build user identifier
       addConfigureArg "--with-build-user=" "adoptium"


### PR DESCRIPTION
Due to upstream change [make/hotspot/lib/CompileJvm.gmk](https://github.com/adoptium/jdk/commit/b4ab5fe1daf22a543e1bd973bcd34322360054b4#diff-d13a7651e18897b90a4f95c5d6dbdca71dec523606997303d29d467e4f6fe599) MacOS non-Release builds will fail
the notarization as the libjvm.dylib gets rebuilt due to a change in the HOTSPOT_BUILD_TIME on the 2nd pass make.
This PR ensures --with-hotspot-build-time is specified for all jdk-17+ non-release type reproducible builds.

Fixes: https://github.com/adoptium/temurin-build/issues/3025#issuecomment-1182454454

Signed-off-by: Andrew Leonard <anleonar@redhat.com>