### PR TITLE
Fix java version logic for repro params so it does not use undefined variable

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -91,9 +91,18 @@ configureShenandoahBuildParameter() {
 }
 
 # Configure reproducible build
-# jdk-17 and jdk-19+ support reproducible builds
+# jdk-17 and jdk-19+ support reproducible builds, no others do
 configureReproducibleBuildParameter() {
-  if [[ "${JAVA_FEATURE_VERSION}" -ge 19 || "${JAVA_FEATURE_VERSION}" -eq 17 ]]
+  if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK8_CORE_VERSION}"  ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK9_CORE_VERSION}"  ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK10_CORE_VERSION}" ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK11_CORE_VERSION}" ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK12_CORE_VERSION}" ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK13_CORE_VERSION}" ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK14_CORE_VERSION}" ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK15_CORE_VERSION}" ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK16_CORE_VERSION}" ] && \
+     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK18_CORE_VERSION}" ]
   then
       # Enable reproducible builds implicitly with --with-source-date
       if [ "${BUILD_CONFIG[RELEASE]}" == "true" ]

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -91,18 +91,9 @@ configureShenandoahBuildParameter() {
 }
 
 # Configure reproducible build
-# jdk-17 and jdk-19+ support reproducible builds, no others do
+# jdk-17 and jdk-19+ support reproducible builds
 configureReproducibleBuildParameter() {
-  if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK8_CORE_VERSION}"  ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK9_CORE_VERSION}"  ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK10_CORE_VERSION}" ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK11_CORE_VERSION}" ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK12_CORE_VERSION}" ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK13_CORE_VERSION}" ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK14_CORE_VERSION}" ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK15_CORE_VERSION}" ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK16_CORE_VERSION}" ] && \
-     [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK18_CORE_VERSION}" ]
+  if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 19 || "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -eq 17 ]]
   then
       # Enable reproducible builds implicitly with --with-source-date
       if [ "${BUILD_CONFIG[RELEASE]}" == "true" ]


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3048

We should possible look at the use of `OPENJDK_FEATURE_NUMBER` vs `OPENJDK_CORE_VERSION` in `build.sh` more in the future, but while this is inconsistent with most of the other comparisons in the script that use the latter, the former allows us to do the `-ge` comparison as it's purely numeric. The alternative with `OPENJDK_CORE_VERSION` would be to use an explicit list of versions that are not allowed.
