### PR TITLE
build.sh: Use --with-build-user=VARIANT instead of hard coding to adoptium

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -106,7 +106,7 @@ configureReproducibleBuildParameter() {
           addConfigureArg "--with-source-date=" "updated"
       fi
       # Ensure reproducible binary with a unique build user identifier
-      addConfigureArg "--with-build-user=" "adoptium"
+      addConfigureArg "--with-build-user=" "${BUILD_CONFIG[BUILD_VARIANT]}"
   fi
 }
 


### PR DESCRIPTION
Currently the reproducible build option to define the build user (picked up by `gcc`) is hard coded in the scripts to `adoptium`. This happens on all values of VARIANT and so end users building their own openjdk with our scripts will have the `adoptium` user name being used. This is undesirable. This adjusts the code so that the default with no variant set will set the user to `hotspot` (The default VARIANT).

NOTE: This will change the builds of Eclipse Temurin fromusing a build user value of  `adoptium` to `temurin`. We could put in an extra if clause to change this if we want it to be left as adoptium.