### PR TITLE
revert: back to "false" for BUILD_CONFIG[CREATE_SBOM]

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1759,7 +1759,7 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   printJavaVersionString
   addInfoToReleaseFile
   addInfoToJson
-  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]] && [[ -d "${CYCLONEDB_DIR}" ]]; then
+  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
     javaHome="$(setupAntEnv)"
     buildCyclonedxLib "${javaHome}"
     generateSBoM "${javaHome}"
@@ -1795,7 +1795,7 @@ if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" != "true" ]]; then
   printJavaVersionString
   addInfoToReleaseFile
   addInfoToJson
-  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]] && [[ -d "${CYCLONEDB_DIR}" ]]; then
+  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
     javaHome="$(setupAntEnv)"
     buildCyclonedxLib "${javaHome}"
     generateSBoM "${javaHome}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1759,7 +1759,7 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   printJavaVersionString
   addInfoToReleaseFile
   addInfoToJson
-  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
+  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]] && [[ -d "${CYCLONEDB_DIR}" ]]; then
     javaHome="$(setupAntEnv)"
     buildCyclonedxLib "${javaHome}"
     generateSBoM "${javaHome}"
@@ -1795,7 +1795,7 @@ if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" != "true" ]]; then
   printJavaVersionString
   addInfoToReleaseFile
   addInfoToJson
-  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]]; then
+  if [[ "${BUILD_CONFIG[CREATE_SBOM]}" == "true" ]] && [[ -d "${CYCLONEDB_DIR}" ]]; then
     javaHome="$(setupAntEnv)"
     buildCyclonedxLib "${javaHome}"
     generateSBoM "${javaHome}"

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -472,8 +472,8 @@ function configDefaults() {
   # The default behavior of whether we want to create the legacy JRE
   BUILD_CONFIG[CREATE_JRE_IMAGE]="false"
 
-  # Set default value to "true. If we do not want this behavior, we can update buildArg per each config file instead
-  BUILD_CONFIG[CREATE_SBOM]="true"
+  # Set default value to "false". We config buildArg per each config file to have it enabled by our pipeline
+  BUILD_CONFIG[CREATE_SBOM]="false"
 
   # The default behavior of whether we want to create a separate source archive
   BUILD_CONFIG[CREATE_SOURCE_ARCHIVE]="false"


### PR DESCRIPTION
	- disable create sbom by default (for build without using ci-jenkins-pipeline)
	
	- enable our CI build from https://github.com/adoptium/ci-jenkins-pipelines/pull/369 
Ref: https://github.com/adoptium/temurin-build/issues/3047