### PR TITLE
unixPB: use JDK8 for bootstrapping JDK8 on Linux

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -147,6 +147,10 @@ then
     # which is only available from jdk-19 so we cannot bootstrap with JDK18
     JDK_BOOT_VERSION="19"
   fi
+  if [ "${JAVA_FEATURE_VERSION}" == "8" ]; then
+     # Reduce external dependencies and use Adoptium builds if present
+    JDK_BOOT_VERSION="8"
+  fi
 fi
 echo "Required boot JDK version: ${JDK_BOOT_VERSION}"
 


### PR DESCRIPTION
Prototype using JDK8 as the boot JDK for building Temurin 8. This will reduce our current dependencies on either Zulu or distribution-supplied JDK7 implementations which are no longer available on modern distributions. Similarly we also have a JDK7 that we're using for bootstrapping JDK8 but it's source is unclear.

Part of investigating for SSDF at https://github.com/adoptium/infrastructure/issues/2553#issuecomment-1128953048

Signed-off-by: Stewart X Addison <sxa@redhat.com>