### PR TITLE
feat: update to use jdk17 as boot jdk for jdk17 build to support reproducible builds

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -144,8 +144,10 @@ then
   fi
   if [ "${JAVA_FEATURE_VERSION}" == "17" ]; then
     # To support reproducible-builds the jar/jmod --date option is required
-    # which is only available from jdk-17 so we cannot bootstrap with JDK16
+    # which is only available in jdk-17 and from jdk-19 so we cannot bootstrap with JDK16
     JDK_BOOT_VERSION="17"
+  elif [ "${JAVA_FEATURE_VERSION}" == "19" ]; then
+    JDK_BOOT_VERSION="19"
   fi
 fi
 echo "Required boot JDK version: ${JDK_BOOT_VERSION}"

--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -142,10 +142,10 @@ then
     # OpenJ9 only supports building jdk-11 with jdk-11
     JDK_BOOT_VERSION="11"
   fi
-  if [ "${JAVA_FEATURE_VERSION}" == "19" ]; then
+  if [ "${JAVA_FEATURE_VERSION}" == "17" ]; then
     # To support reproducible-builds the jar/jmod --date option is required
-    # which is only available from jdk-19 so we cannot bootstrap with JDK18
-    JDK_BOOT_VERSION="19"
+    # which is only available from jdk-17 so we cannot bootstrap with JDK16
+    JDK_BOOT_VERSION="17"
   fi
 fi
 echo "Required boot JDK version: ${JDK_BOOT_VERSION}"


### PR DESCRIPTION
	- to enable reproducible build for jdk17 cannot use jdk16 without -date support
	- this will make jdk17 use jdk17 as boot
	- jdk18 use jdk17 as boot
	- jdk19 use jdk19 as boot etc

Ref: https://github.com/adoptium/temurin-build/issues/3057