### PR TITLE
fix: smoke test not working for jdk19/20 on alpine x64

### DIFF
--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -54,10 +54,10 @@
             <fileset dir="${build}"/>
             <fileset dir="${src}/../" includes="*.properties,*.xml"/>
         </jar>
-        <copy todir="${DEST}">
+        <!-- <copy todir="${DEST}">
             <fileset dir="${src}/../" includes="*.xml"/>
             <fileset dir="${src}/../" includes="*.mk"/>
-        </copy>
+        </copy> -->
     </target>
 
     <target name="clean" depends="dist" description="clean up">

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -62,16 +62,22 @@
                 </not>
             </condition>
         </fail> -->
-        <fail message="File xml are missing.">
+        <fail message="File testng.xml is missing.">
             <condition>
                 <not>
                     <available file="${src}/../testng.xml" type="file"/>
                 </not>
             </condition>
         </fail>
-        <copy file="${src}/../testng.xml" todir="${DEST}"/>
-        <copy file="${src}/../playlist.xml" todir="${DEST}"/>
-        <copy file="${src}/../build.xml" todir="${DEST}"/>
+        <copy file="${src}/../testng.xml" tofile="${DEST}/testng.xml"/>
+        <fail message="File playlist.xml is missing.">
+            <condition>
+                <not>
+                    <available file="${src}/../playlist.xml" type="file"/>
+                </not>
+            </condition>
+        </fail>
+        <copy file="${src}/../playlist.xml" tofile="${DEST}/playlist.xml"/>
     </target>
 
 

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -63,7 +63,7 @@
         </fail>
         <apply executable="cp" dest="${DEST}" failonerror="true">
             <srcfile/>
-			<targetfile/>
+	    <targetfile/>
             <fileset dir="${src}/.." includes="*.xml"/>
             <mapper type="glob" from="*.xml" to="*.xml"/>
         </apply>

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -54,7 +54,7 @@
             <fileset dir="${build}"/>
             <fileset dir="${src}/../" includes="*.properties,*.xml"/>
         </jar>
-        <echo message="doing copy from src set to ${src}.."/>
+        <echo message="doing copy from src set to ${src}.. to ${DEST}"/>
          <!-- <fail message="File mk are missing.">
             <condition>
                 <not>
@@ -69,12 +69,9 @@
                 </not>
             </condition>
         </fail>
-        <copy todir="${DEST}">
-            <fileset dir="${src}/../" includes="testng.xml"/>
-            <fileset dir="${src}/../" includes="playlist.xml"/>
-            <fileset dir="${src}/../" includes="build.xml"/>
-            <!-- <fileset dir="${src}/../" includes="*.mk"/> -->
-        </copy>
+        <copy file="${src}/../testng.xml" todir="${DEST}"/>
+        <copy file="${src}/../playlist.xml" todir="${DEST}"/>
+        <copy file="${src}/../build.xml" todir="${DEST}"/>
     </target>
 
 

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -55,17 +55,17 @@
             <fileset dir="${src}/../" includes="*.properties,*.xml"/>
         </jar>
         <echo message="doing copy from src set to ${src}.."/>
-        <fail message="File xml are missing.">
-            <condition>
-                <not>
-                    <available file="${src}/../*.xml" type="file"/>
-                </not>
-            </condition>
-        </fail>
-        <fail message="File mk are missing.">
+         <fail message="File mk are missing.">
             <condition>
                 <not>
                     <available file="${src}/../*.mk" type="file"/>
+                </not>
+            </condition>
+        </fail>
+        <fail message="File xml are missing.">
+            <condition>
+                <not>
+                    <available file="${src}/../testng.xml" type="file"/>
                 </not>
             </condition>
         </fail>

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -58,14 +58,14 @@
         <fail message="File xml are missing.">
             <condition>
                 <not>
-                    <fileset dir="${src}/../" includes="*.xml"/>
+                    <available file="${src}/../*.xml" type="file"/>
                 </not>
             </condition>
         </fail>
         <fail message="File mk are missing.">
             <condition>
                 <not>
-                    <fileset dir="${src}/../" includes="*.mk"/>
+                    <available file="${src}/../*.mk" type="file"/>
                 </not>
             </condition>
         </fail>

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -54,9 +54,6 @@
             <fileset dir="${build}"/>
             <fileset dir="${src}/../" includes="*.properties,*.xml"/>
         </jar>
-    </target>
-
-    <target name="test-copy" depends="dist" description="test if files are in place to be copied">
         <echo message="doing copy from src set to ${src}.."/>
         <fail message="File xml are missing.">
             <condition>

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -61,9 +61,12 @@
                 </not>
             </condition>
         </fail>
-        <exec executable="cp" failonerror="true"> 
-            <arg line="${src}/../testng.xml ${DEST}"/> 
-        </exec> 
+        <apply executable="cp" dest="${DEST}" failonerror="true">
+            <srcfile/>
+			<targetfile/>
+            <fileset dir="${src}/.." includes="*.xml"/>
+            <mapper type="glob" from="*.xml" to="*.xml"/>
+        </apply>
     </target>
 
     <target name="clean" depends="dist" description="clean up">

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -70,7 +70,9 @@
             </condition>
         </fail>
         <copy todir="${DEST}">
-            <fileset dir="${src}/../" includes="*.xml"/>
+            <fileset dir="${src}/../" includes="testng.xml"/>
+            <fileset dir="${src}/../" includes="playlist.xml"/>
+            <fileset dir="${src}/../" includes="build.xml"/>
             <!-- <fileset dir="${src}/../" includes="*.mk"/> -->
         </copy>
     </target>

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -54,32 +54,17 @@
             <fileset dir="${build}"/>
             <fileset dir="${src}/../" includes="*.properties,*.xml"/>
         </jar>
-        <echo message="doing copy from src set to ${src}.. to ${DEST}"/>
-         <!-- <fail message="File mk are missing.">
-            <condition>
-                <not>
-                    <available file="${src}/../*.mk" type="file"/>
-                </not>
-            </condition>
-        </fail> -->
-        <fail message="File testng.xml is missing.">
+        <fail message="testng.xml is missing.">
             <condition>
                 <not>
                     <available file="${src}/../testng.xml" type="file"/>
                 </not>
             </condition>
         </fail>
-        <copy file="${src}/../testng.xml" tofile="${DEST}/testng.xml"/>
-        <fail message="File playlist.xml is missing.">
-            <condition>
-                <not>
-                    <available file="${src}/../playlist.xml" type="file"/>
-                </not>
-            </condition>
-        </fail>
-        <copy file="${src}/../playlist.xml" tofile="${DEST}/playlist.xml"/>
+        <exec executable="cp" failonerror="true"> 
+            <arg line="${src}/../testng.xml ${DEST}"/> 
+        </exec> 
     </target>
-
 
     <target name="clean" depends="dist" description="clean up">
         <!-- Delete the ${build} directory trees -->

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -54,11 +54,30 @@
             <fileset dir="${build}"/>
             <fileset dir="${src}/../" includes="*.properties,*.xml"/>
         </jar>
-        <!-- <copy todir="${DEST}">
+    </target>
+
+    <target name="test-copy" depends="dist" description="test if files are in place to be copied">
+        <echo message="doing copy from src set to ${src}.."/>
+        <fail message="File xml are missing.">
+            <condition>
+                <not>
+                    <fileset dir="${src}/../" includes="*.xml"/>
+                </not>
+            </condition>
+        </fail>
+        <fail message="File mk are missing.">
+            <condition>
+                <not>
+                    <fileset dir="${src}/../" includes="*.mk"/>
+                </not>
+            </condition>
+        </fail>
+        <copy todir="${DEST}">
             <fileset dir="${src}/../" includes="*.xml"/>
             <fileset dir="${src}/../" includes="*.mk"/>
-        </copy> -->
+        </copy>
     </target>
+
 
     <target name="clean" depends="dist" description="clean up">
         <!-- Delete the ${build} directory trees -->

--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -55,13 +55,13 @@
             <fileset dir="${src}/../" includes="*.properties,*.xml"/>
         </jar>
         <echo message="doing copy from src set to ${src}.."/>
-         <fail message="File mk are missing.">
+         <!-- <fail message="File mk are missing.">
             <condition>
                 <not>
                     <available file="${src}/../*.mk" type="file"/>
                 </not>
             </condition>
-        </fail>
+        </fail> -->
         <fail message="File xml are missing.">
             <condition>
                 <not>
@@ -71,7 +71,7 @@
         </fail>
         <copy todir="${DEST}">
             <fileset dir="${src}/../" includes="*.xml"/>
-            <fileset dir="${src}/../" includes="*.mk"/>
+            <!-- <fileset dir="${src}/../" includes="*.mk"/> -->
         </copy>
     </target>
 


### PR DESCRIPTION
- suspect it could be ant with underlying jdk version 19/20 not working well with target "copy"
- this PR changes:
1. add check if testng.xml exist before copy (this is a known issue in ant that if source file is missing, copy could hang)
2. use cp command than copy target (we are running either on linux, or windows with cygwin or mac, so cp should work in all three cases)
3. only testng.xml is needed, not build.xml or playlist.xml or any makefile for smoketest. But to make it align with old code, do cp on all matched *.xml files

P.S: this PR is only trying to fix the hanging smoke test job from Jenkins. It has not solid evidence that Ant is not working with jdk19/20 and why it is only seen on certain jobs on certain platform+OS

test run:
https://ci.adoptopenjdk.net/job/Grinder/5548/console is on jdk 19 alpine x64
https://ci.adoptopenjdk.net/job/Grinder/5552/console is windows jdk19 x64
https://ci.adoptopenjdk.net/job/Grinder/5553/console is mac jdk20 aarch64

Fix: https://github.com/adoptium/temurin-build/issues/3031