### PR TITLE
Force TZ=UTC for reproducible release builds

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -98,8 +98,8 @@ configureReproducibleBuildParameter() {
       # Enable reproducible builds implicitly with --with-source-date
       if [ "${BUILD_CONFIG[RELEASE]}" == "true" ]
       then
-           # TZ issue: https://github.com/adoptium/temurin-build/issues/3075
-           export TZ=UTC
+          # TZ issue: https://github.com/adoptium/temurin-build/issues/3075
+          export TZ=UTC
           # Use release date and disable CCache( remove --enable-ccache if exist)
           addConfigureArg "--with-source-date=version"  " --disable-ccache"
           CONFIGURE_ARGS="${CONFIGURE_ARGS//--enable-ccache/}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -98,6 +98,8 @@ configureReproducibleBuildParameter() {
       # Enable reproducible builds implicitly with --with-source-date
       if [ "${BUILD_CONFIG[RELEASE]}" == "true" ]
       then
+           # TZ issue: https://github.com/adoptium/temurin-build/issues/3075
+           export TZ=UTC
           # Use release date and disable CCache( remove --enable-ccache if exist)
           addConfigureArg "--with-source-date=version"  " --disable-ccache"
           CONFIGURE_ARGS="${CONFIGURE_ARGS//--enable-ccache/}"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3075

While most timestamps in the builds are neutralised when some of the files are produced there are some files which have timestamps that are affected by the time zone setting, so if you build on a machine in a different time zone then the builds are not identical. I've seen this on xLinux (Timestamps within the `ct.sym` zipfile are different) as well as in the issue reference above between two Linux/s390x systems. This fix will set `TZ=UTC` alongside the other options when the reproducible builds are enabled.

Signed-off-by: Stewart X Addison <sxa@redhat.com>