### PR TITLE
Compile OpenJ9 Windows jdk11 with VS2019

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -173,11 +173,7 @@ then
     elif [ "${JAVA_TO_BUILD}" == "${JDK10_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
-    elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
-    then
-      TOOLCHAIN_VERSION="2017"
-      export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
-    elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
+    elif [ "$JAVA_FEATURE_VERSION" -ge 11 ]
     then
       TOOLCHAIN_VERSION="2019"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"


### PR DESCRIPTION
This change is already used for OpenJ9/Semeru 11.0.17 builds via https://github.com/ibmruntimes/temurin-build/pull/25

FYI OpenJ9 also needed this OpenJDK change https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/574 related to using VS2019, to include vcruntime140_1.dll into the build. Perhaps Temurin would benefit from the same.