### PR TITLE
hotspot: use correct repo for non-temurin aarch32 builds

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -176,7 +176,7 @@ setRepository() {
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "armv7l" ] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/aarch32-jdk8u";
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "armv7l" ] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]]; then
-    suffix="adoptium/aarch32-port-jdk8u";
+    suffix="openjdk/aarch32-port-jdk8u";
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
   else


### PR DESCRIPTION
Repository was using an incorrect name (Still referencing adoptium rather than openjdk)

Signed-off-by: Stewart X Addison <sxa@redhat.com>