### PR TITLE
docs: update release step options

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -126,17 +126,21 @@ Here are the steps:
 1. If desired, add a banner to the website to indicate that the releases are coming in the near future ([Sample PR](https://github.com/adoptium/website-v2/pull/408/files))
 1. Build and Test the OpenJDK for "release" at Adoptium using a build pipeline job as follows:
    - Job: https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/build (Switch `openjdk8` for your version number)
-   - `targetConfigurations`: remove all the entries for the variants you don't want to build (e.g. remove the openj9 ones for hotspot releases) or any platforms you don't want to release (Currently that would include OpenJ9 aarch64)
+   - `targetConfigurations`: 
+    1. only keep termurin variants
+    2. make sure windows aarch64 is removed (as this is written, it is not officially supported yet)
    - `releaseType: Release`
    - <details><summary>Extra steps for OpenJ9 ONLY</summary>
      For OpenJ9 releases, `overridePublishName` should be set to the GitHub binaries publish name (NOTE: If you are doing a point release, do NOT adjust this as we don't want the filenames to include the `.x` part), e.g. `jdk8u232-b09_openj9-0.14.0` or `jdk-11.0.5+10_openj9-0.14.0`. Similarly, `scmReference` for OpenJ9 releases should be the name of the  extensions release branch: e.g. `openj9-0.14.0`</details>
    - `adoptBuildNumber`: Leave blank unless you are doing a point release in which case it should be a number starting at `1` for the first point release.
-   - `additionalConfigureArgs`: JDK8 automatically adds`--with-milestone=fcs` in `build.sh` so there's no need to provide it here. For JDK11+ use `--without-version-pre --without-version-opt` (for EA releases use: `--with-version-pre=ea --without-version-opt`)
+   - `additionalConfigureArgs`: 
+    1. JDK8 automatically adds`--with-milestone=fcs` in `build.sh` so there's no need to provide it here. 
+    2. For JDK11+ use `--without-version-pre --without-version-opt` (for EA releases use: `--with-version-pre=ea --without-version-opt`)
    - `scmReference`: One of the following:
      - For HotSpot, it's the same tag suffixed with `_adopt` e.g. `jdk-17.0.2+9_adopt`
      - For HotSpot (arm32), the tag usually takes the form `jdk8u322-b04-aarch32-xxxxxxxx`
-     - NOTE you need to set `overridePublishName` for arm32 to the actual OpenJDK tag (`jdk8u322-b04`)
-     - For OpenJ9 (all versions) use the OpenJ9 branch e.g. `openj9-0.15.1`
+       - NOTE you need to set `overridePublishName` for arm32 to the actual OpenJDK tag (`jdk8u322-b04`)
+     - <details><summary>For OpenJ9 (all versions)</summary> use the OpenJ9 branch e.g. `openj9-0.15.1`</details>
    - `aqaReference` should be set to the appropriate branch of the `aqa-tests` repository which is appropriate for this release. Generally of the form `vX.Y.Z-release`
    - `enableTests`: tick
    - SUBMIT!!

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -126,15 +126,15 @@ Here are the steps:
 1. If desired, add a banner to the website to indicate that the releases are coming in the near future ([Sample PR](https://github.com/adoptium/website-v2/pull/408/files))
 1. Build and Test the OpenJDK for "release" at Adoptium using a build pipeline job as follows:
    - Job: https://ci.adoptopenjdk.net/job/build-scripts/job/openjdk8-pipeline/build (Switch `openjdk8` for your version number)
-   - `targetConfigurations`: 
+   - `targetConfigurations`:
     1. only keep termurin variants
     2. make sure windows aarch64 is removed (as this is written, it is not officially supported yet)
    - `releaseType: Release`
    - <details><summary>Extra steps for OpenJ9 ONLY</summary>
      For OpenJ9 releases, `overridePublishName` should be set to the GitHub binaries publish name (NOTE: If you are doing a point release, do NOT adjust this as we don't want the filenames to include the `.x` part), e.g. `jdk8u232-b09_openj9-0.14.0` or `jdk-11.0.5+10_openj9-0.14.0`. Similarly, `scmReference` for OpenJ9 releases should be the name of the  extensions release branch: e.g. `openj9-0.14.0`</details>
    - `adoptBuildNumber`: Leave blank unless you are doing a point release in which case it should be a number starting at `1` for the first point release.
-   - `additionalConfigureArgs`: 
-    1. JDK8 automatically adds`--with-milestone=fcs` in `build.sh` so there's no need to provide it here. 
+   - `additionalConfigureArgs`:
+    1. JDK8 automatically adds`--with-milestone=fcs` in `build.sh` so there's no need to provide it here.
     2. For JDK11+ use `--without-version-pre --without-version-opt` (for EA releases use: `--with-version-pre=ea --without-version-opt`)
    - `scmReference`: One of the following:
      - For HotSpot, it's the same tag suffixed with `_adopt` e.g. `jdk-17.0.2+9_adopt`


### PR DESCRIPTION
For review: https://github.com/zdtsw/temurin-build/blob/wenzhou/docs3/RELEASING.md#steps-for-every-version (4)

updated some parts for the input values to build openjdkX-pipeline for release