### PR TITLE
Add --build-reproducible-date=ISO8601_date build option to allow reproducible nightly builds

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -38,6 +38,7 @@ OPENJDK_BUILD_REPO_BRANCH
 OPENJDK_BUILD_REPO_URI
 BRANCH
 BUILD_FULL_NAME
+BUILD_REPRODUCIBLE_DATE
 BUILD_VARIANT
 CERTIFICATE
 CLEAN_DOCKER_BUILD
@@ -211,6 +212,9 @@ function parseConfigurationArguments() {
 
         "--build-variant" )
         BUILD_CONFIG[BUILD_VARIANT]="$1"; shift;;
+
+        "--build-reproducible-date" )
+        BUILD_CONFIG[BUILD_REPRODUCIBLE_DATE]="$1"; shift;;
 
         "--branch" | "-b" )
         BUILD_CONFIG[BRANCH]="$1"; shift;;
@@ -465,6 +469,9 @@ function configDefaults() {
       BUILD_CONFIG[MAKE_COMMAND_NAME]="make"
       ;;
   esac
+
+  # Default to no supplied reproducible build date, uses current date
+  BUILD_CONFIG[BUILD_REPRODUCIBLE_DATE]=""
 
   # The default behavior of whether we want to create a separate debug symbols archive
   BUILD_CONFIG[CREATE_DEBUG_IMAGE]="false"


### PR DESCRIPTION
Add --build-reproducible-date=ISO8601_date build build arg, which sets the build date & time used in the build
so for nightly builds the pre/post version output date, and all build dates are reproducible.

A follow on PR will update Temurin nightly builds to use this along with a "dual-build" with the same nightly "date", then invoking the reproducible comparison job, publishing the reproducible % to the metadata and subsequent publish to website... (ok, maybe more than one PR to follow!)

Signed-off-by: Andrew Leonard <anleonar@redhat.com>