### PR TITLE
test: fix smoke cacert test expected number 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
       - "sbin/**"
       - "**.sh"
       - ".github/workflows/build.yml"
+      - "security/**"
 
 # Cancel existing runs if user makes another push.
 concurrency:

--- a/test/functional/buildAndPackage/src/net/adoptium/test/VerifyCACertsTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/VerifyCACertsTest.java
@@ -39,8 +39,8 @@ public class VerifyCACertsTest {
     private static final JdkVersion JDK_VERSION = new JdkVersion();
 
     // Expect matching certs number
-    private static final int EXPECTED_COUNT = 138;
-    /* TODO: add up to 138 certs
+    private static final int EXPECTED_COUNT = 139;
+    /* TODO: add up to 139 certs
     private static final Map<String, String> EXPFP_MAP = new HashMap<>() {
         put("amazonrootca1 [jdk]",          "8E:CD:E6:88:4F:3D:87:B1:12:5B:A3:1A:C3:FC:B1:3D:70:16:DE:7F:57:CC:90:4F:E1:CB:97:C6:AE:98:19:6E");
         put("amazonrootca2 [jdk]",          "1B:A5:B2:AA:8C:65:40:1A:82:96:01:18:F8:0B:EC:4F:62:30:4D:83:CE:C4:71:3A:19:C3:9C:01:1E:A4:6D:B4");


### PR DESCRIPTION
Fix: https://github.com/adoptium/temurin-build/issues/3212

Test locally with 
```
./mk-ca-bundle.pl -n -d
./mk-cacerts.sh 
```
got` Number of certs processed: 139
`which matches smoketest result 139 


some more discussion: https://adoptium.slack.com/archives/C09NW3L2J/p1673446583214579 