### PR TITLE
alpine: switch jdk8u to build from other fork

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -177,6 +177,8 @@ setRepository() {
     suffix="adoptium/aarch32-jdk8u";
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "armv7l" ] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]]; then
     suffix="openjdk/aarch32-port-jdk8u";
+  elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_FULL_VERSION]}" == *"Alpine"* ] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
+    suffix="adoptium/alpine-jdk8u";
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
   else

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -177,7 +177,7 @@ setRepository() {
     suffix="adoptium/aarch32-jdk8u";
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "armv7l" ] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]]; then
     suffix="openjdk/aarch32-port-jdk8u";
-  elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_FULL_VERSION]}" == *"Alpine"* ] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
+  elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [[ "${BUILD_CONFIG[OS_FULL_VERSION]}" == *"Alpine"* ]] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/alpine-jdk8u";
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"


### PR DESCRIPTION
As per https://github.com/adoptium/jdk8u/issues/11, we are splitting the JDK8u Alpine specific patches into their own separate mirror to keep our mainline jdk8u repo as clean as possible.