### PR TITLE
Run code freeze bots on pull requests made to release branches

### DIFF
--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -3,7 +3,7 @@ name: Code Freeze Bot
 # Controls when the workflow will run
 on:
   pull_request_target:
-    branches: [ "master", "v[0-9]*.[0-9]*" ]
+    branches: [ "master", "v[0-9]{4}.[0-9]{2}" ]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -3,7 +3,7 @@ name: Code Freeze Bot
 # Controls when the workflow will run
 on:
   pull_request_target:
-    branches: [ "master" ]
+    branches: [ "master", "v[0-9]*.[0-9]*" ]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
This PR enables the Code Freeze bot on release branches such as `v2023.01`. A recent PMC conversation suggested that this would make sense to add.