### PR TITLE
Fix Smoke Test openj9 AIX libfreetype error

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/BundledFreetypeTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/BundledFreetypeTest.java
@@ -81,7 +81,7 @@ public class BundledFreetypeTest {
             assertTrue(freetypeFiles.size() > 0,
               "Expected freetype.dll to be bundled, but it is not.");
         } else if (jdkPlatform.runsOn(OperatingSystem.AIX)
-                && (jdkVersion.isNewerOrEqual(13) || (jdkVersion.usesVM(VM.OPENJ9) && jdkVersion.isNewerOrEqual(11)))) {
+                && (jdkVersion.isNewerOrEqual(13) || (jdkVersion.usesVM(VM.OPENJ9) && jdkVersion.isNewerOrEqual(8)))) {
             assertTrue(freetypeFiles.size() > 0,
               "Expected libfreetype.so to be bundled, but it is not.");
         } else {


### PR DESCRIPTION
- Fix Smoke Test openj9 AIX libfreetype error due to jdk 8 aix freetype update
Related Issue: ibm_git/runtimes/backlog/issues/766

Signed-off-by: LongyuZhang <longyu.zhang@ibm.com>