### PR TITLE
Ensure TemurinGenSOM.java build with jdk-17+ for openkeystore support

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -696,7 +696,7 @@ setupAntEnv() {
   fi
 
   if [ ! -z "$javaHome" ]; then
-    javaVer=$("$javaHome}/bin/java -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r' | tr '+' '.' | cut -d'.' -f1")
+    javaVer=$("${javaHome}/bin/java -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r' | tr '+' '.' | cut -d'.' -f1")
   fi
 
   if [[ -z "$javaVer" ]] || [[ "$javaVer" -lt "17" ]]; then 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2155,SC2153,SC2038,SC1091,SC2116
+# shellcheck disable=SC2155,SC2153,SC2038,SC1091,SC2116,SC2086
 
 ################################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -695,7 +695,7 @@ setupAntEnv() {
     javaHome="${BUILD_CONFIG[JDK_BOOT_DIR]}"
   fi
 
-  if [ ! -z "$javaHome" ]; then
+  if [ -n "$javaHome" ]; then
     javaVer=$("${javaHome}/bin/java -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r' | tr '+' '.' | cut -d'.' -f1")
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -684,29 +684,17 @@ createOpenJDKFailureLogsArchive() {
     createArchive "${adoptLogArchiveDir}" "${makeFailureLogsName}"
 }
 
-# Setup JAVA env to run "ant task"
+# Setup JAVA env to run "ant task" for CycloneDX build
 setupAntEnv() {
   local javaHome=""
 
-  if [ ${JAVA_HOME+x} ] && [ -d "${JAVA_HOME}" ]; then
-    javaHome=${JAVA_HOME}
-  elif [ ${BUILD_CONFIG[JDK_BOOT_DIR]+x} ] && [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then
-    # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
-    javaHome="${BUILD_CONFIG[JDK_BOOT_DIR]}"
-  fi
+  # TemurinGenSBOM.java requires jdk-17+ to build openkeystore
+  apiURL="https://api.adoptium.net/v3/binary/latest/17/ga/${OPERATING_SYSTEM}/${BUILD_CONFIG[OS_ARCHITECTURE]}/jdk/hotspot/normal/eclipse"
+  rm -rf ${CYCLONEDB_DIR}/jdk
+  mkdir -p ${CYCLONEDB_DIR}/jdk
+  curl -sL "${apiURL}" | tar xpzf - --strip-components=1 -C "${CYCLONEDB_DIR}/jdk"
+  javaHome="${CYCLONEDB_DIR}/jdk"
 
-  if [ -n "$javaHome" ]; then
-    javaVer=$("${javaHome}/bin/java -XshowSettings:properties -version 2>&1 | grep 'java.runtime.version' | sed 's/^.*= //' | tr -d '\r' | tr '+' '.' | cut -d'.' -f1")
-  fi
-
-  if [[ -z "$javaVer" ]] || [[ "$javaVer" -lt "17" ]]; then 
-    # TemurinGenSBOM.java requires jdk-17+ to build openkeystore
-    apiURL="https://api.adoptium.net/v3/binary/latest/17/ga/${OPERATING_SYSTEM}/${BUILD_CONFIG[OS_ARCHITECTURE]}/jdk/hotspot/normal/eclipse"
-    rm -rf ${CYCLONEDB_DIR}/jdk
-    mkdir -p ${CYCLONEDB_DIR}/jdk
-    curl -sL "${apiURL}" | tar xpzf - --strip-components=1 -C "${CYCLONEDB_DIR}/jdk"
-    javaHome="${CYCLONEDB_DIR}/jdk"
-  fi
   echo "${javaHome}"
 }
 

--- a/sbin/common/sbom.sh
+++ b/sbin/common/sbom.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build the CycloneDX Java library and app used for SBoM generation
+# Build the CycloneDX Java library and app used for SBOM generation
 buildCyclonedxLib() {
   local javaHome="${1}"
 

--- a/sbin/common/sbom.sh
+++ b/sbin/common/sbom.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+
+# Build the CycloneDX Java library and app used for SBoM generation
+buildCyclonedxLib() {
+  local javaHome="${1}"
+
+  # Make Ant aware of cygwin path
+  if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
+    ANTBUILDFILE=$(cygpath -m "${CYCLONEDB_DIR}/build.xml")
+  else
+    ANTBUILDFILE="${CYCLONEDB_DIR}/build.xml"
+  fi
+
+  JAVA_HOME="${javaHome}" ant -f "${ANTBUILDFILE}" clean
+  JAVA_HOME="${javaHome}" ant -f "${ANTBUILDFILE}" build
+}
+
 # Create a default SBOM json file: sbomJson
 createSBOMFile() {
   local javaHome="${1}"

--- a/sbin/common/sbom.sh
+++ b/sbin/common/sbom.sh
@@ -4,6 +4,8 @@
 buildCyclonedxLib() {
   local javaHome="${1}"
 
+  echo "Building CycloneDX Java library using JAVA_HOME=${javaHome}"
+
   # Make Ant aware of cygwin path
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     ANTBUILDFILE=$(cygpath -m "${CYCLONEDB_DIR}/build.xml")


### PR DESCRIPTION
Fix build.sh to build TemurinGenSOM.java with jdk-17+ as openkeystore won't compile.

Fixes up: https://github.com/adoptium/temurin-build/pull/3209

Signed-off-by: Andrew Leonard <anleonar@redhat.com>