### PR TITLE
Dont build openkeystore as breaks builds due to jdk requirement

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -113,7 +113,7 @@
 		            <ant dir="build/openkeystore/library" target="build"/>
         </target>
 
-	      <target name="build" depends="dep-checks, download-cyclonedx, download-jackson-core, download-jackson-dataformat-xml, download-jackson-databind, download-jackson-annotations, download-json-schema, download-commons-codec, download-commons-io, download-github-package-url, build-openkeystore, compile, jar">
+	      <target name="build" depends="dep-checks, download-cyclonedx, download-jackson-core, download-jackson-dataformat-xml, download-jackson-databind, download-jackson-annotations, download-json-schema, download-commons-codec, download-commons-io, download-github-package-url, compile, jar">
                 <echo message="Building cyclonedx-lib"/>
         </target>
 


### PR DESCRIPTION
Backout building of openkeystore, as breaks build due to jdk dependency.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>