### PR TITLE
doc: add EclipseMirror to the end-of-release steps

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -275,6 +275,7 @@ Once the PRs to change those files have been merged, the [adoptium-packages-linu
 
 - Via slack on the Adoptium #release channel
 - Find someone with the appropriate authority (Carmen, George, Martijn, Shelley, Stewart, Tim) to post a tweet about the new release from the Adoptium twitter account
+- Also run the EclipseMirror job in the Eclipse jenkins instance to create a backup of the release from GitHub onto the Eclipse servers.
 
 ### Post Release Tasks
 


### PR DESCRIPTION
Add steps to post to our mirror of the github releases as a backup so we have all of our released artefacts in multiple locations.

Signed-off-by: Stewart X Addison <sxa@redhat.com>