### PR TITLE
Build OpenJ9 Windows jdk19+ with VS2022, and disable ccache

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -157,13 +157,12 @@ then
   then
     export HAS_AUTOCONF=1
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar"
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
       export INCLUDE="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;$INCLUDE"
       export PATH="$PATH:/c/cygwin64/bin"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
       TOOLCHAIN_VERSION="2017"
     elif [ "${JAVA_TO_BUILD}" == "${JDK9_VERSION}" ]
@@ -173,9 +172,13 @@ then
     elif [ "${JAVA_TO_BUILD}" == "${JDK10_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
-    elif [ "$JAVA_FEATURE_VERSION" -ge 11 ]
+    elif [ "$JAVA_FEATURE_VERSION" -lt 19 ]
     then
       TOOLCHAIN_VERSION="2019"
+      export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+    elif [ "$JAVA_FEATURE_VERSION" -ge 19 ]
+    then
+      TOOLCHAIN_VERSION="2022"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
     fi
 


### PR DESCRIPTION
OpenJ9 was missing the change to disable ccache for all versions.

Issue https://github.com/eclipse-openj9/openj9/issues/16701