### PR TITLE
Move cyclonedx java library dependencies to 7.3.2 dep versions

### DIFF
--- a/.github/workflows/testsbom.yml
+++ b/.github/workflows/testsbom.yml
@@ -10,7 +10,7 @@ on:
 
 # Cancel existing runs if user makes another push.
 concurrency:
-  group: "${{ github.ref }}"
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -21,14 +21,14 @@
 -->
 
         <!-- Dependency versions -->
-        <property name="cyclonedx-core-java-version" value="7.1.4"/>
-        <property name="jackson-core-version" value="2.13.3"/>
-        <property name="jackson-annotations-version" value="2.13.3"/>
-        <property name="jackson-databind-version" value="2.13.3"/>
-        <property name="json-schema-version" value="1.0.58"/>
+        <property name="cyclonedx-core-java-version" value="7.3.2"/>
+        <property name="jackson-core-version" value="2.14.2"/>
+        <property name="jackson-annotations-version" value="2.14.2"/>
+        <property name="jackson-databind-version" value="2.14.2"/>
+        <property name="json-schema-version" value="1.0.77"/>
         <property name="commons-codec-version" value="1.15"/>
         <property name="commons-io-version" value="2.11.0"/>
-        <property name="github-package-url-version" value="1.4.0"/>
+        <property name="github-package-url-version" value="1.4.1"/>
 
         <!-- classpath for running application -->
         <property name="classpath" value="build/jar/temurin-gen-sbom.jar:build/jar/cyclonedx-core-java.jar:build/jar/jackson-core.jar:build/jar/jackson-dataformat-xml.jar:build/jar/jackson-databind.jar:build/jar/jackson-annotations.jar:build/jar/json-schema.jar:build/jar/commons-codec.jar:build/jar/commons-io.jar:build/jar/github-package-url.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar"/>


### PR DESCRIPTION
Bump the cyclone DX core java library dependencies to 7.3.2 and associated dependency versions.
