### PR TITLE
skip ZGC test on Windows aarch64

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
@@ -144,7 +144,9 @@ public class FeatureTests {
             processBuilder.inheritIO();
 
             int retCode = processBuilder.start().waitFor();
-            if (!jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.X64)) {
+            if (!jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.X64)
+                || !jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.AARCH64)
+            ) {
                 if (shouldBePresent) {
                     assertEquals(retCode, 0, "Expected ZGC to be present but it is absent.");
                 } else {


### PR DESCRIPTION
This test should be skipped on Aarch64 (like it is on x64)