### PR TITLE
fix broken logic in smoke test

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
@@ -145,7 +145,7 @@ public class FeatureTests {
 
             int retCode = processBuilder.start().waitFor();
             if (!jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.X64)
-                || !jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.AARCH64)
+                && !jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.AARCH64)
             ) {
                 if (shouldBePresent) {
                     assertEquals(retCode, 0, "Expected ZGC to be present but it is absent.");


### PR DESCRIPTION
had a silly moment

Test run: https://ci.adoptium.net/job/build-scripts/job/jobs/job/evaluation/job/jobs/job/jdk20/job/jdk20-evaluation-windows-aarch64-temurin_SmokeTests/8/