### PR TITLE
AIX: Fix Smoketest to change default JFR check for JDK20

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
@@ -181,6 +181,11 @@ public class FeatureTests {
                 shouldBePresent = true;
             }
         }
+        if (jdkVersion.isNewerOrEqual(20)) {
+            if (jdkPlatform.runsOn(OperatingSystem.AIX)) {
+                shouldBePresent = true;
+            }
+        }
         LOGGER.info(String.format("Detected %s on %s, expect JFR to be present: %s",
                 jdkVersion, jdkPlatform, shouldBePresent));
         List<String> command = new ArrayList<>();


### PR DESCRIPTION
Alter the existing JFR check for JDK20 on AIX to set JFR present to "True"

Successful trial run inside my fork/branch

https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk20/job/jdk20-aix-ppc64-temurin_SmokeTests/37/