### PR TITLE
Add configuration for jdk8u, jdk11u, and jdk17u on riscv64

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -77,6 +77,13 @@ doAnyBuildVariantOverrides() {
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_SAP}" ]]; then
     local branch="sapmachine10"
     BUILD_CONFIG[BRANCH]=${branch:-${BUILD_CONFIG[BRANCH]}}
+  elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
+    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK17_VERSION}" ]; then
+      local branch="riscv-port"
+      BUILD_CONFIG[BRANCH]=${branch:-${BUILD_CONFIG[BRANCH]}}
+    fi
   fi
 }
 
@@ -179,6 +186,14 @@ setRepository() {
     suffix="openjdk/aarch32-port-jdk8u";
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [[ "${BUILD_CONFIG[OS_FULL_VERSION]}" == *"Alpine"* ]] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/alpine-jdk8u";
+  elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
+    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK17_VERSION}" ]; then
+      suffix="openjdk/riscv-port-${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
+    else
+      suffix="openjdk/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
+    fi
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
   else

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -78,9 +78,9 @@ doAnyBuildVariantOverrides() {
     local branch="sapmachine10"
     BUILD_CONFIG[BRANCH]=${branch:-${BUILD_CONFIG[BRANCH]}}
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
-    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_VERSION}" ] \
-      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_VERSION}" ] \
-      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK17_VERSION}" ]; then
+    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_CORE_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK17_CORE_VERSION}" ]; then
       local branch="riscv-port"
       BUILD_CONFIG[BRANCH]=${branch:-${BUILD_CONFIG[BRANCH]}}
     fi
@@ -187,10 +187,10 @@ setRepository() {
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [[ "${BUILD_CONFIG[OS_FULL_VERSION]}" == *"Alpine"* ]] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/alpine-jdk8u";
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
-    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_VERSION}" ] \
-      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_VERSION}" ] \
-      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK17_VERSION}" ]; then
-      suffix="openjdk/riscv-port-${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
+    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_CORE_VERSION}" ] \
+      || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK17_CORE_VERSION}" ]; then
+      suffix="openjdk/riscv-port-${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
     else
       suffix="openjdk/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
     fi


### PR DESCRIPTION
The backports of Linux/RISC-V to JDK 8, 11, and 17 are in progress. To get a head's start on building and testing these backports, we want to special-case these repositories.