### PR TITLE
Reproducible build comparison tooling

### DIFF
--- a/tooling/linux_repro_build_compare.sh
+++ b/tooling/linux_repro_build_compare.sh
@@ -139,6 +139,7 @@ if diff -r "jdk-${TEMURIN_VERSION}" "compare.$$/jdk-$TEMURIN_VERSION" 2>&1 > "re
     echo "Compare identical !"
     exit 0
 else
+    cat "reprotest.$(uname).$TEMURIN_VERSION.diff"
     echo "Differences found..., logged in: reprotest.$(uname).$TEMURIN_VERSION.diff"
     exit 1
 fi

--- a/tooling/linux_repro_build_compare.sh
+++ b/tooling/linux_repro_build_compare.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# This script examines the given SBOM metadata file, and then builds the exact same binary
+# and then compares with the Temurin JDK for the same build version, or the optionally supplied TARBALL_URL.
+
+set -e
+
+[ $# -lt 1 ] && echo "Usage: $0 SBOM_URL TARBALL_URL" && exit 1
+SBOM_URL=$1
+TARBALL_URL=$2
+ANT_VERSION=1.10.5
+ANT_CONTRIB_VERSION=1.0b3
+
+installPrereqs() {
+  if test -r /etc/redhat-release; then
+    yum install -y gcc gcc-c++ make autoconf unzip zip alsa-lib-devel cups-devel libXtst-devel libXt-devel libXrender-devel libXrandr-devel libXi-devel
+    yum install -y file fontconfig fontconfig-devel systemtap-sdt-devel # Not included above ...
+    yum install -y git bzip2 xz openssl pigz which # pigz/which not strictly needed but help in final compression
+    if grep -i release.6 /etc/redhat-release; then
+      if [ ! -r /usr/local/bin/autoconf ]; then
+        curl https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz | tar xpfz - || exit 1
+        (cd autoconf-2.69 && ./configure --prefix=/usr/local && make install)
+      fi
+    fi
+  fi
+}
+
+# ant required for --create-sbom
+downloadAnt() {
+  if [ ! -r /usr/local/apache-ant-${ANT_VERSION}/bin/ant ]; then
+    echo Downloading ant for SBOM creation:
+    curl https://archive.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.zip > /tmp/apache-ant-${ANT_VERSION}-bin.zip
+    (cd /usr/local && unzip -qn /tmp/apache-ant-${ANT_VERSION}-bin.zip)
+    rm /tmp/apache-ant-${ANT_VERSION}-bin.zip
+    echo Downloading ant-contrib-${ANT_CONTRIB_VERSION}:
+    curl -L https://sourceforge.net/projects/ant-contrib/files/ant-contrib/${ANT_CONTRIB_VERSION}/ant-contrib-${ANT_CONTRIB_VERSION}-bin.zip > /tmp/ant-contrib-${ANT_CONTRIB_VERSION}-bin.zip
+    (unzip -qnj /tmp/ant-contrib-${ANT_CONTRIB_VERSION}-bin.zip ant-contrib/ant-contrib-${ANT_CONTRIB_VERSION}.jar -d /usr/local/apache-ant-${ANT_VERSION}/lib)
+    rm /tmp/ant-contrib-${ANT_CONTRIB_VERSION}-bin.zip
+  fi
+}
+
+# get the TEMURIN_VERSION form the SBOM metadata
+getTemurinVersion() {
+  TEMVER_MAJOR=$(grep '"major":' "$SBOM" | tr -d ' ,' | cut -d':' -f2)
+  TEMVER_MINOR=$(grep '"minor":' "$SBOM" | tr -d ' ,' | cut -d':' -f2)
+  TEMVER_SECURITY=$(grep '"security":' "$SBOM" | tr -d ' ,' | cut -d':' -f2)
+  TEMVER_BUILD=$(grep '"build":' "$SBOM" | tr -d ' ,' | cut -d':' -f2)
+
+  TEMURIN_VERSION="$TEMVER_MAJOR"
+  if [ "$TEMVER_SECURITY" != "0" ]; then
+    TEMURIN_VERSION="$TEMURIN_VERSION.$TEMVER_MINOR.$TEMVER_SECURITY"
+  fi
+  TEMURIN_VERSION="$TEMURIN_VERSION+$TEMVER_BUILD"
+}
+
+setEnvironment() {
+  export CC="${LOCALGCCDIR}/bin/gcc-${GCCVERSION}"
+  export CXX="${LOCALGCCDIR}/bin/g++-${GCCVERSION}"
+  export LD_LIBRARY_PATH="${LOCALGCCDIR}/lib64"
+  # /usr/local/bin required to pick up the new autoconf if required
+  export PATH="${LOCALGCCDIR}/bin:/usr/local/bin:/usr/bin:$PATH:/usr/local/apache-ant-${ANT_VERSION}/bin"
+  ls -ld "$CC" "$CXX" "/usr/lib/jvm/jdk-${BOOTJDK_VERSION}/bin/javac" || exit 1
+}
+
+cleanBuildInfo() {
+  # BUILD_INFO name of OS level build was built on will likely differ
+  sed -i '/^BUILD_INFO=.*$/d' "jdk-${TEMURIN_VERSION}/release"
+  sed -i '/^BUILD_INFO=.*$/d' "compare.$$/jdk-${TEMURIN_VERSION}/release"
+}
+
+downloadTooling() {
+  if [ ! -r "/usr/lib/jvm/jdk-${BOOTJDK_VERSION}/bin/javac" ]; then
+    echo "Retrieving boot JDK $BOOTJDK_VERSION" && mkdir -p /usr/lib/jvm && curl -L "https://api.adoptopenjdk.net/v3/binary/version/jdk-${BOOTJDK_VERSION}/linux/${NATIVE_API_ARCH}/jdk/hotspot/normal/adoptopenjdk?project=jdk" | (cd /usr/lib/jvm && tar xpzf -)
+  fi
+  if [ ! -r "${LOCALGCCDIR}/bin/g++-${GCCVERSION}" ]; then
+    echo "Retrieving gcc $GCCVERSION" && curl "https://ci.adoptium.net/userContent/gcc/gcc$(echo "$GCCVERSION" | tr -d .).$(uname -m).tar.xz" | (cd /usr/local && tar xJpf -) || exit 1
+  fi
+  if [ ! -r temurin-build ]; then
+    git clone https://github.com/adoptium/temurin-build || exit 1
+  fi
+  (cd temurin-build && git checkout "$TEMURIN_BUILD_SHA")
+}
+
+checkAllVariablesSet() {
+    [ -z "$SBOM" ] || [ -z "${BOOTJDK_VERSION}" ] || [ -z "${TEMURIN_BUILD_SHA}" ] || [ -z "${TEMURIN_BUILD_ARGS}" ] || [ -z "${TEMURIN_VERSION}" ] && echo "Could not determine one of the variables - run with sh -x to diagnose" && sleep 10 && exit 1
+}
+
+installPrereqs
+downloadAnt
+
+echo "Retrieving and parsing SBOM from $SBOM_URL"
+curl -LO "$SBOM_URL"
+SBOM=$(basename "$SBOM_URL")
+BOOTJDK_VERSION=$(grep configure_arguments "$SBOM" | tr ' ' \\n | grep ^Temurin- | uniq | cut -d- -f2)
+GCCVERSION=$(tr ' ' \\n < "$SBOM" | grep CC= | cut -d- -f2 | cut -d\\ -f1)
+LOCALGCCDIR=/usr/local/gcc$(echo "$GCCVERSION" | cut -d. -f1)
+TEMURIN_BUILD_SHA=$(awk -F'"' '/buildRef/{print$4}' "$SBOM"  | cut -d/ -f7)
+TEMURIN_BUILD_ARGS=$(grep makejdk_any_platform_args "$SBOM" | cut -d\" -f4 | sed -e "s/--disable-warnings-as-errors --enable-dtrace --without-version-pre --without-version-opt/'--disable-warnings-as-errors --enable-dtrace --without-version-pre --without-version-opt'/" -e "s/ --disable-warnings-as-errors --enable-dtrace/ '--disable-warnings-as-errors --enable-dtrace'/" -e 's/\\n//g' -e "s,--jdk-boot-dir [^ ]*,--jdk-boot-dir /usr/lib/jvm/jdk-$BOOTJDK_VERSION,g")
+
+getTemurinVersion
+
+NATIVE_API_ARCH=$(uname -m)
+if [ "${NATIVE_API_ARCH}" = "x86_64" ]; then NATIVE_API_ARCH=x64; fi
+if [ "${NATIVE_API_ARCH}" = "armv7l" ]; then NATIVE_API_ARCH=arm; fi
+
+checkAllVariablesSet
+
+downloadTooling
+setEnvironment
+
+if [ ! -d "jdk-${TEMURIN_VERSION}" ]; then
+   if [ -z "$TARBALL_URL" ]; then
+       TARBALL_URL="https://api.adoptopenjdk.net/v3/binary/version/jdk-${TEMURIN_VERSION}/linux/${NATIVE_API_ARCH}/jdk/hotspot/normal/adoptopenjdk?project=jdk"
+   fi
+   echo Retrieving original tarball from adoptium.net && curl -L "$TARBALL_URL" | tar xpfz - && ls -lart "$PWD/jdk-${TEMURIN_VERSION}" || exit 1
+fi
+
+echo "  cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS 2>&1 | tee build.$$.log" | sh
+
+echo Comparing ...
+mkdir compare.$$
+tar xpfz temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz -C compare.$$
+
+cleanBuildInfo
+
+diff -r "jdk-${TEMURIN_VERSION}" "compare.$$/jdk-$TEMURIN_VERSION" 2>&1 | tee "reprotest.$(uname).$TEMURIN_VERSION.diff"
+if [ "$(wc -l < "reprotest.$(uname).$TEMURIN_VERSION.diff")" -gt 0 ]; then
+    echo "Differences found..., logged in: reprotest.$(uname).$TEMURIN_VERSION.diff"
+    exit 1
+else
+    echo "Compare identical !"
+    exit 0
+fi
+

--- a/tooling/linux_repro_build_compare.sh
+++ b/tooling/linux_repro_build_compare.sh
@@ -135,12 +135,11 @@ tar xpfz temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz -C compare.$$
 
 cleanBuildInfo
 
-diff -r "jdk-${TEMURIN_VERSION}" "compare.$$/jdk-$TEMURIN_VERSION" 2>&1 | tee "reprotest.$(uname).$TEMURIN_VERSION.diff"
-if [ "$(wc -l < "reprotest.$(uname).$TEMURIN_VERSION.diff")" -gt 0 ]; then
-    echo "Differences found..., logged in: reprotest.$(uname).$TEMURIN_VERSION.diff"
-    exit 1
-else
+if diff -r "jdk-${TEMURIN_VERSION}" "compare.$$/jdk-$TEMURIN_VERSION" 2>&1 > "reprotest.$(uname).$TEMURIN_VERSION.diff"; then
     echo "Compare identical !"
     exit 0
+else
+    echo "Differences found..., logged in: reprotest.$(uname).$TEMURIN_VERSION.diff"
+    exit 1
 fi
 

--- a/tooling/linux_repro_compare.sh
+++ b/tooling/linux_repro_compare.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+BLD_TYPE1="$1"
+JDK_DIR1="$2"
+BLD_TYPE2="$3"
+JDK_DIR2="$4"
+
+cleanTemurinFiles() {
+  DIR=$1
+
+  echo "Removing Temurin NOTICE file from $DIR"
+  rm "${DIR}"/NOTICE
+
+  echo "Removing Temurin specific lines from release file in $DIR"
+  sed -i '/^BUILD_SOURCE=.*$/d' "${DIR}/release"
+  sed -i '/^BUILD_SOURCE_REPO=.*$/d' "${DIR}/release"
+  sed -i '/^SOURCE_REPO=.*$/d' "${DIR}/release"
+  sed -i '/^FULL_VERSION=.*$/d' "${DIR}/release"
+  sed -i '/^SEMANTIC_VERSION=.*$/d' "${DIR}/release"
+  sed -i '/^BUILD_INFO=.*$/d' "${DIR}/release"
+  sed -i '/^JVM_VARIANT=.*$/d' "${DIR}/release"
+  sed -i '/^JVM_VERSION=.*$/d' "${DIR}/release"
+  sed -i '/^IMAGE_TYPE=.*$/d' "${DIR}/release"
+
+  echo "Removing JDK image files not shipped by Temurin(*.pdb, *.pdb, demo) in $DIR"
+  find "${DIR}" -type f -name "*.pdb" -delete
+  find "${DIR}" -type f -name "*.map" -delete
+  rm -rf "${DIR}/demo"
+}
+
+if [ ! -d "${JDK_DIR1}" ]; then
+  echo "$JDK_DIR1 does not exist"
+  echo "linux_repro_compare.sh (temurin|openjdk) JDK_DIR1 (temurin|openjdk) JDK_DIR2"
+  exit 1
+fi
+
+if [ ! -d "${JDK_DIR2}" ]; then
+  echo "$JDK_DIR2 does not exist"
+  echo "linux_repro_compare.sh (temurin|openjdk) JDK_DIR1 (temurin|openjdk) JDK_DIR2"
+  exit 1
+fi
+
+echo "Pre-processing ${JDK_DIR1}"
+if ! linux_repro_process.sh "${JDK_DIR1}"; then
+  echo "Pre-process of ${JDK_DIR1} failed"
+  exit 1
+fi
+
+echo "Pre-processing ${JDK_DIR2}"
+if ! linux_repro_process.sh "${JDK_DIR2}"; then
+  echo "Pre-process of ${JDK_DIR2} failed"
+  exit 1
+fi
+
+# If comparing a plain openjdk build to a Temurin built one clean Temurin script specific content
+if [ "$BLD_TYPE1" != "$BLD_TYPE2" ]; then
+  cleanTemurinFiles "${JDK_DIR1}"
+  cleanTemurinFiles "${JDK_DIR2}"
+fi
+
+files1=$(find "${JDK_DIR1}" -type f | wc -l)
+
+output="repro_diff.out"
+echo "Comparing ${JDK_DIR1} with ${JDK_DIR2} ... output to file: ${output}"
+diff -r "${JDK_DIR1}" "${JDK_DIR2}" > "${output}"
+rc=$?
+echo "diff rc=${rc}"
+
+num_differences=$(wc -l < "${output}")
+echo "Number of differences: ${num_differences}"
+repro_pc100=$(( (files1-num_differences)*100*100/files1 ))
+value_len=${#repro_pc100}
+if [ "$repro_pc100" == "10000" ]; then
+    repro_pc="100"
+elif [ "$value_len" == "4" ]; then
+    repro_pc=${repro_pc100:0:2}"."${repro_pc100:2:2}
+elif [ "$value_len" == "3" ]; then
+    repro_pc=${repro_pc100:0:1}"."${repro_pc100:1:2}
+else
+    repro_pc="0.${repro_pc100}"
+fi
+echo "ReproduciblePercent = ${repro_pc} %"
+
+exit $rc
+

--- a/tooling/linux_repro_process.sh
+++ b/tooling/linux_repro_process.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -e
+
+JDK_DIR="$1"
+
+if [ ! -d "${JDK_DIR}" ]; then
+  echo "$JDK_DIR does not exist"
+  exit 1
+fi
+
+echo "Expanding the 'modules' Image to compare within.."
+jimage extract --dir "${JDK_DIR}/lib/modules_extracted" "${JDK_DIR}/lib/modules"
+rm "${JDK_DIR}/lib/modules"
+
+echo "Expanding the 'src.zip' to normalize file permissions"
+unzip "${JDK_DIR}/lib/src.zip" -d "${JDK_DIR}/lib/src_zip_expanded"
+rm "${JDK_DIR}/lib/src.zip"
+
+echo "Expanding jmods to compare within"
+FILES=$(find "${JDK_DIR}" -type f -path '*.jmod')
+for f in $FILES
+  do
+    echo "Unzipping $f"
+    base=$(basename "$f")
+    dir=$(dirname "$f")
+    expand_dir="${dir}/expanded_${base}"
+    mkdir -p "${expand_dir}"
+    jmod extract --dir "${expand_dir}" "$f"
+    rm "$f"
+  done
+
+echo "Expanding the 'jrt-fs.jar' to compare within.."
+mkdir "${JDK_DIR}/lib/jrt-fs-expanded"
+unzip -d "${JDK_DIR}/lib/jrt-fs-expanded" "${JDK_DIR}/lib/jrt-fs.jar"
+rm "${JDK_DIR}/lib/jrt-fs.jar"
+
+mkdir "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded"
+unzip -d "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded" "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs.jar"
+rm "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs.jar"
+
+echo "Removing jrt-fs.jar MANIFEST.MF BootJDK vendor string lines"
+sed -i '/^Implementation-Vendor:.*$/d' "${JDK_DIR}/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+sed -i '/^Created-By:.*$/d' "${JDK_DIR}/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+sed -i '/^Implementation-Vendor:.*$/d' "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+sed -i '/^Created-By:.*$/d' "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+
+echo "***********"
+echo "SUCCESS :-)"
+echo "***********"
+

--- a/tooling/windows_build_as_temurin.sh
+++ b/tooling/windows_build_as_temurin.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -e
+
+# This script demonstrates how to build an identical Windows Temurin binary without directly using temurin-build scripts
+# for the purpose of trusted reproducible build validation.
+
+TSTAMP=$1
+BOOTJDK_HOME=$2
+VCTOOLS=$3
+TAG=$4
+
+if [ -z "$TAG" ]; then
+    echo "Syntax: windows_build_as_temurin.sh <ISO8601_timestamp> <BootJDK_Home> <VC Tools directory> <Tag being built>"
+    echo "  eg: windows_build_as_temurin.sh 2023-03-20T09:06:00Z /cygdrive/c/workspace/jdk-19.0.2+7 /cygdrive/d/VS2019/VC/Tools jdk-20+36"
+    exit 1
+fi
+
+echo "Checking out tag $TAG..."
+if ! git checkout "$TAG"; then
+  echo "Failed to checkout tag $TAG"
+  exit 1
+fi
+
+TSTAMP_ID=${TSTAMP:0:4}${TSTAMP:5:2}${TSTAMP:8:2}${TSTAMP:11:2}${TSTAMP:14:2}
+VER_FULL=$(echo "$TAG" | cut -d'-' -f2)
+BLD=$(echo "$VER_FULL" | cut -d'+' -f2)
+
+echo "Performing configure as Temurin..."
+configStr="bash ./configure --verbose  --with-vendor-name=\"Eclipse Adoptium\" --with-vendor-url=https://adoptium.net/ --with-vendor-bug-url=https://github.com/adoptium/adoptium-support/issues --with-vendor-vm-bug-url=https://github.com/adoptium/adoptium-support/issues --with-version-opt=${TSTAMP_ID} --with-version-pre=beta --with-version-build=${BLD} --with-vendor-version-string=Temurin-${VER_FULL}-${TSTAMP_ID} --with-boot-jdk=${BOOTJDK_HOME} --with-debug-level=release --with-native-debug-symbols=external --with-source-date=${TSTAMP} --with-hotspot-build-time=${TSTAMP} --with-build-user=temurin --with-jvm-variants=server --disable-warnings-as-errors --disable-ccache --with-toolchain-version=2019 --with-tools-dir=${VCTOOLS}  --with-freetype=bundled"
+echo "${configStr}"
+eval "${configStr}"
+
+echo "Building as Temurin..."
+make product-images legacy-jre-image test-image static-libs-image
+

--- a/tooling/windows_repro_compare.sh
+++ b/tooling/windows_repro_compare.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+BLD_TYPE1="$1"
+JDK_DIR1="$2"
+BLD_TYPE2="$3"
+JDK_DIR2="$4"
+SELF_CERT_FILE="$5"
+SELF_CERT_PASS="$6"
+
+cleanTemurinFiles() {
+  DIR=$1
+
+  echo "Removing Temurin NOTICE file from $DIR"
+  rm "${DIR}"/NOTICE
+
+  echo "Removing Temurin specific lines from release file in $DIR"
+  sed -i '/^BUILD_SOURCE=.*$/d' "${DIR}/release"
+  sed -i '/^BUILD_SOURCE_REPO=.*$/d' "${DIR}/release"
+  sed -i '/^SOURCE_REPO=.*$/d' "${DIR}/release"
+  sed -i '/^FULL_VERSION=.*$/d' "${DIR}/release"
+  sed -i '/^SEMANTIC_VERSION=.*$/d' "${DIR}/release"
+  sed -i '/^BUILD_INFO=.*$/d' "${DIR}/release"
+  sed -i '/^JVM_VARIANT=.*$/d' "${DIR}/release"
+  sed -i '/^JVM_VERSION=.*$/d' "${DIR}/release"
+  sed -i '/^IMAGE_TYPE=.*$/d' "${DIR}/release"
+
+  echo "Removing JDK image files not shipped by Temurin(*.pdb, *.pdb, demo) in $DIR"
+  find "${DIR}" -type f -name "*.pdb" -delete
+  find "${DIR}" -type f -name "*.map" -delete
+  rm -rf "${DIR}/demo"
+}
+
+echo "Pre-processing ${JDK_DIR1}"
+if ! windows_repro_process.sh "${JDK_DIR1}" "${SELF_CERT_FILE}" "${SELF_CERT_PASS}"; then
+  echo "Pre-process of ${JDK_DIR1} failed"
+  exit 1
+fi
+
+echo "Pre-processing ${JDK_DIR2}"
+if ! windows_repro_process.sh "${JDK_DIR2}" "${SELF_CERT_FILE}" "${SELF_CERT_PASS}"; then
+  echo "Pre-process of ${JDK_DIR2} failed"
+  exit 1
+fi
+
+# If comparing a plain openjdk build to a Temurin built one clean Temurin script specific content
+if [ "$BLD_TYPE1" != "$BLD_TYPE2" ]; then
+  cleanTemurinFiles "${JDK_DIR1}"
+  cleanTemurinFiles "${JDK_DIR2}"
+fi
+
+files1=$(find "${JDK_DIR1}" -type f | wc -l)
+files2=$(find "${JDK_DIR2}" -type f | wc -l)
+
+output="repro_diff.out"
+echo "Comparing ${JDK_DIR1} with ${JDK_DIR2} ... output to file: ${output}"
+diff -r "${JDK_DIR1}" "${JDK_DIR2}" > "${output}"
+rc=$?
+echo "diff rc=${rc}"
+
+num_differences=$(wc -l < "${output}")
+echo "Number of differences: ${num_differences}"
+repro_pc100=$(( (files1-num_differences)*100*100/files1 ))
+value_len=${#repro_pc100}
+if [ "$repro_pc100" == "10000" ]; then
+    repro_pc="100"
+elif [ "$value_len" == "4" ]; then
+    repro_pc=${repro_pc100:0:2}"."${repro_pc100:2:2}
+elif [ "$value_len" == "3" ]; then
+    repro_pc=${repro_pc100:0:1}"."${repro_pc100:1:2}
+else
+    repro_pc="0.${repro_pc100}"
+fi
+echo "ReproduciblePercent = ${repro_pc} %"
+
+exit $rc
+

--- a/tooling/windows_repro_process.sh
+++ b/tooling/windows_repro_process.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -e
+
+JDK_DIR="$1"
+SELF_CERT_FILE="$2"
+SELF_CERT_PASS="$3"
+
+removeSignatures() {
+  echo "Removing Signatures from ${JDK_DIR}"
+  FILES=$(find "${JDK_DIR}" -type f -path '*.exe' && find "${JDK_DIR}" -type f -path '*.dll')
+  for f in $FILES
+    do
+      echo "Removing signature from $f"
+      if signtool remove /s $f ; then
+        echo "  ==> Successfully removed signature from $f"
+      else
+        echo "  ==> $f contains no signature"
+      fi
+    done
+  echo "Successfully removed all Signatures from ${JDK_DIR}"
+}
+
+# This script unpacks the JDK_DIR and removes windows signing Signatures in a neutral way
+# ensuring identical output once Signature is removed.
+
+if [[ ! -d "${JDK_DIR}" ]] || [[ ! -d "${JDK_DIR}/bin"  ]]; then
+  echo "$JDK_DIR does not exist or does not point at a JDK"
+  exit 1
+fi
+
+echo "Expanding the 'modules' Image to remove signatures from within.."
+jimage extract --dir "${JDK_DIR}/lib/modules_extracted" "${JDK_DIR}/lib/modules"
+rm ${JDK_DIR}/lib/modules
+
+echo "Expanding the 'src.zip' to normalize file permissions"
+unzip ${JDK_DIR}/lib/src.zip -d ${JDK_DIR}/lib/src_zip_expanded
+rm ${JDK_DIR}/lib/src.zip
+
+echo "Expanding jmods to process exe/dll within"
+FILES=$(find "${JDK_DIR}" -type f -path '*.jmod')
+for f in $FILES
+  do
+    echo "Unzipping $f"
+    base=$(basename $f)
+    dir=$(dirname $f)
+    expand_dir="${dir}/expanded_${base}"
+    mkdir -p "${expand_dir}"
+    jmod extract --dir "${expand_dir}" "$f"
+    rm "$f"
+  done
+
+echo "Expanding the 'jrt-fs.jar' to remove signatures from within.."
+mkdir ${JDK_DIR}/lib/jrt-fs-expanded
+unzip -d ${JDK_DIR}/lib/jrt-fs-expanded ${JDK_DIR}/lib/jrt-fs.jar
+rm ${JDK_DIR}/lib/jrt-fs.jar
+
+mkdir ${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded
+unzip -d ${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded ${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs.jar
+rm ${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs.jar
+
+# Remove existing signature
+removeSignatures
+
+# Add the SELF_SIGN temporary signature
+echo "Adding SELF_SIGN Signatures for ${JDK_DIR}"
+FILES=$(find "${JDK_DIR}" -type f -path '*.exe' && find "${JDK_DIR}" -type f -path '*.dll')
+for f in $FILES
+  do
+    echo "Signing $f"
+    if signtool sign /f $SELF_CERT_FILE /p $SELF_CERT_PASS $f ; then
+        echo "  ==> Successfully signed $f"
+    else
+        echo "  ==> $f failed to be signed!!"
+        exit 1
+    fi
+  done
+
+echo "Successfully SELF_CERT signed all Signatures in ${JDK_DIR}"
+
+# Remove temporary SELF_SIGN signature, which will then normalize binary length
+removeSignatures
+
+echo "Removing jrt-fs.jar MANIFEST.MF BootJDK vendor string lines"
+sed -i '/^Implementation-Vendor:.*$/d' "${JDK_DIR}/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+sed -i '/^Created-By:.*$/d' "${JDK_DIR}/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+sed -i '/^Implementation-Vendor:.*$/d' "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+sed -i '/^Created-By:.*$/d' "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded/META-INF/MANIFEST.MF"
+
+echo "Removing SOURCE= from ${JDK_DIR}/release file, as Temurin builds from mirror _adopt tag"
+sed -i '/^SOURCE=.*$/d' "${JDK_DIR}/release"
+
+echo "Removing cacerts file, as Temurin builds with different Mozilla cacerts"
+find "${JDK_DIR}" -type f -name "cacerts" -delete
+
+echo "***********"
+echo "SUCCESS :-)"
+echo "***********"
+


### PR DESCRIPTION
A handful of reproducible build helper scripts, for:
- linux_repro_build_compare.sh : Build the selected JDK by SBOM metadata, and perform compare
- linux_repro_compare.sh : Compares two linux builds
- linux_repro_process.sh : Neutrallzing script for pre-processing a linux JDK for compare
- windows_repro_compare.sh : Compares two windows builds
- windows_repro_process.sh : Windows JDK binary Signature neutrallzing script for pre-processing a Windows JDK for compare
- windows_build_as_temurin.sh : Example script of building a trusted upstream openjdk as Temurin for the purpose of trusted comparison