### PR TITLE
Make build timestamp changes work on Solaris

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -282,7 +282,7 @@ configureVersionStringParameter() {
 
   # Convert ISO-8601 buildTimestamp string to dateSuffix format: %Y%m%d%H%M
   # "%Y-%m-%d %H:%M:%S" to "%Y%m%d%H%M"
-  local dateSuffix=$(echo "${buildTimestamp}" | cut -d":" -f1-2 | tr -d "\-: ")
+  local dateSuffix=$(echo "${buildTimestamp}" | cut -d":" -f1-2 | tr -d ":- ")
 
   # Configures "vendor" jdk properties.
   # Temurin default values are set after this code block

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -282,7 +282,7 @@ configureVersionStringParameter() {
 
   # Convert ISO-8601 buildTimestamp string to dateSuffix format: %Y%m%d%H%M
   # "%Y-%m-%d %H:%M:%S" to "%Y%m%d%H%M"
-  local dateSuffix=$(echo "${buildTimestamp}" | cut -d":" -f1-2 | tr -d ":- ")
+  local dateSuffix=$(echo "${buildTimestamp}" | cut -d":" -f1-2 | tr -d ": -")
 
   # Configures "vendor" jdk properties.
   # Temurin default values are set after this code block

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -276,11 +276,7 @@ configureVersionStringParameter() {
     buildTimestamp="${buildTimestamp//Z/}"
   else
     # Get current ISO-8601 datetime
-    if isGnuCompatDate; then
-      buildTimestamp=$(date --utc +"%Y-%m-%d %H:%M:%S")
-    else
-      buildTimestamp=$(date -u +"%Y-%m-%d %H:%M:%S") 
-    fi
+    buildTimestamp=$(date -u +"%Y-%m-%d %H:%M:%S") 
   fi
   BUILD_CONFIG[BUILD_TIMESTAMP]="${buildTimestamp}"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -279,18 +279,14 @@ configureVersionStringParameter() {
     if isGnuCompatDate; then
       buildTimestamp=$(date --utc +"%Y-%m-%d %H:%M:%S")
     else
-      buildTimestamp=$(date -u -j +"%Y-%m-%d %H:%M:%S") 
+      buildTimestamp=$(date -u +"%Y-%m-%d %H:%M:%S") 
     fi
   fi
   BUILD_CONFIG[BUILD_TIMESTAMP]="${buildTimestamp}"
 
   # Convert ISO-8601 buildTimestamp string to dateSuffix format: %Y%m%d%H%M
-  local dateSuffix
-  if isGnuCompatDate; then
-    dateSuffix=$(date --utc --date="${buildTimestamp}" +"%Y%m%d%H%M")
-  else
-    dateSuffix=$(date -u -j -f "%Y-%m-%d %H:%M:%S" "${buildTimestamp}" +"%Y%m%d%H%M")
-  fi
+  # "%Y-%m-%d %H:%M:%S" to "%Y%m%d%H%M"
+  local dateSuffix=$(echo "${buildTimestamp}" | cut -d":" -f1-2 | tr -d "\-: ")
 
   # Configures "vendor" jdk properties.
   # Temurin default values are set after this code block


### PR DESCRIPTION
Recent reproducible build/SBOM [change](https://github.com/adoptium/temurin-build/pull/3313) broke jdk8 Solaris due to date tool formating:
```
14:29:37  date: illegal option -- j
14:29:37  usage:	date [-u] mmddHHMM[[cc]yy][.SS]
14:29:37  	date [-u] [+format]
14:29:37  	date -a [-]sss[.fff]
```

Changed date formating to use simple bash cmds.

Tests on Solaris:
Current date:
```
-bash-3.2$ date -u +"%Y-%m-%d %H:%M:%S"
2023-04-13 15:37:02
```
Conversion:
```
-bash-3.2$ echo "2023-04-13 15:31:01" | cut -d":" -f1-2 | tr -d "\-: "
202304131531
```

Test Solaris non-release build to show timestamp: https://ci.adoptium.net/job/build-scripts/job/jobs/job/release/job/jobs/job/jdk8u/job/jdk8u-release-solaris-x64-temurin/6/console
```
user-release-suffix=202304131550
```
