### PR TITLE
Set --with-version-opt=LTS for LTS versions from jdk-21

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -389,8 +389,8 @@ configureVersionStringParameter() {
       addConfigureArg "--with-version-opt=" "${dateSuffix}"
       addConfigureArg "--with-version-pre=" "beta"
     else
-      # "LTS" builds (every 2 years) from jdk-21 will use "LTS" version opt
-      if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 21 ]] && [[ $(((BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]-21) % 4)) == 0 ]]; then
+      # "LTS" builds from jdk-21 will use "LTS" version opt
+      if isFromJdk21LTS; then
           addConfigureArg "--with-version-opt=" "LTS"
       else
           addConfigureArg "--without-version-opt" ""

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -389,7 +389,12 @@ configureVersionStringParameter() {
       addConfigureArg "--with-version-opt=" "${dateSuffix}"
       addConfigureArg "--with-version-pre=" "beta"
     else
-      addConfigureArg "--without-version-opt" ""
+      # "LTS" builds (every 2 years) from jdk-21 will use "LTS" version opt
+      if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 21 ]] && [[ $(((BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]-21) % 4)) == 0 ]]; then
+          addConfigureArg "--with-version-opt=" "LTS"
+      else
+          addConfigureArg "--without-version-opt" ""
+      fi
       addConfigureArg "--without-version-pre" ""
     fi
 

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -224,4 +224,9 @@ function isGnuCompatDate() {
   [ "x${isGnuCompatDate}" != "x" ]
 }
 
+# Returns true if the OPENJDK_FEATURE_NUMBER is an LTS version (every 2 years)
+# from jdk-21 onwards
+function isFromJdk21LTS() {
+  [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 21 ]] && [[ $(((BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]-21) % 4)) == 0 ]]
+}
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3270

Sets --with-version-opt for LTS release builds jdk-21+