### PR TITLE
Make embedded jvm internal build user name unique

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -120,8 +120,8 @@ configureReproducibleBuildParameter() {
           # Use supplied date
           addConfigureArg "--with-hotspot-build-time=" "'${BUILD_CONFIG[BUILD_TIMESTAMP]}'"
       fi
-      # Ensure reproducible binary with a unique build user identifier
-      addConfigureArg "--with-build-user=" "${BUILD_CONFIG[BUILD_VARIANT]}"
+      # Ensure reproducible and comparable binary with a unique build user identifier
+      addConfigureArg "--with-build-user=" "admin"
   fi
 }
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3341
by making the internal binary text for the "build user" unique.
