### PR TITLE
Enable build scripts support for user vendor strings

### DIFF
--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -176,6 +176,18 @@ If true (default), a custom cacerts file will be generated based on Mozilla's
 list of CA certificates (see folder security/). If false, the file shipped by
 OpenJDK will be used. 
 .TP
+.BR \-\-vendor " " \fI<vendor>\fR
+specify the vendor name
+.TP
+.BR \-\-vendor-url " " \fI<vendor url>\fR
+specify the vendor url
+.TP
+.BR \-\-vendor-bug-url " " \fI<vendor bug url>\fR
+specify the vendor bug url
+.TP
+.BR \-\-vendor-vm-bug-url " " \fI<vendor vm bug url>\fR
+specify the vendor vm bug url
+.TP
 .BR \-v ", " \-\-version " " \fI<version>\fR
 specify the OpenJDK version to build e.g. jdk8u.  Left for backwards compatibility.
 .TP

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -354,6 +354,15 @@ function parseConfigurationArguments() {
         "--vendor" | "-ve" )
         BUILD_CONFIG[VENDOR]="$1"; shift;;
 
+        "--vendor-url")
+        BUILD_CONFIG[VENDOR_URL]="$1"; shift;;
+
+        "--vendor-bug-url")
+        BUILD_CONFIG[VENDOR_BUG_URL]="$1"; shift;;
+
+        "--vendor-vm-bug-url")
+        BUILD_CONFIG[VENDOR_VM_BUG_URL]="$1"; shift;;
+
         "--version"  | "-v" )
         setOpenJdkVersion "$1"
         setDockerVolumeSuffix "$1"; shift;;


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3343

Change the ERROR exit policing of the vendor name, to just a WARNING.
And allow setting the vendor-url, vendor-bug-url, vendor-vm-bug-url.
