### PR TITLE
linux.sh: Pull some parts into functions and do GPG signature checks on boot JDK downloads

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -26,6 +26,171 @@ NATIVE_API_ARCH=$(uname -m)
 if [ "${NATIVE_API_ARCH}" = "x86_64" ]; then NATIVE_API_ARCH=x64; fi
 if [ "${NATIVE_API_ARCH}" = "armv7l" ]; then NATIVE_API_ARCH=arm; fi
 
+function locateDragonwell8BootJDK()
+{
+  if [ -d /opt/dragonwell8 ]; then
+    export "${BOOT_JDK_VARIABLE}"=/opt/dragonwell8
+  elif [ -d /usr/lib/jvm/dragonwell8 ]; then
+    export "${BOOT_JDK_VARIABLE}"=/usr/lib/jvm/dragonwell8
+  else
+    echo Dragonwell 8 requires a Dragonwell boot JDK - downloading one ...
+    mkdir -p "$PWD/jdk-8"
+    if [ "$(uname -m)" = "x86_64" ]; then
+      curl -L "https://github.com/alibaba/dragonwell8/releases/download/dragonwell-8.11.12_jdk8u332-ga/Alibaba_Dragonwell_8.11.12_x64_linux.tar.gz" | tar xpzf - --strip-components=1 -C "$PWD/jdk-8"
+    elif [ "$(uname -m)" = "aarch64" ]; then
+      curl -L "https://github.com/alibaba/dragonwell8/releases/download/dragonwell-8.8.9_jdk8u302-ga/Alibaba_Dragonwell_8.8.9_aarch64_linux.tar.gz" | tar xpzf - --strip-components=1 -C "$PWD/jdk-8"
+    else
+      echo "Unknown architecture $(uname -m) for building Dragonwell - cannot download boot JDK"
+      exit 1
+    fi
+    export "${BOOT_JDK_VARIABLE}"="$PWD/jdk-8"
+  fi
+}
+
+function setCrossCompilerEnvironment()
+{
+  if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+    export BUILDJDK=${WORKSPACE:-$PWD}/buildjdk
+    echo "RISCV cross-compilation for OpenJ9 ... Downloading required nightly OpenJ9/${NATIVE_API_ARCH} as build JDK to $BUILDJDK"
+    rm -rf "$BUILDJDK"
+    mkdir "$BUILDJDK"
+    # TOFIX: Switch this back once Semeru has an API to pull the nightly builds.
+    curl -L "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ga/linux/${NATIVE_API_ARCH}/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
+    "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g' || exit 1
+    CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-jdk=$BUILDJDK --disable-ddr"
+    if [ -d /usr/local/openssl102 ]; then
+      CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/usr/local/openssl102"
+    fi
+  elif [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
+    if [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
+      BUILD_CC=/usr/local/gcc/bin/gcc-7.5
+      BUILD_CXX=/usr/local/gcc/bin/g++-7.5
+      BUILD_LIBRARY_PATH=/usr/local/gcc/lib64:/usr/local/gcc/lib
+    fi
+    # Check if BUILD_CXX/BUILD_CC for Bisheng RISC-V exists
+    if [ ! -x "$BUILD_CXX" ]; then
+      echo "Bisheng RISC-V host compiler BUILD_CXX=$BUILD_CXX does not exist on this system - cannot continue"
+      exit 1
+    fi
+  fi
+
+  # RISC-V cross compile settings for all VARIANT values
+  echo RISC-V cross-compilation setup ...  Setting RISCV64, LD_LIBRARY_PATH, PATH, CC, CXX
+  export RISCV64=/opt/riscv_toolchain_linux
+  export LD_LIBRARY_PATH=$RISCV64/lib64
+  if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BUILD_LIBRARY_PATH
+  fi
+
+  if [ -r "$RISCV64/bin/riscv64-unknown-linux-gnu-g++" ]; then
+    export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
+    export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
+    export PATH="$RISCV64/bin:$PATH"
+  elif [ -r /usr/bin/riscv64-linux-gnu-g++ ]; then
+    export CC=/usr/bin/riscv64-linux-gnu-gcc
+    export CXX=/usr/bin/riscv64-linux-gnu-g++
+    # This is required for OpenJ9 if not using "riscv64-unknown-linux-gnu-*"
+    # i.e. if using the default cross compiler supplied with Debian/Ubuntu
+    export RISCV_TOOLCHAIN_TYPE=install
+  fi
+  RISCV_SYSROOT=${RISCV_SYSROOT:-/opt/fedora28_riscv_root}
+  if [ ! -d "${RISCV_SYSROOT}" ]; then
+     echo "RISCV_SYSROOT=${RISCV_SYSROOT} is undefined or does not exist - cannot proceed"
+     exit 1
+  fi
+  CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=${RISCV_SYSROOT} -with-boot-jdk=$JDK_BOOT_DIR"
+
+  # RISC-V cross compilation does not work with OpenJ9's option: --with-openssl=fetched
+  # TODO: This file needs an overhaul as it's getting too long and hard to maintain ...
+  if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+    # shellcheck disable=SC2001
+    CONFIGURE_ARGS_FOR_ANY_PLATFORM=$(echo "$CONFIGURE_ARGS_FOR_ANY_PLATFORM" | sed "s,with-openssl=[^ ]*,with-openssl=${RISCV_SYSROOT}/usr,g")
+    if ! which qemu-riscv64-static; then
+      # don't download it if we already have it from a previous build
+      if [ ! -x "$WORKSPACE/qemu-riscv64-static" ]; then
+        echo Download qemu-riscv64-static as it is required for the OpenJ9 cross build ...
+        curl https://ci.adoptium.net/userContent/riscv/qemu-riscv64-static.xz | xz -d > "$WORKSPACE/qemu-riscv64-static" && \
+        chmod 755 "$WORKSPACE/qemu-riscv64-static"
+      fi
+      export PATH="$PATH:$WORKSPACE" && \
+      qemu-riscv64-static --version
+    fi
+  fi
+
+  if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
+    CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-jvm-features=shenandoahgc BUILD_CC=$BUILD_CC BUILD_CXX=$BUILD_CXX"
+  fi
+  BUILD_ARGS="${BUILD_ARGS} --cross-compile -F"
+  if [ ! -x "$CXX" ]; then
+    echo "RISC-V cross compiler CXX=$CXX does not exist on this system - cannot continue"
+    exit 1
+  fi
+}
+
+function downloadBootJDK()
+{
+  ARCH=$1
+  VER=$2
+  export GNUPGHOME=$PWD/.gnupg-temp
+  mkdir -m 700 -p "$GNUPGHOME"
+  export downloadArch
+  case "$ARCH" in
+     "riscv64") downloadArch="$NATIVE_API_ARCH";;
+             *) downloadArch="$ARCH";;
+  esac
+  releaseType="ga"
+  vendor="eclipse"
+  apiUrlTemplate="https://api.adoptium.net/v3/binary/latest/\${VER}/\${releaseType}/linux/\${downloadArch}/jdk/hotspot/normal/\${vendor}"
+  apiURL=$(eval echo ${apiUrlTemplate})
+  apiSigUrlTemplate="https://api.adoptium.net/v3/assets/feature_releases/\${VER}/\${releaseType}?architecture=\$ARCH&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse"
+  apiSigURL=$(eval echo "${apiSigUrlTemplate}")
+  echo "Downloading GA release of boot JDK version ${VER} from ${apiURL}"
+  # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
+  # the fallback mechanism, as downloading of the GA binary might fail.
+  set +e
+  curl -L -o bootjdk.tar.gz "${apiURL}"
+  if [ $? -eq 0 ]; then
+    curl -L -o bootjdk.tar.gz.sig $(curl -s "${apiSigURL}" | grep signature_link.*-jdk_ | awk '{split($0,a,"\""); print a[4]}' | head -1)
+    gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
+    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
+    gpg --verify bootjdk.tar.gz.sig bootjdk.tar.gz || exit 1
+    mkdir "$bootDir"
+    tar xpzf bootjdk.tar.gz --strip-components=1 -C "$bootDir"
+    set -e
+  else
+    # We must be a JDK HEAD build for which no boot JDK exists other than
+    # nightlies?
+    echo "Downloading GA release of boot JDK version ${VER} failed."
+    # shellcheck disable=SC2034
+    releaseType="ea"
+    # shellcheck disable=SC2034
+    vendor="adoptium"
+    apiURL=$(eval echo ${apiUrlTemplate})
+    apiSigURL=$(eval echo ${apiSigUrlTemplate})
+    echo "Attempting to download EA release of boot JDK version ${VER} from ${apiURL}"
+    set +e
+    curl -L -o bootjdk.tar.gz "${apiURL}"
+    if [ $? -eq 0 ]; then
+      curl -o bootjdk.tar.gz.sig $(curl -s "${apiSigURL}" | grep signature_link | awk '{split($0,a,"\""); print a[4]}')
+      gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
+      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
+      gpg --verify bootjdk.tar.gz.sig bootjdk.tar.gz || exit 1
+      mkdir "$bootDir"
+      tar xpzf bootjdk.tar.gz --strip-components=1 -C "$bootDir"
+    else
+      # If no binaries are available then try from adoptopenjdk
+      echo "Downloading Temurin release of boot JDK version ${VER} failed."
+      # shellcheck disable=SC2034
+      releaseType="ga"
+      # shellcheck disable=SC2034
+      vendor="adoptium"
+      apiURL=$(eval echo ${apiUrlTemplate})
+      echo "Attempting to download GA release of boot JDK version ${VER} from ${apiURL}"
+      curl -L "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
+    fi
+  fi
+}
+
 if [ "${ARCHITECTURE}" == "x64" ]
 then
   export PATH=/opt/rh/devtoolset-2/root/usr/bin:$PATH
@@ -111,23 +276,7 @@ fi
 
 BOOT_JDK_VARIABLE="JDK${JDK_BOOT_VERSION}_BOOT_DIR"
 if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 8 ]; then
-  if [ -d /opt/dragonwell8 ]; then
-    export "${BOOT_JDK_VARIABLE}"=/opt/dragonwell8
-  elif [ -d /usr/lib/jvm/dragonwell8 ]; then
-    export "${BOOT_JDK_VARIABLE}"=/usr/lib/jvm/dragonwell8
-  else
-    echo Dragonwell 8 requires a Dragonwell boot JDK - downloading one ...
-    mkdir -p "$PWD/jdk-8"
-    if [ "$(uname -m)" = "x86_64" ]; then
-      curl -L "https://github.com/alibaba/dragonwell8/releases/download/dragonwell-8.11.12_jdk8u332-ga/Alibaba_Dragonwell_8.11.12_x64_linux.tar.gz" | tar xpzf - --strip-components=1 -C "$PWD/jdk-8"
-    elif [ "$(uname -m)" = "aarch64" ]; then
-      curl -L "https://github.com/alibaba/dragonwell8/releases/download/dragonwell-8.8.9_jdk8u302-ga/Alibaba_Dragonwell_8.8.9_aarch64_linux.tar.gz" | tar xpzf - --strip-components=1 -C "$PWD/jdk-8"
-    else
-      echo "Unknown architecture $(uname -m) for building Dragonwell - cannot download boot JDK"
-      exit 1
-    fi
-    export "${BOOT_JDK_VARIABLE}"="$PWD/jdk-8"
-  fi
+  locateDragonwell8BootJDK
 fi
 
 if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
@@ -142,49 +291,7 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
       # shellcheck disable=SC2140
       export "${BOOT_JDK_VARIABLE}"="/usr/lib/jvm/jdk-${JDK_BOOT_VERSION}"
     elif [ "$JDK_BOOT_VERSION" -ge 8 ]; then # Adoptium has no build pre-8
-      mkdir -p "$bootDir"
-      export downloadArch
-      case "$ARCHITECTURE" in
-         "riscv64") downloadArch="$NATIVE_API_ARCH";;
-                 *) downloadArch="$ARCHITECTURE";;
-      esac
-      releaseType="ga"
-      vendor="eclipse"
-      apiUrlTemplate="https://api.adoptium.net/v3/binary/latest/\${JDK_BOOT_VERSION}/\${releaseType}/linux/\${downloadArch}/jdk/hotspot/normal/\${vendor}"
-      apiURL=$(eval echo ${apiUrlTemplate})
-      echo "Downloading GA release of boot JDK version ${JDK_BOOT_VERSION} from ${apiURL}"
-      # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
-      # the fallback mechanism, as downloading of the GA binary might fail.
-      set +e
-      curl -L "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-      retVal=$?
-      set -e
-      if [ $retVal -ne 0 ]; then
-        # We must be a JDK HEAD build for which no boot JDK exists other than
-        # nightlies?
-        echo "Downloading GA release of boot JDK version ${JDK_BOOT_VERSION} failed."
-        # shellcheck disable=SC2034
-        releaseType="ea"
-        # shellcheck disable=SC2034
-        vendor="adoptium"
-        apiURL=$(eval echo ${apiUrlTemplate})
-        echo "Attempting to download EA release of boot JDK version ${JDK_BOOT_VERSION} from ${apiURL}"
-        set +e
-        curl -L "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        retVal=$?
-        set -e
-        if [ $retVal -ne 0 ]; then
-          # If no binaries are available then try from adoptopenjdk
-          echo "Downloading Temurin release of boot JDK version ${JDK_BOOT_VERSION} failed."
-          # shellcheck disable=SC2034
-          releaseType="ga"
-          # shellcheck disable=SC2034
-          vendor="adoptium"
-          apiURL=$(eval echo ${apiUrlTemplate})
-          echo "Attempting to download GA release of boot JDK version ${JDK_BOOT_VERSION} from ${apiURL}"
-          curl -L "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        fi
-      fi
+      downloadBootJDK "${ARCHITECTURE}" "${JDK_BOOT_VERSION}"
     fi
   fi
 fi
@@ -246,80 +353,5 @@ fi
 
 # Handle cross compilation environment for RISC-V
 if [ "${ARCHITECTURE}" == "riscv64" ] && [ "${NATIVE_API_ARCH}" != "riscv64" ]; then
-  if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
-    export BUILDJDK=${WORKSPACE:-$PWD}/buildjdk
-    echo "RISCV cross-compilation for OpenJ9 ... Downloading required nightly OpenJ9/${NATIVE_API_ARCH} as build JDK to $BUILDJDK"
-    rm -rf "$BUILDJDK"
-    mkdir "$BUILDJDK"
-    # TOFIX: Switch this back once Semeru has an API to pull the nightly builds.
-    curl -L "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ga/linux/${NATIVE_API_ARCH}/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
-    "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g' || exit 1
-    CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-jdk=$BUILDJDK --disable-ddr"
-    if [ -d /usr/local/openssl102 ]; then
-      CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/usr/local/openssl102"
-    fi
-  elif [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
-    if [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
-      BUILD_CC=/usr/local/gcc/bin/gcc-7.5
-      BUILD_CXX=/usr/local/gcc/bin/g++-7.5
-      BUILD_LIBRARY_PATH=/usr/local/gcc/lib64:/usr/local/gcc/lib
-    fi
-    # Check if BUILD_CXX/BUILD_CC for Bisheng RISC-V exists
-    if [ ! -x "$BUILD_CXX" ]; then
-      echo "Bisheng RISC-V host compiler BUILD_CXX=$BUILD_CXX does not exist on this system - cannot continue"
-      exit 1
-    fi
-  fi
-
-  # RISC-V cross compile settings for all VARIANT values
-  echo RISC-V cross-compilation setup ...  Setting RISCV64, LD_LIBRARY_PATH, PATH, CC, CXX
-  export RISCV64=/opt/riscv_toolchain_linux
-  export LD_LIBRARY_PATH=$RISCV64/lib64
-  if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BUILD_LIBRARY_PATH
-  fi
-
-  if [ -r "$RISCV64/bin/riscv64-unknown-linux-gnu-g++" ]; then
-    export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
-    export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
-    export PATH="$RISCV64/bin:$PATH"
-  elif [ -r /usr/bin/riscv64-linux-gnu-g++ ]; then
-    export CC=/usr/bin/riscv64-linux-gnu-gcc
-    export CXX=/usr/bin/riscv64-linux-gnu-g++
-    # This is required for OpenJ9 if not using "riscv64-unknown-linux-gnu-*"
-    # i.e. if using the default cross compiler supplied with Debian/Ubuntu
-    export RISCV_TOOLCHAIN_TYPE=install
-  fi
-  RISCV_SYSROOT=${RISCV_SYSROOT:-/opt/fedora28_riscv_root}
-  if [ ! -d "${RISCV_SYSROOT}" ]; then
-     echo "RISCV_SYSROOT=${RISCV_SYSROOT} is undefined or does not exist - cannot proceed"
-     exit 1
-  fi
-  CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=${RISCV_SYSROOT} -with-boot-jdk=$JDK_BOOT_DIR"
-
-  # RISC-V cross compilation does not work with OpenJ9's option: --with-openssl=fetched
-  # TODO: This file needs an overhaul as it's getting too long and hard to maintain ...
-  if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
-    # shellcheck disable=SC2001
-    CONFIGURE_ARGS_FOR_ANY_PLATFORM=$(echo "$CONFIGURE_ARGS_FOR_ANY_PLATFORM" | sed "s,with-openssl=[^ ]*,with-openssl=${RISCV_SYSROOT}/usr,g")
-    if ! which qemu-riscv64-static; then
-      # don't download it if we already have it from a previous build
-      if [ ! -x "$WORKSPACE/qemu-riscv64-static" ]; then
-        echo Download qemu-riscv64-static as it is required for the OpenJ9 cross build ...
-        curl https://ci.adoptium.net/userContent/riscv/qemu-riscv64-static.xz | xz -d > "$WORKSPACE/qemu-riscv64-static" && \
-        chmod 755 "$WORKSPACE/qemu-riscv64-static"
-      fi
-      export PATH="$PATH:$WORKSPACE" && \
-      qemu-riscv64-static --version
-    fi
-  fi
-
-  if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
-    CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-jvm-features=shenandoahgc BUILD_CC=$BUILD_CC BUILD_CXX=$BUILD_CXX"
-  fi
-  BUILD_ARGS="${BUILD_ARGS} --cross-compile -F"
-  if [ ! -x "$CXX" ]; then
-    echo "RISC-V cross compiler CXX=$CXX does not exist on this system - cannot continue"
-    exit 1
-  fi
+  setCrossCompilerEnvironment
 fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -132,7 +132,7 @@ function downloadBootJDK()
   ARCH=$1
   VER=$2
   export GNUPGHOME=$PWD/.gnupg-temp
-  mkdir -m 700 -p "$GNUPGHOME"
+  mkdir -m 700 "$GNUPGHOME"
   export downloadArch
   case "$ARCH" in
      "riscv64") downloadArch="$NATIVE_API_ARCH";;
@@ -141,16 +141,15 @@ function downloadBootJDK()
   releaseType="ga"
   vendor="eclipse"
   apiUrlTemplate="https://api.adoptium.net/v3/binary/latest/\${VER}/\${releaseType}/linux/\${downloadArch}/jdk/hotspot/normal/\${vendor}"
-  apiURL=$(eval echo ${apiUrlTemplate})
+  apiURL=$(eval echo "${apiUrlTemplate}")
   apiSigUrlTemplate="https://api.adoptium.net/v3/assets/feature_releases/\${VER}/\${releaseType}?architecture=\$ARCH&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse"
   apiSigURL=$(eval echo "${apiSigUrlTemplate}")
   echo "Downloading GA release of boot JDK version ${VER} from ${apiURL}"
   # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
   # the fallback mechanism, as downloading of the GA binary might fail.
   set +e
-  curl -L -o bootjdk.tar.gz "${apiURL}"
-  if [ $? -eq 0 ]; then
-    curl -L -o bootjdk.tar.gz.sig $(curl -s "${apiSigURL}" | grep signature_link.*-jdk_ | awk '{split($0,a,"\""); print a[4]}' | head -1)
+  if curl -L -o bootjdk.tar.gz "${apiURL}"; then
+    curl -L -o bootjdk.tar.gz.sig "$(curl -s "${apiSigURL}" | grep "signature_link.*-jdk_" | awk '{split($0,a,"\""); print a[4]}' | head -1)"
     gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
     echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
     gpg --verify bootjdk.tar.gz.sig bootjdk.tar.gz || exit 1
@@ -166,12 +165,11 @@ function downloadBootJDK()
     # shellcheck disable=SC2034
     vendor="adoptium"
     apiURL=$(eval echo ${apiUrlTemplate})
-    apiSigURL=$(eval echo ${apiSigUrlTemplate})
+    apiSigURL=$(eval echo "${apiSigUrlTemplate}")
     echo "Attempting to download EA release of boot JDK version ${VER} from ${apiURL}"
     set +e
-    curl -L -o bootjdk.tar.gz "${apiURL}"
-    if [ $? -eq 0 ]; then
-      curl -o bootjdk.tar.gz.sig $(curl -s "${apiSigURL}" | grep signature_link | awk '{split($0,a,"\""); print a[4]}')
+    if curl -L -o bootjdk.tar.gz "${apiURL}"; then
+      curl -o bootjdk.tar.gz.sig "$(curl -s "${apiSigURL}" | grep "signature_link.*-jdk_" | awk '{split($0,a,"\""); print a[4]}')"
       gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
       echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
       gpg --verify bootjdk.tar.gz.sig bootjdk.tar.gz || exit 1


### PR DESCRIPTION
Part of https://github.com/adoptium/temurin-build/issues/3096 - we should be verifing the GPG signatures when downloading a boot JDK during the build.

I've also taken this opportunity to split out a couple of large sections into functions which I've wanted to do for some time as it'll make the script easier to read and remove a lot of the stuff that is mostly not important when reading the file from the main flow, however it will mess with the `blame` history of the individual lines in there...

- `locateDragonwell8BootJDK`
- `setCrossCompilerEnvironment` (For RISC-V cross compilation)
- `downloadBootJDK` (The function I'm modifying here)

The downloadBootJDK additions are all of the lines relating to `gpg` and I've split the `curl | tar xpfz` pipe up so it does the curl download, then the signature check, then extracts. Slower but in keeping with our goal of having a secure supply chain.

So far this has been tested on Linux/aarch64 JDK21 (head)

We need a better way of pulling the signature information down, since this is still a bit of a mess, but that can be addressed separately...

Initial diff of the download code if you want to use it to review separately is 
[diff.log.txt](https://github.com/adoptium/temurin-build/files/11490312/diff.log.txt)


