### PR TITLE
Fix GPG checking of boot JDK for EA downloads and Alpine

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -298,7 +298,8 @@ checkingAndDownloadingAlsa() {
     ALSA_BUILD_URL="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
-    export GNUPGHOME="$PWD/.gpg-temp"
+    # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
+    export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
     # Should we clear this directory up after checking?
     # Would this risk removing anyone's existing dir with that name?
     # Erring on the side of caution for now


### PR DESCRIPTION
Two fixes for the code merged in https://github.com/adoptium/temurin-build/pull/3350 yesterday:
- The check for a valid download of the GA boot JDK was incorrect (Checking the curl return code is not a valid way to do it as curl will download a message with the error code and return success)
- On Alpine if the current directory used when running the check is more than 83 characters long then the receiving of the keys from the keyserver will fail, so I'm going to use the value of `WORKSPACE` instead of 

For future reference and search fodder:
Failure on s390x/arm (Platforms where we have no GA build for JDK20 so this shows up on JDK21 builds) because it tries to download the signature of something that isn't there.
```
09:23:15  gpg: can't open `bootjdk.tar.gz.sig': No such file or directory
09:23:15  gpg: verify signatures failed: No such file or directory
```
Failure on Alpine:
```
09:24:39  gpg: connecting dirmngr at '/home/jenkins/workspace/build-scripts/jobs/jdk/jdk-alpine-linux-x64-temurin/workspace/libs/.gpg-temp/S.dirmngr' failed: Filename too long
```