### PR TITLE
Fix GPG Verification of ALSA on Alpine Linux

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -304,6 +304,7 @@ checkingAndDownloadingAlsa() {
 
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
       export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      echo GNUPGHOME=$GNUPGHOME
       # Should we clear this directory up after checking?
       # Would this risk removing anyone's existing dir with that name?
       # Erring on the side of caution for now

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -305,7 +305,7 @@ checkingAndDownloadingAlsa() {
     # Erring on the side of caution for now
     mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
     gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}" || true
-    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
+    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust; || true
     gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then
       bzip2 -d alsa-lib.tar.bz2

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -305,6 +305,7 @@ checkingAndDownloadingAlsa() {
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
       export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
       echo GNUPGHOME=$GNUPGHOME
+      gpg-agent --homedir=$GNUPGHOME --daemon
       # Should we clear this directory up after checking?
       # Would this risk removing anyone's existing dir with that name?
       # Erring on the side of caution for now

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -295,18 +295,24 @@ checkingAndDownloadingAlsa() {
   if [[ -n "$FOUND_ALSA" ]]; then
     echo "Skipping ALSA download"
   else
-    ALSA_BUILD_URL="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
-    curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
-    curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
-    # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
-    export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-    # Should we clear this directory up after checking?
-    # Would this risk removing anyone's existing dir with that name?
-    # Erring on the side of caution for now
-    mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
-    gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
+    if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
+      ## Add Temporary GPG Exclusion For Alpine Linx As This Doesnt Work In docker
+      downloadFile "alsa-lib.tar.bz2" "https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2" "${ALSA_LIB_CHECKSUM}"
+      ALSA_BUILD_INFO="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
+    else
+      ALSA_BUILD_URL="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
+      curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
+      curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
+      # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
+      export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      # Should we clear this directory up after checking?
+      # Would this risk removing anyone's existing dir with that name?
+      # Erring on the side of caution for now
+      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
+      gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
+    fi
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then
       bzip2 -d alsa-lib.tar.bz2
       tar -xf alsa-lib.tar --strip-components=1 -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedalsa/"
@@ -440,7 +446,7 @@ checkingAndDownloadingFreeType() {
       cd .. || exit
       ;;
     esac
-  
+
     # Fetch the sha for the commit we just cloned
     cd freetype || exit
     FREETYPE_SHA=$(git rev-parse HEAD) || exit

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -305,7 +305,7 @@ checkingAndDownloadingAlsa() {
     # Erring on the side of caution for now
     mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
     gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}" || true
-    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust; | true
+    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust; true
     gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then
       bzip2 -d alsa-lib.tar.bz2

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -305,7 +305,9 @@ checkingAndDownloadingAlsa() {
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
       export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
       echo GNUPGHOME=$GNUPGHOME
+      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
       gpg-agent --homedir=$GNUPGHOME --daemon
+      gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       # Should we clear this directory up after checking?
       # Would this risk removing anyone's existing dir with that name?
       # Erring on the side of caution for now

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -295,18 +295,27 @@ checkingAndDownloadingAlsa() {
   if [[ -n "$FOUND_ALSA" ]]; then
     echo "Skipping ALSA download"
   else
+    
     ALSA_BUILD_URL="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
-    # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
-    export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-    # Should we clear this directory up after checking?
-    # Would this risk removing anyone's existing dir with that name?
-    # Erring on the side of caution for now
-    mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}" || true
-    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust; true
-    gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
+
+    ## Add Exclusion For Alpine Linx As This Doesnt Work In docker
+
+    if echo ${BUILD_CONFIG[OS_KERNEL_NAME]} | grep -qi "alpine" ; then
+      downloadFile "alsa-lib.tar.bz2" "https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2" "${ALSA_LIB_CHECKSUM}"
+      ALSA_BUILD_INFO="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
+    else
+      # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
+      export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      # Should we clear this directory up after checking?
+      # Would this risk removing anyone's existing dir with that name?
+      # Erring on the side of caution for now
+      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
+      gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
+    fi
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then
       bzip2 -d alsa-lib.tar.bz2
       tar -xf alsa-lib.tar --strip-components=1 -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedalsa/"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -295,24 +295,17 @@ checkingAndDownloadingAlsa() {
   if [[ -n "$FOUND_ALSA" ]]; then
     echo "Skipping ALSA download"
   else
-    if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
-      ## Add Temporary GPG Exclusion For Alpine Linx As This Doesnt Work In docker
-      downloadFile "alsa-lib.tar.bz2" "https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2" "${ALSA_LIB_CHECKSUM}"
-      ALSA_BUILD_INFO="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
-    else
-      ALSA_BUILD_URL="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
-      curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
-      curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
-      # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
-      export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-      # Should we clear this directory up after checking?
-      # Would this risk removing anyone's existing dir with that name?
-      # Erring on the side of caution for now
-      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
-      gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
-    fi
+    curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
+    curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
+    # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
+    export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+    # Should we clear this directory up after checking?
+    # Would this risk removing anyone's existing dir with that name?
+    # Erring on the side of caution for now
+    mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}" 2>/dev/null
+    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
+    gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then
       bzip2 -d alsa-lib.tar.bz2
       tar -xf alsa-lib.tar --strip-components=1 -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedalsa/"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -303,7 +303,7 @@ checkingAndDownloadingAlsa() {
     # Would this risk removing anyone's existing dir with that name?
     # Erring on the side of caution for now
     mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}" 2>/dev/null
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}" || true
     echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
     gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -305,7 +305,7 @@ checkingAndDownloadingAlsa() {
     # Erring on the side of caution for now
     mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
     gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}" || true
-    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust; || true
+    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust; | true
     gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then
       bzip2 -d alsa-lib.tar.bz2

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -295,6 +295,7 @@ checkingAndDownloadingAlsa() {
   if [[ -n "$FOUND_ALSA" ]]; then
     echo "Skipping ALSA download"
   else
+    ALSA_BUILD_URL="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
     # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -307,13 +307,14 @@ checkingAndDownloadingAlsa() {
       export GNUPGHOME="/tmp/.gpg-temp"
       echo GNUPGHOME=$GNUPGHOME
       mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-      gpg-agent --homedir=$GNUPGHOME --daemon
-      gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      ## gpg-agent --homedir=$GNUPGHOME --daemon
+      ## gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       # Should we clear this directory up after checking?
       # Would this risk removing anyone's existing dir with that name?
       # Erring on the side of caution for now
-      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-      gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      ## gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
       gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     else

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -303,12 +303,12 @@ checkingAndDownloadingAlsa() {
     ## Add Exclusion For Alpine Linx As This Doesnt Work In docker
 
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
-      # export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
       # Should we clear this directory up after checking?
       # Would this risk removing anyone's existing dir with that name?
       # Erring on the side of caution for now
-      sudo mkdir -p "~/.gnupg" && chmod og-rwx "~/.gnupg"
-      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+      gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
       gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     else

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -303,12 +303,13 @@ checkingAndDownloadingAlsa() {
     ## Add Special Rules For Alpine Linx As This Doesnt Work In docker
 
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
-      #export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
+      # Alpine also cannot create ~/.gpg-temp within a docker context
       export GNUPGHOME="/tmp/.gpg-temp.$$"
     else
       export GNUPGHOME="$HOME/.gpg-temp.$$"
     fi
-
+    
     echo GNUPGHOME=$GNUPGHOME
     mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
     gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
@@ -316,15 +317,6 @@ checkingAndDownloadingAlsa() {
     # Would this risk removing anyone's existing dir with that name?
     # Erring on the side of caution for now
     ## gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
-    gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
-    # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
-    export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-    # Should we clear this directory up after checking?
-    # Would this risk removing anyone's existing dir with that name?
-    # Erring on the side of caution for now
-    mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
     gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
     echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
     gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -303,8 +303,14 @@ checkingAndDownloadingAlsa() {
     ## Add Exclusion For Alpine Linx As This Doesnt Work In docker
 
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
-      downloadFile "alsa-lib.tar.bz2" "https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2" "${ALSA_LIB_CHECKSUM}"
-      ALSA_BUILD_INFO="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
+      # export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      # Should we clear this directory up after checking?
+      # Would this risk removing anyone's existing dir with that name?
+      # Erring on the side of caution for now
+      # mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
+      gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
     else
       # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
       export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -304,12 +304,12 @@ checkingAndDownloadingAlsa() {
 
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
       #export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-      #export GNUPGHOME="/tmp/.gpg-temp"
+      export GNUPGHOME="/tmp/.gpg-temp.$$"
+    else
       export GNUPGHOME="$HOME/.gpg-temp.$$"
+    fi
       echo GNUPGHOME=$GNUPGHOME
       mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-      ## gpg-agent --homedir=$GNUPGHOME --daemon
-      ## gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       # Should we clear this directory up after checking?
       # Would this risk removing anyone's existing dir with that name?
@@ -318,7 +318,6 @@ checkingAndDownloadingAlsa() {
       gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
       gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
-    else
       # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
       export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
       # Should we clear this directory up after checking?

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -304,7 +304,8 @@ checkingAndDownloadingAlsa() {
 
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
       #export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-      export GNUPGHOME="/tmp/.gpg-temp"
+      #export GNUPGHOME="/tmp/.gpg-temp"
+      export GNUPGHOME="$HOME/.gpg-temp.$$"
       echo GNUPGHOME=$GNUPGHOME
       mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
       ## gpg-agent --homedir=$GNUPGHOME --daemon

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -308,26 +308,27 @@ checkingAndDownloadingAlsa() {
     else
       export GNUPGHOME="$HOME/.gpg-temp.$$"
     fi
-      echo GNUPGHOME=$GNUPGHOME
-      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-      # Should we clear this directory up after checking?
-      # Would this risk removing anyone's existing dir with that name?
-      # Erring on the side of caution for now
-      ## gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
-      gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
-      # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
-      export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-      # Should we clear this directory up after checking?
-      # Would this risk removing anyone's existing dir with that name?
-      # Erring on the side of caution for now
-      mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
-      gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
-      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
-      gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
-    fi
+
+    echo GNUPGHOME=$GNUPGHOME
+    mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+    # Should we clear this directory up after checking?
+    # Would this risk removing anyone's existing dir with that name?
+    # Erring on the side of caution for now
+    ## gpg --homedir $GNUPGHOME --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
+    gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
+    # WORKSPACE in preference as Alpine fails gpg operation if PWD > 83 characters
+    export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+    # Should we clear this directory up after checking?
+    # Would this risk removing anyone's existing dir with that name?
+    # Erring on the side of caution for now
+    mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
+    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
+    gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1
+
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]] || [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]]; then
       bzip2 -d alsa-lib.tar.bz2
       tar -xf alsa-lib.tar --strip-components=1 -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedalsa/"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -307,7 +307,7 @@ checkingAndDownloadingAlsa() {
       # Should we clear this directory up after checking?
       # Would this risk removing anyone's existing dir with that name?
       # Erring on the side of caution for now
-      # mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
+      sudo mkdir -p "~/.gnupg" && chmod og-rwx "~/.gnupg"
       gpg --keyserver keyserver.ubuntu.com --recv-keys "${ALSA_LIB_GPGKEYID}"
       echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key "${ALSA_LIB_GPGKEYID}" trust;
       gpg --verify alsa-lib.tar.bz2.sig alsa-lib.tar.bz2 || exit 1

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -295,14 +295,14 @@ checkingAndDownloadingAlsa() {
   if [[ -n "$FOUND_ALSA" ]]; then
     echo "Skipping ALSA download"
   else
-    
+
     ALSA_BUILD_URL="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
 
     ## Add Exclusion For Alpine Linx As This Doesnt Work In docker
 
-    if echo ${BUILD_CONFIG[OS_KERNEL_NAME]} | grep -qi "alpine" ; then
+    if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
       downloadFile "alsa-lib.tar.bz2" "https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2" "${ALSA_LIB_CHECKSUM}"
       ALSA_BUILD_INFO="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2"
     else

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -300,10 +300,11 @@ checkingAndDownloadingAlsa() {
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
 
-    ## Add Exclusion For Alpine Linx As This Doesnt Work In docker
+    ## Add Special Rules For Alpine Linx As This Doesnt Work In docker
 
     if echo ${BUILD_CONFIG[OS_FULL_VERSION]} | grep -qi "alpine" ; then
-      export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      #export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+      export GNUPGHOME="/tmp/.gpg-temp"
       echo GNUPGHOME=$GNUPGHOME
       mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
       gpg-agent --homedir=$GNUPGHOME --daemon


### PR DESCRIPTION
Fixes : #3359 

Amended prepareWorkspace.sh for ALSA GPG verification to use a shortened path ( ~/home/.gpg-temp ) for everything except alpine which when running within docker cannot create a .gpg-temp directory on the root directory. Sine $HOME does not resolve to anything on the build alpine docker image,  its been amended to use /tmp. Pathing has been made unique by using .$$ (PID) as part of the path name, to minimise impact.