### PR TITLE
Fix TemurinSignSBOM build failures due to upstream pki jar changes

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -21,6 +21,7 @@
 -->
 
         <!-- Dependency versions -->
+        <property name="openkeystore-version" value="1.0.0"/>
         <property name="cyclonedx-core-java-version" value="7.3.2"/>
         <property name="jackson-core-version" value="2.14.2"/>
 
@@ -33,7 +34,7 @@
         <property name="github-package-url-version" value="1.4.1"/>
 
         <!-- classpath for running application -->
-        <property name="classpath" value="build/jar/temurin-gen-sbom.jar:build/jar/cyclonedx-core-java.jar:build/jar/jackson-core.jar:build/jar/jackson-dataformat-xml.jar:build/jar/jackson-databind.jar:build/jar/jackson-annotations.jar:build/jar/json-schema.jar:build/jar/commons-codec.jar:build/jar/commons-io.jar:build/jar/github-package-url.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar:build/sign_jar/temurin-sign-sbom.jar"/>
+        <property name="classpath" value="build/jar/temurin-gen-sbom.jar:build/jar/cyclonedx-core-java.jar:build/jar/jackson-core.jar:build/jar/jackson-dataformat-xml.jar:build/jar/jackson-databind.jar:build/jar/jackson-annotations.jar:build/jar/json-schema.jar:build/jar/commons-codec.jar:build/jar/commons-io.jar:build/jar/github-package-url.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar:build/sign_jar/temurin-sign-sbom.jar"/>
 
         <target name="dep-checks">
                 <available file="build/jar/cyclonedx-core-java.jar" property="cyclonedx_available"/>
@@ -45,7 +46,7 @@
                 <available file="build/jar/commons-codec.jar" property="commons-codec_available"/>
                 <available file="build/jar/commons-io.jar" property="commons-io_available"/>
                 <available file="build/jar/github-package-url.jar" property="github-package-url_available"/>
-                <available file="build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar" property="openkeystore_available"/>
+                <available file="build/openkeystore/library/dist/webpki.org-libext-1.00.jar" property="openkeystore_available"/>
         </target>
 
         <target name="download-cyclonedx" unless="cyclonedx_available">
@@ -61,7 +62,7 @@
         <target name="clone-and-build-openkeystore" unless="openkeystore_available">
 		            <mkdir dir="build"/>
 		            <exec executable="git" dir="build">
-			          <arg line="clone https://github.com/cyberphone/openkeystore" />
+			          <arg line="clone --branch ${openkeystore-version} https://github.com/cyberphone/openkeystore" />
 		            </exec>
 		            <ant dir="build/openkeystore/library" target="build"/>
         </target>
@@ -72,8 +73,8 @@
 
         <target name="compile-sign-sbom">
                 <mkdir dir="build/sign_classes"/>
-                <javac srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar:build/openkeystore/library/dist/webpki.org-webutil-1.0.0.jar" includeantruntime="false"/>
-                <javac debug="true" debuglevel="lines,vars,source" srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar:build/openkeystore/library/dist/webpki.org-webutil-1.0.0.jar" includeantruntime="false"/>
+                <javac srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar:build/openkeystore/library/dist/webpki.org-webutil-1.00.jar" includeantruntime="false"/>
+                <javac debug="true" debuglevel="lines,vars,source" srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar:build/openkeystore/library/dist/webpki.org-webutil-1.00.jar" includeantruntime="false"/>
         </target>
 
 
@@ -131,8 +132,8 @@
 
         <target name="compile">
                 <mkdir dir="build/classes"/>
-                <javac srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar" includeantruntime="false"/>
-                <javac debug="true" debuglevel="lines,vars,source" srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar" includeantruntime="false"/>
+                <javac srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar" includeantruntime="false"/>
+                <javac debug="true" debuglevel="lines,vars,source" srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar" includeantruntime="false"/>
         </target>
 
         <target name="jar">

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -33,7 +33,7 @@
         <property name="github-package-url-version" value="1.4.1"/>
 
         <!-- classpath for running application -->
-        <property name="classpath" value="build/jar/temurin-gen-sbom.jar:build/jar/cyclonedx-core-java.jar:build/jar/jackson-core.jar:build/jar/jackson-dataformat-xml.jar:build/jar/jackson-databind.jar:build/jar/jackson-annotations.jar:build/jar/json-schema.jar:build/jar/commons-codec.jar:build/jar/commons-io.jar:build/jar/github-package-url.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar:build/sign_jar/temurin-sign-sbom.jar"/>
+        <property name="classpath" value="build/jar/temurin-gen-sbom.jar:build/jar/cyclonedx-core-java.jar:build/jar/jackson-core.jar:build/jar/jackson-dataformat-xml.jar:build/jar/jackson-databind.jar:build/jar/jackson-annotations.jar:build/jar/json-schema.jar:build/jar/commons-codec.jar:build/jar/commons-io.jar:build/jar/github-package-url.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar:build/sign_jar/temurin-sign-sbom.jar"/>
 
         <target name="dep-checks">
                 <available file="build/jar/cyclonedx-core-java.jar" property="cyclonedx_available"/>
@@ -45,7 +45,7 @@
                 <available file="build/jar/commons-codec.jar" property="commons-codec_available"/>
                 <available file="build/jar/commons-io.jar" property="commons-io_available"/>
                 <available file="build/jar/github-package-url.jar" property="github-package-url_available"/>
-                <available file="build/openkeystore/library/dist/webpki.org-libext-1.00.jar" property="openkeystore_available"/>
+                <available file="build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar" property="openkeystore_available"/>
         </target>
 
         <target name="download-cyclonedx" unless="cyclonedx_available">
@@ -72,8 +72,8 @@
 
         <target name="compile-sign-sbom">
                 <mkdir dir="build/sign_classes"/>
-                <javac srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar:build/openkeystore/library/dist/webpki.org-webutil-1.00.jar" includeantruntime="false"/>
-                <javac debug="true" debuglevel="lines,vars,source" srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar:build/openkeystore/library/dist/webpki.org-webutil-1.00.jar" includeantruntime="false"/>
+                <javac srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar:build/openkeystore/library/dist/webpki.org-webutil-1.0.0.jar" includeantruntime="false"/>
+                <javac debug="true" debuglevel="lines,vars,source" srcdir="sign_src" destdir="build/sign_classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar:build/openkeystore/library/dist/webpki.org-webutil-1.0.0.jar" includeantruntime="false"/>
         </target>
 
 
@@ -131,8 +131,8 @@
 
         <target name="compile">
                 <mkdir dir="build/classes"/>
-                <javac srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar" includeantruntime="false"/>
-                <javac debug="true" debuglevel="lines,vars,source" srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.00.jar" includeantruntime="false"/>
+                <javac srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar" includeantruntime="false"/>
+                <javac debug="true" debuglevel="lines,vars,source" srcdir="src" destdir="build/classes" classpath="build/jar/cyclonedx-core-java.jar:build/openkeystore/library/dist/webpki.org-libext-1.0.0.jar" includeantruntime="false"/>
         </target>
 
         <target name="jar">

--- a/cyclonedx-lib/sign_src/TemurinSignSBOM.java
+++ b/cyclonedx-lib/sign_src/TemurinSignSBOM.java
@@ -36,7 +36,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import org.cyclonedx.exception.ParseException;

--- a/cyclonedx-lib/sign_src/TemurinSignSBOM.java
+++ b/cyclonedx-lib/sign_src/TemurinSignSBOM.java
@@ -36,6 +36,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import org.cyclonedx.exception.ParseException;
@@ -123,7 +124,7 @@ public final class TemurinSignSBOM {
             JsonParser parser = new JsonParser();
             Bom signedBom = parser.parse(new StringReader(signedData));
             return signedBom;
-        } catch (IOException | ParseException e) {
+        } catch (IOException | GeneralSecurityException | ParseException e) {
             LOGGER.log(Level.SEVERE, "Error signing SBOM", e);
             return null;
         }
@@ -173,7 +174,7 @@ public final class TemurinSignSBOM {
             JSONSignatureDecoder signature = reader.getSignature(new JSONCryptoHelper.Options());
             signature.verify(new JSONAsymKeyVerifier(publicKey));
             return true;
-        } catch (IOException e) {
+        } catch (IOException | GeneralSecurityException e) {
             LOGGER.log(Level.SEVERE, "Exception verifying json signature", e);
         }
         return false;

--- a/cyclonedx-lib/sign_src/TemurinSignSBOM.java
+++ b/cyclonedx-lib/sign_src/TemurinSignSBOM.java
@@ -124,7 +124,7 @@ public final class TemurinSignSBOM {
             JsonParser parser = new JsonParser();
             Bom signedBom = parser.parse(new StringReader(signedData));
             return signedBom;
-        } catch (IOException | GeneralSecurityException | ParseException e) {
+        } catch (IOException | ParseException e) {
             LOGGER.log(Level.SEVERE, "Error signing SBOM", e);
             return null;
         }
@@ -174,7 +174,7 @@ public final class TemurinSignSBOM {
             JSONSignatureDecoder signature = reader.getSignature(new JSONCryptoHelper.Options());
             signature.verify(new JSONAsymKeyVerifier(publicKey));
             return true;
-        } catch (IOException | GeneralSecurityException e) {
+        } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Exception verifying json signature", e);
         }
         return false;


### PR DESCRIPTION
openkeystore updates to change their jar name
and fix TemurinSignSBOM.java incorrect exception handling

Fixes https://github.com/adoptium/temurin-build/issues/3364
