### PR TITLE
doc: Add EclipseMirror information to RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -271,7 +271,9 @@ Once the PRs to change those files have been merged, the [adoptium-packages-linu
 
 4. **[Docker Hub]** The information on updating the Adoptium official dockerhub repository is at <https://github.com/adoptium/containers#maintenance-of-dockerfiles> at the moment you cannot do this until all Linux architectures and windows64 are published for the appropriate version
 
-5. Publicise the Temurin release
+5. Once everything has been published to GitHub, use the [EclipseMirror](https://github.com/adoptium/temurin-build/issues/3355#issuecomment-1560927672) job to mirror the artefacts to our Eclipse server for backup purposes. Note that this will need to be done by a team member in the temurin-compliance project (Run once for each of the releases)
+
+6. Publicise the Temurin release
 
 - Via slack on the Adoptium #release channel
 - Find someone with the appropriate authority (Carmen, George, Martijn, Shelley, Stewart, Tim) to post a tweet about the new release from the Adoptium twitter account

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -271,13 +271,12 @@ Once the PRs to change those files have been merged, the [adoptium-packages-linu
 
 4. **[Docker Hub]** The information on updating the Adoptium official dockerhub repository is at <https://github.com/adoptium/containers#maintenance-of-dockerfiles> at the moment you cannot do this until all Linux architectures and windows64 are published for the appropriate version
 
-5. Once everything has been published to GitHub, use the [EclipseMirror](https://github.com/adoptium/temurin-build/issues/3355#issuecomment-1560927672) job to mirror the artefacts to our Eclipse server for backup purposes. Note that this will need to be done by a team member in the temurin-compliance project (Run once for each of the releases)
+5. Once everything has been published to GitHub, use the [EclipseMirror](https://ci.eclipse.org/temurin-compliance/job/EclipseMirror/) job to mirror the artifacts to our Eclipse server for backup purposes. Note that this will need to be done by a team member in the temurin-compliance project (Run once for each of the releases)
 
 6. Publicise the Temurin release
 
 - Via slack on the Adoptium #release channel
 - Find someone with the appropriate authority (Carmen, George, Martijn, Shelley, Stewart, Tim) to post a tweet about the new release from the Adoptium twitter account
-- Also run the EclipseMirror job in the Eclipse jenkins instance to create a backup of the release from GitHub onto the Eclipse servers.
 
 ### Post Release Tasks
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -273,7 +273,7 @@ Once the PRs to change those files have been merged, the [adoptium-packages-linu
 
 5. Once everything has been published to GitHub, use the [EclipseMirror](https://ci.eclipse.org/temurin-compliance/job/EclipseMirror/) job to mirror the artifacts to our Eclipse server for backup purposes. Note that this will need to be done by a team member in the temurin-compliance project (Run once for each of the releases)
 
-6. Publicise the Temurin release
+6. Publicise the Temurin release:
 
 - Via slack on the Adoptium #release channel
 - Find someone with the appropriate authority (Carmen, George, Martijn, Shelley, Stewart, Tim) to post a tweet about the new release from the Adoptium twitter account


### PR DESCRIPTION
We have a mirror of the github artifacts on an Eclipse-owned server. This is a manual step once all of the artifacts are in GitHub.

Note that because of how the credentials for pushing to the Eclipse repository are managed, this step has to be done on the Temurin Compliance jenkins instance.