### PR TITLE
Use alternate path for GNUPGHOME when path length >83 characters

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -122,6 +122,10 @@ configureReproducibleBuildParameter() {
       fi
       # Ensure reproducible and comparable binary with a unique build user identifier
       addConfigureArg "--with-build-user=" "admin"
+      if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]; then
+         addConfigureArg "--with-extra-cflags" "-qnotimestamp"
+         addConfigureArg "--with-extra-cxxflags" "-qnotimestamp"
+      fi
   fi
 }
 

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -300,9 +300,8 @@ checkingAndDownloadingAlsa() {
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
 
-    ## Add Special Rules For Alpine Linux as this doesn't work In docker
-
-    if [ "$(echo $PWD | wc -c)" -gt 83 ]; then
+    ## This affects Alpine docker images and also evaluation pipelines
+    if [ "$(pwd | wc -c)" -gt 83 ]; then
       # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
       # Alpine also cannot create ~/.gpg-temp within a docker context
       export GNUPGHOME="/tmp/.gpg-temp.$$"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -302,7 +302,7 @@ checkingAndDownloadingAlsa() {
 
     ## Add Special Rules For Alpine Linux as this doesn't work In docker
 
-    if echo "${BUILD_CONFIG[OS_FULL_VERSION]}" | grep -qi "alpine" ; then
+    if [ "$(echo $PWD | wc -c)" -gt 83 ]; then
       # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
       # Alpine also cannot create ~/.gpg-temp within a docker context
       export GNUPGHOME="/tmp/.gpg-temp.$$"


### PR DESCRIPTION
This is causing failures in the evaluation pipelines as per https://github.com/adoptium/temurin-build/issues/3378.

Bizarrely it also seems user specific - if I test without this fix using the `jenkins` ID and my own user ID, even in a subdirectory outside `/home` (I tested with a long name under `/dev/shm`) it fails as jenkins, not as `sxa`. I have not yet explained this, but this fix appears to work ok.

Fixed build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/evaluation/job/jobs/job/jdk20u/job/jdk20u-evaluation-linux-riscv64-temurin/32/console