### PR TITLE
Remove typo in aix cflags argument

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -123,8 +123,8 @@ configureReproducibleBuildParameter() {
       # Ensure reproducible and comparable binary with a unique build user identifier
       addConfigureArg "--with-build-user=" "admin"
       if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]; then
-         addConfigureArg "--with-extra-cflags" "-qnotimestamp"
-         addConfigureArg "--with-extra-cxxflags" "-qnotimestamp"
+         addConfigureArg "--with-extra-cflags=" "-qnotimestamps"
+         addConfigureArg "--with-extra-cxxflags=" "-qnotimestamps"
       fi
   fi
 }


### PR DESCRIPTION
Adding an equals sign that needs to be present to make this a valid argument.