### PR TITLE
Use updated static libs target

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -132,7 +132,7 @@ setVariablesForConfigure() {
 
   # JDK 22+ uses static-libs-graal-image target, using static-libs-graal
   # folder.
-  if [ "$openjdk_core_version" == "${JDKHEAD_CORE_VERSION}" ]; then
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 22 ]; then
     local static_libs_path="static-libs-graal"
   else
     local static_libs_path="static-libs"

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -129,8 +129,14 @@ setVariablesForConfigure() {
   # test-image, debug-image and static-libs-image targets are optional - build scripts check whether the directories exist
   local openjdk_test_image_path="test"
   local openjdk_debug_image_path="debug-image"
-  local openjdk_static_libs_image_path="static-libs"
 
+  # JDK 22+ uses static-libs-graal-image target, using static-libs-graal
+  # folder.
+  if [ "$openjdk_core_version" == "${JDKHEAD_CORE_VERSION}" ]; then
+    local static_libs_path="static-libs-graal"
+  else
+    local static_libs_path="static-libs"
+  fi
   if [ "$openjdk_core_version" == "${JDK8_CORE_VERSION}" ]; then
     local jdk_path="j2sdk-image"
     local jre_path="j2re-image"
@@ -155,7 +161,7 @@ setVariablesForConfigure() {
   BUILD_CONFIG[JRE_PATH]=$jre_path
   BUILD_CONFIG[TEST_IMAGE_PATH]=$openjdk_test_image_path
   BUILD_CONFIG[DEBUG_IMAGE_PATH]=$openjdk_debug_image_path
-  BUILD_CONFIG[STATIC_LIBS_IMAGE_PATH]=$openjdk_static_libs_image_path
+  BUILD_CONFIG[STATIC_LIBS_IMAGE_PATH]=$static_libs_path
 }
 
 # Set the repository to build from, defaults to adoptium if not set by the user

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -95,7 +95,7 @@ buildOpenJDKViaDocker()
     local jre_directory=""
     # JDK 22+ uses static-libs-graal-image target, using static-libs-graal
     # folder.
-    if [ "$openjdk_core_version" == "${JDKHEAD_CORE_VERSION}" ]; then
+    if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 22 ]; then
       local static_libs_dir="static-libs-graal"
     else
       local static_libs_dir="static-libs"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -91,9 +91,15 @@ buildOpenJDKViaDocker()
     # test-image, debug-image and static-libs-image targets are optional - build scripts check whether the directories exist
     local openjdk_test_image_path="test"
     local openjdk_debug_image_path="debug-image"
-    local openjdk_static_libs_image_path="static-libs"
     local jdk_directory=""
     local jre_directory=""
+    # JDK 22+ uses static-libs-graal-image target, using static-libs-graal
+    # folder.
+    if [ "$openjdk_core_version" == "${JDKHEAD_CORE_VERSION}" ]; then
+      local static_libs_dir="static-libs-graal"
+    else
+      local static_libs_dir="static-libs"
+    fi
 
     if [ "$openjdk_core_version" == "${JDK8_CORE_VERSION}" ]; then
       case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
@@ -123,7 +129,7 @@ buildOpenJDKViaDocker()
     BUILD_CONFIG[JRE_PATH]=$jre_directory
     BUILD_CONFIG[TEST_IMAGE_PATH]=$openjdk_test_image_path
     BUILD_CONFIG[DEBUG_IMAGE_PATH]=$openjdk_debug_image_path
-    BUILD_CONFIG[STATIC_LIBS_IMAGE_PATH]=$openjdk_static_libs_image_path
+    BUILD_CONFIG[STATIC_LIBS_IMAGE_PATH]=$static_libs_dir
 
   if [ -z "$(command -v docker)" ]; then
      # shellcheck disable=SC2154

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -558,12 +558,15 @@ buildTemplatedFile() {
   fi
 
   # If it's Java 9+ then we also make test-image to build the native test libraries,
-  # For openj9 add debug-image
+  # For openj9 add debug-image. For JDK 22+ static-libs-image target name changed to
+  # static-libs-graal-image. See JDK-8307858.
   JDK_VERSION_NUMBER="${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]]; then
     ADDITIONAL_MAKE_TARGETS=" test-image debug-image"
-  elif [ "$JDK_VERSION_NUMBER" -gt 8 ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]; then
+  elif [ "$JDK_VERSION_NUMBER" -gt 8 ] && [ "$JDK_VERSION_NUMBER" -lt 22 ]; then
     ADDITIONAL_MAKE_TARGETS=" test-image static-libs-image"
+  elif [ "$JDK_VERSION_NUMBER" -ge 22 ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]; then
+    ADDITIONAL_MAKE_TARGETS=" test-image static-libs-graal-image"
   fi
 
   if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" == "true" ]]; then


### PR DESCRIPTION
Upstream OpenJDK changed what the static-libs image means. It includes a static version of libjvm.a with JDK 22+. Therefore, in order to get a version without libjvm.a, static-libs-graal-image target is being used instead.

Closes: #3339