### PR TITLE
signing: Remove redundant trimming of timeserver string

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -63,7 +63,7 @@ checkSignConfiguration() {
 # Sign the built binary
 signRelease()
 {
-  TIMESTAMPSERVERS=$(cut -d= -f2 < "$WORKSPACE/$TIMESTAMP_SERVER_CONFIG" | tr -d \\\\r)
+  TIMESTAMPSERVERS=$(cut -d= -f2 < "$WORKSPACE/$TIMESTAMP_SERVER_CONFIG" )
 
   case "$OPERATING_SYSTEM" in
     "windows")


### PR DESCRIPTION
Fixes issue #3337 

Remove an unneeded trim string function from the timeserver parsing.