### PR TITLE
Ensure debug files are deterministic by mapping system include paths

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -162,8 +162,8 @@ configureReproducibleBuildDebugMapping() {
       fdebug_flags+=" -fdebug-prefix-map=${gcc_include}/="
     fi
 
-    addConfigureArg "--with-extra-cflags=" "${fdebug_flags}"
-    addConfigureArg "--with-extra-cxxflags=" "${fdebug_flags}"
+    addConfigureArg "--with-extra-cflags=" "'${fdebug_flags}'"
+    addConfigureArg "--with-extra-cxxflags=" "'${fdebug_flags}'"
   fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -150,9 +150,9 @@ configureReproducibleBuildDebugMapping() {
 
     # Add debug prefix map for gcc include, allowing for SYSROOT
     if [ "x$CC" != "x" ]; then
-      gcc_include=$(dirname $(echo "#include <stddef.h>" | $CC $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2))
+      gcc_include="$(dirname $(echo "#include <stddef.h>" | $CC $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2))"
     elif [ "$(which gcc)" != "" ]; then
-      gcc_include=$(dirname $(echo "#include <stddef.h>" | gcc $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2))
+      gcc_include="$(dirname $(echo "#include <stddef.h>" | gcc $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2))"
     else
       # Can't find gcc..
       gcc_include=""

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -150,9 +150,9 @@ configureReproducibleBuildDebugMapping() {
 
     # Add debug prefix map for gcc include, allowing for SYSROOT
     if [ -n "$CC" ]; then
-      gcc_include="$(dirname $(echo "#include <stddef.h>" | $CC $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2))"
+      gcc_include="$(dirname "$(echo "#include <stddef.h>" | $CC $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2)")"
     elif [ "$(which gcc)" != "" ]; then
-      gcc_include="$(dirname $(echo "#include <stddef.h>" | gcc $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2))"
+      gcc_include="$(dirname "$(echo "#include <stddef.h>" | gcc $gcc_sysroot -v -E - 2>&1 | grep stddef | tail -1 | tr -s " " | cut -d'"' -f2)")"
     else
       # Can't find gcc..
       gcc_include=""
@@ -164,9 +164,9 @@ configureReproducibleBuildDebugMapping() {
 
     # Add debug prefix map for g++ include, allowing for SYSROOT
     if [ -n "$CXX" ]; then
-      gxx_include="$(dirname $(echo "#include <cstddef>" | $CXX $gcc_sysroot -v -E -x c++ - 2>&1 | grep cstddef | tail -1 | tr -s " " | cut -d'"' -f2))"
+      gxx_include="$(dirname "$(echo "#include <cstddef>" | $CXX $gcc_sysroot -v -E -x c++ - 2>&1 | grep cstddef | tail -1 | tr -s " " | cut -d'"' -f2)")"
     elif [ "$(which g++)" != "" ]; then
-      gxx_include="$(dirname $(echo "#include <cstddef>" | g++ $gcc_sysroot -v -E -x c++ - 2>&1 | grep cstddef | tail -1 | tr -s " " | cut -d'"' -f2))"
+      gxx_include="$(dirname "$(echo "#include <cstddef>" | g++ $gcc_sysroot -v -E -x c++ - 2>&1 | grep cstddef | tail -1 | tr -s " " | cut -d'"' -f2)")"
     else
       # Can't find g++..
       gxx_include=""


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3397

Update the build-scripts to add cflags for -fdebug-prefix-map of the gcc system include paths, so that an absolute path is not embedded in the debug files, which then makes the JDK libraries different due to the embedded CRC code.
