### PR TITLE
Ensure deterministic cacert ALIAS name

### DIFF
--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -83,7 +83,7 @@ IMPORTED=('null')
 alreadyExistsCounter=0 # counter for duplicated file
 
 for FILE in certs/*.crt; do
-    ALIAS=$(openssl x509 -subject -noout -in "$FILE" | sed 's/^subject=//' | tr '/' ',')
+    ALIAS=$(openssl x509 -subject -noout -nameopt compat -in "$FILE" | 's/^subject=[[:space:]]*//' | tr '/' ',')
 
     if printf '%s\n' "${IMPORTED[@]}" | grep "temurin_${ALIAS}_temurin"; then
         echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -83,7 +83,7 @@ IMPORTED=('null')
 alreadyExistsCounter=0 # counter for duplicated file
 
 for FILE in certs/*.crt; do
-    ALIAS=$(openssl x509 -subject -noout -nameopt compat -in "$FILE" | 's/^subject=[[:space:]]*//' | tr '/' ',')
+    ALIAS=$(openssl x509 -subject -noout -nameopt compat -in "$FILE" | sed 's/^subject=[[:space:]]*//' | tr '/' ',')
 
     if printf '%s\n' "${IMPORTED[@]}" | grep "temurin_${ALIAS}_temurin"; then
         echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"


### PR DESCRIPTION
Add "-nameopt compat" option to the openssl command used to generate the ALIAS name, and remove any leading spaces.

Fixes: https://github.com/adoptium/temurin-build/issues/3396
