### PR TITLE
Boot JDK download not always using the correct gpg signature file for verification

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -151,7 +151,6 @@ function downloadBootJDK()
   apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< Location:/{print $3 ".sig"}')
   if ! grep "No releases match the request" bootjdk.tar.gz; then
     curl -L -o bootjdk.tar.gz.sig "${apiSigURL}"
-    curl 
     gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
     echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
     gpg --verify bootjdk.tar.gz.sig bootjdk.tar.gz || exit 1

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -143,15 +143,15 @@ function downloadBootJDK()
   vendor="eclipse"
   apiUrlTemplate="https://api.adoptium.net/v3/binary/latest/\${VER}/\${releaseType}/linux/\${downloadArch}/jdk/hotspot/normal/\${vendor}"
   apiURL=$(eval echo "${apiUrlTemplate}")
-  apiSigUrlTemplate="https://api.adoptium.net/v3/assets/feature_releases/\${VER}/\${releaseType}?architecture=\$ARCH&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&vendor=eclipse"
-  apiSigURL=$(eval echo "${apiSigUrlTemplate}")
   echo "Downloading GA release of boot JDK version ${VER} from ${apiURL}"
   # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
   # the fallback mechanism, as downloading of the GA binary might fail.
   set +e
   curl -L -o bootjdk.tar.gz "${apiURL}"
+  apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< Location:/{print $3 ".sig"}')
   if ! grep "No releases match the request" bootjdk.tar.gz; then
-    curl -L -o bootjdk.tar.gz.sig "$(curl -s "${apiSigURL}" | grep "signature_link.*-jdk_" | awk '{split($0,a,"\""); print a[4]}' | head -1)"
+    curl -L -o bootjdk.tar.gz.sig "${apiSigURL}"
+    curl 
     gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
     echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
     gpg --verify bootjdk.tar.gz.sig bootjdk.tar.gz || exit 1
@@ -167,12 +167,12 @@ function downloadBootJDK()
     # shellcheck disable=SC2034
     vendor="adoptium"
     apiURL=$(eval echo ${apiUrlTemplate})
-    apiSigURL=$(eval echo "${apiSigUrlTemplate}")
     echo "Attempting to download EA release of boot JDK version ${VER} from ${apiURL}"
     set +e
     curl -L -o bootjdk.tar.gz "${apiURL}"
     if ! grep "No releases match the request" bootjdk.tar.gz; then
-      curl -L -o bootjdk.tar.gz.sig "$(curl -s "${apiSigURL}" | grep "signature_link.*-jdk_" | awk '{split($0,a,"\""); print a[4]}' | head -1)"
+      apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< Location:/{print $3 ".sig"}')
+      curl -L -o bootjdk.tar.gz.sig "${apiSigURL}"
       gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
       echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
       gpg --verify bootjdk.tar.gz.sig bootjdk.tar.gz || exit 1


### PR DESCRIPTION
The current mechanism used a different sorting order for the releases which meant that the GPG signature was not always the correct one for the downloaded boot JDK. This change ensures that it is the correct one which will match the file by taking the target tarball name and appending `.sig` to it.

Note: The correct solution to this is to pull the GPG signature from the API but that can be changed in a follow up PR as this is a fix for a build break in (at least) JDK22. There is also a potential race condition if the latest is updated while the boot JDK is being downloaded but again that will be fixed subsequently by pulling the signature file from the API.