### PR TITLE
Ensure deterministic cacert ALIAS name

### DIFF
--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -83,7 +83,7 @@ IMPORTED=('null')
 alreadyExistsCounter=0 # counter for duplicated file
 
 for FILE in certs/*.crt; do
-    ALIAS=$(openssl x509 -subject -noout -nameopt compat -in "$FILE" | sed 's/^subject=[[:space:]]*//' | tr '/' ',')
+    ALIAS=$(openssl x509 -subject -noout -nameopt compat -in "$FILE" | tr '/' ' ' | sed 's/^subject=[[:space:]]*//' | tr -d ',')
 
     if printf '%s\n' "${IMPORTED[@]}" | grep "temurin_${ALIAS}_temurin"; then
         echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"


### PR DESCRIPTION
Fix for https://github.com/adoptium/temurin-build/issues/3396
didn't quite do the job, as Centos7 docker build container openssl name-compat output doesn't use /'s and commas in the same places!
So to achieve a determinstic alias, needs a tweak to remove the /'s and commas.

Example: raw Subject outputs with just -nameopt compat:
**Centos7 build container:**
```
subject= C=HK, ST=Hong Kong, L=Hong Kong, O=Hongkong Post, CN=Hongkong Post Root CA 3
```
**RHEL8:**
```
subject=/C=HK/ST=Hong Kong/L=Hong Kong/O=Hongkong Post/CN=Hongkong Post Root CA 3
```
**MacOS:**
```
subject= /C=HK/ST=Hong Kong/L=Hong Kong/O=Hongkong Post/CN=Hongkong Post Root CA 3
```

