### PR TITLE
Ensure deterministic cacert ALIAS name by only using recognised DNs

### DIFF
--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -84,9 +84,11 @@ alreadyExistsCounter=0 # counter for duplicated file
 
 for FILE in certs/*.crt; do
     # Use rfc2253 standard format, so output format is deterministic
-    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | tr '/' ' ' | sed 's/^subject=[[:space:]]*//' | tr -d ',')
+    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | sed 's/^subject=[[:space:]]*//' | tr ' ' '_')
+    echo "Subject: ${ALIAS_FROM_SUBJECT}"
 
     # Create ALIAS from widely recognised standard DN's
+    # shellcheck disable=SC2206
     arrALIAS=(${ALIAS_FROM_SUBJECT//,/ })
     ALIAS=""
     for dn in "${arrALIAS[@]}"; do
@@ -101,6 +103,7 @@ for FILE in certs/*.crt; do
     done
     # Remove leading ","
     ALIAS=${ALIAS#,}
+    echo "Generated alias: ${ALIAS}"
 
     if printf '%s\n' "${IMPORTED[@]}" | grep "temurin_${ALIAS}_temurin"; then
         echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -83,7 +83,24 @@ IMPORTED=('null')
 alreadyExistsCounter=0 # counter for duplicated file
 
 for FILE in certs/*.crt; do
-    ALIAS=$(openssl x509 -subject -noout -nameopt compat -in "$FILE" | tr '/' ' ' | sed 's/^subject=[[:space:]]*//' | tr -d ',')
+    # Use rfc2253 standard format, so output format is deterministic
+    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | tr '/' ' ' | sed 's/^subject=[[:space:]]*//' | tr -d ',')
+
+    # Create ALIAS from widely recognised standard DN's
+    arrALIAS=(${ALIAS_FROM_SUBJECT//,/ })
+    ALIAS=""
+    for dn in "${arrALIAS[@]}"; do
+        case "$dn" in
+            # Build ALIAS from widely recognised DN's
+            C=*|CT=*|L=*|O=*|OU=*|ST=*|CN=*)
+                ALIAS="${ALIAS},${dn}"
+                ;;
+            *)
+                ;;
+        esac
+    done
+    # Remove leading ","
+    ALIAS=${ALIAS#,}
 
     if printf '%s\n' "${IMPORTED[@]}" | grep "temurin_${ALIAS}_temurin"; then
         echo "Skipping certificate file $FILE with alias: $ALIAS as it already exists"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3407

Use rfc2253 openssl Subject format, and only use widely recognised DNs to form the ALIAS.
