### PR TITLE
Add JDK JRE version test for openj9 jdk8

### DIFF
--- a/test/functional/buildAndPackage/playlist.xml
+++ b/test/functional/buildAndPackage/playlist.xml
@@ -24,6 +24,22 @@
 			<group>functional</group>
 		</groups>
 	</test>
+	<test>
+		<testCaseName>Jdk_Jre_Version</testCaseName>
+		<command>$(TEST_JDK_HOME)$(D)jre$(D)bin$(D)java -version; $(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+		</impls>
+		<versions>
+			<version>8</version>
+		</versions>
+	</test>
     <test>
         <testCaseName>Adopt_HS_FeatureTests</testCaseName>
         <command>


### PR DESCRIPTION
- This test will test the jre jave version under jdk folder
- Only add for openj9 jdk8
Related Issue: ibm_git/infrastructure/issues/7925