### PR TITLE
Add hsdis support into the build for JDK24+

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -341,7 +341,7 @@ else
   fi
 fi
 
-if [ "$JAVA_FEATURE_VERSION" -ge 20 ] && [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]; then
+if [ "$JAVA_FEATURE_VERSION" -ge 24 ] && [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]; then
   # hsdis+capstone only supported on these two in openjdk
   if [ "${ARCHITECTURE}" = "x64" ] || [ "${ARCHITECTURE}" = "aarch64" ]; then
     if [ -r /usr/local/lib/libcapstone.so.4 ]; then

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -341,9 +341,9 @@ else
   fi
 fi
 
-if [ "$JAVA_FEATURE_VERSION" -ge 20 ]; then
+if [ "$JAVA_FEATURE_VERSION" -ge 20 -a "${ARCHITECTURE}" = "x64" -o "${ARCHITECTURE}" = "aarch64" -a "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]; then
   if [ -r /usr/local/lib/libcapstone.so.4 ]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-capstone=/usr/local"
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-hsdis-bundling --with-hsdis=capstone --with-capstone=/usr/local"
   fi
 fi
 

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -341,6 +341,12 @@ else
   fi
 fi
 
+if [ "$JAVA_FEATURE_VERSION" -ge 20 ]; then
+  if [ -r /usr/local/lib/libcapstone.so.4 ]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-capstone=/usr/local"
+  fi
+fi
+
 if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
   # BUILD_C/CXX required for native (non-cross) RISC-V builds of Bisheng
   if [ -n "$CXX" ]; then

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -341,9 +341,12 @@ else
   fi
 fi
 
-if [ "$JAVA_FEATURE_VERSION" -ge 20 -a "${ARCHITECTURE}" = "x64" -o "${ARCHITECTURE}" = "aarch64" -a "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]; then
-  if [ -r /usr/local/lib/libcapstone.so.4 ]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-hsdis-bundling --with-hsdis=capstone --with-capstone=/usr/local"
+if [ "$JAVA_FEATURE_VERSION" -ge 20 ] && [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]; then
+  # hsdis+capstone only supported on these two in openjdk
+  if [ "${ARCHITECTURE}" = "x64" ] || [ "${ARCHITECTURE}" = "aarch64" ]; then
+    if [ -r /usr/local/lib/libcapstone.so.4 ]; then
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-hsdis-bundling --with-hsdis=capstone --with-capstone=/usr/local"
+    fi
   fi
 fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -122,6 +122,20 @@ configureShenandoahBuildParameter() {
   fi
 }
 
+# capstone disassembler support is available in JDK19+
+configureCapstoneBuildParameter() {
+  if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 19 && "${BUILD_CONFIG[OS_KERNEL_NAME]}" = "linux" ]]; then
+    # Ref: https://github.com/adoptium/jdk21/blob/c86f4dea9529640cd3234c5cad2f36f3201b1385/make/Hsdis.gmk#L45
+    if [ "${ARCHITECTURE}" = "x64" -o "${ARCHITECTURE}" = "aarch64" ]; then
+      echo Configuring with hsdis capstone bundling support
+      addConfigureArg "--enable-hsdis-bundling" ""
+      addConfigureArg "--with-hsdis=" "capstone"
+      addConfigureArg "--with-capstone=" "/usr/local"
+    else
+      echo Not configuring with hsdis/capstone support as we are not building on x64 or aarch64
+    fi
+  fi
+}
 # Configure reproducible build
 # jdk-17 and jdk-19+ support reproducible builds
 configureReproducibleBuildParameter() {
@@ -586,6 +600,7 @@ configureCommandParameters() {
   configureBootJDKConfigureParameter
   configureDevKitConfigureParameter
   configureLinkableRuntimeParameter
+  configureCapstoneBuildParameter
   configureShenandoahBuildParameter
   configureMacOSCodesignParameter
   configureDebugParameters

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -586,7 +586,6 @@ configureCommandParameters() {
   configureBootJDKConfigureParameter
   configureDevKitConfigureParameter
   configureLinkableRuntimeParameter
-  configureCapstoneBuildParameter
   configureShenandoahBuildParameter
   configureMacOSCodesignParameter
   configureDebugParameters

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -122,20 +122,6 @@ configureShenandoahBuildParameter() {
   fi
 }
 
-# capstone disassembler support is available in JDK19+
-configureCapstoneBuildParameter() {
-  if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 19 && "${BUILD_CONFIG[OS_KERNEL_NAME]}" = "linux" ]]; then
-    # Ref: https://github.com/adoptium/jdk21/blob/c86f4dea9529640cd3234c5cad2f36f3201b1385/make/Hsdis.gmk#L45
-    if [ "${ARCHITECTURE}" = "x64" -o "${ARCHITECTURE}" = "aarch64" ]; then
-      echo Configuring with hsdis capstone bundling support
-      addConfigureArg "--enable-hsdis-bundling" ""
-      addConfigureArg "--with-hsdis=" "capstone"
-      addConfigureArg "--with-capstone=" "/usr/local"
-    else
-      echo Not configuring with hsdis/capstone support as we are not building on x64 or aarch64
-    fi
-  fi
-}
 # Configure reproducible build
 # jdk-17 and jdk-19+ support reproducible builds
 configureReproducibleBuildParameter() {


### PR DESCRIPTION
Partial implementation of https://github.com/adoptium/adoptium/issues/213 - limited to Linux only.
