### PR TITLE
Fix mk-cacerts.sh Solaris sed failure and escaped subject commas

### DIFF
--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -84,7 +84,8 @@ alreadyExistsCounter=0 # counter for duplicated file
 
 for FILE in certs/*.crt; do
     # Use rfc2253 standard format, so output format is deterministic
-    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | sed 's/^subject=[[:space:]]*//' | tr ' ' '_')
+    # Translate spaces and escaped commas(\,) to underscore
+    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | sed 's/^subject= *//' | tr ' ' '_' | sed "s/\\\,/_/g" )
     echo "Subject: ${ALIAS_FROM_SUBJECT}"
 
     # Create ALIAS from widely recognised standard DN's

--- a/security/mk-cacerts.sh
+++ b/security/mk-cacerts.sh
@@ -85,7 +85,7 @@ alreadyExistsCounter=0 # counter for duplicated file
 for FILE in certs/*.crt; do
     # Use rfc2253 standard format, so output format is deterministic
     # Translate spaces and escaped commas(\,) to underscore
-    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | sed 's/^subject= *//' | tr ' ' '_' | sed "s/\\\,/_/g" )
+    ALIAS_FROM_SUBJECT=$(openssl x509 -subject -noout -nameopt rfc2253 -in "$FILE" | sed 's/^subject= *//' | tr ' ' '_' | sed 's/\\\,/_/g')
     echo "Subject: ${ALIAS_FROM_SUBJECT}"
 
     # Create ALIAS from widely recognised standard DN's


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3418

Solaris sed does not recognise [[:space:]]
and don't split on escaped commas (\\,) in the subject