### PR TITLE
Improve Resilience Of Signing Checks For MacOS

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -180,11 +180,17 @@ signRelease()
         JDK_DIR=$(ls -d "${TMP_DIR}"/jdk*)
         JDK=$(basename "${JDK_DIR}")
         cd "${TMP_DIR}"
-        zip -r "${TMP_DIR}/unsigned.zip" "${JDK}"
+        zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 1"
-        unzip -vl "${TMP_DIR}/unsigned.zip"
+        unzip -p "${TMP_DIR}/unsigned.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources" > adb.txt
+        unzip -p "${TMP_DIR}/signed.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources" > adb2.txt
+        diff adb.txt adb2.txt
+        echo "File 1"
+        cat adb.txt
+        echo "File 2"
+        cat adb2.txt
         echo "Debug 2 = $MACSIGNSTRING"
         TESTMACSIGN=`unzip -l "${TMP_DIR}/signed.zip" | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
         # TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
@@ -219,12 +225,12 @@ signRelease()
               errcount=$((errcount+1))
             fi
           done
-        fi
-        if [[ $errcount -gt 0 ]]
-        then
-            echo "Errors Encountered During Signing"
-            echo "Error Count = $errcount"
-            exit 1
+          if [[ $errcount -gt 0 ]]
+          then
+              echo "Errors Encountered During Signing"
+              echo "Error Count = $errcount"
+              exit 1
+          fi
         fi
       else
         # Login to KeyChain

--- a/sign.sh
+++ b/sign.sh
@@ -170,7 +170,7 @@ signRelease()
               fi
             done
           fi
-          if [ $errcount -gt 0 ]
+          if [ "$errcount" -gt 0 ]
           then
             echo "Errors Encountered During Signing"
             echo "Error Count = $errcount"

--- a/sign.sh
+++ b/sign.sh
@@ -184,7 +184,7 @@ signRelease()
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 2 = $MACSIGNSTRING"
-        TESTMACSIGN=`unzip -p . "${TMP_DIR}/signed.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"|grep -i "$MACSIGNSTRING"|wc -l`
+        TESTMACSIGN=`unzip -l jdk.zip | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
         # TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]
@@ -202,7 +202,7 @@ signRelease()
             echo $iteration Of $max_iterations
             sleep 1
             curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-            TESTMACSIGN2=`unzip -p . "${TMP_DIR}/signed.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"|grep -i "$MACSIGNSTRING"|wc -l`
+            TESTMACSIGN2=`unzip -l jdk.zip | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
             echo TESTMACSIGN2 = $TESTMACSIGN2
             if [[ $TESTMACSIGN2 -gt 0 ]]
             then

--- a/sign.sh
+++ b/sign.sh
@@ -154,7 +154,7 @@ signRelease()
               echo $iteration Of $max_iterations
               sleep 1
               curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-              TESTMACSIGN2==(grep -ic "$MACSIGNSTRING" "$f")
+              TESTMACSIGN2=(grep -ic "$MACSIGNSTRING" "$f")
               echo TESTMACSIGN2 = $TESTMACSIGN2
               if [[ $TESTMACSIGN2 -gt 0 ]]
               then
@@ -169,15 +169,14 @@ signRelease()
                 errcount=$((errcount+1))
               fi
             done
-            if [[ $errcount -gt 0 ]]
-            then
-            	echo "Errors Encountered During Signing"
-            	echo "Error Count = $errcount"
-              exit 1
-            fi
+          fi
+          if [[ $errcount -gt 0 ]]
+          then
+            echo "Errors Encountered During Signing"
+            echo "Error Count = $errcount"
+            exit 1
           fi
         done
-      fi
         JDK_DIR=$(ls -d "${TMP_DIR}"/jdk*)
         JDK=$(basename "${JDK_DIR}")
         cd "${TMP_DIR}"

--- a/sign.sh
+++ b/sign.sh
@@ -183,7 +183,6 @@ signRelease()
         zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-        diff "${TMP_DIR}/unsigned.zip" "${TMP_DIR}/signed.zip"
         rm -rf "${JDK_DIR}"
         unzip -q -d "${TMP_DIR}" "${TMP_DIR}/signed.zip"
       else

--- a/sign.sh
+++ b/sign.sh
@@ -169,12 +169,12 @@ signRelease()
                 errcount=$((errcount+1))
               fi
             done
-          fi
-          if [ "$errcount" -gt 0 ]
-          then
-            echo "Errors Encountered During Signing"
-            echo "Error Count = $errcount"
-            exit 1
+            if [ "$errcount" -gt 0 ]
+            then
+              echo "Errors Encountered During Signing"
+              echo "Error Count = $errcount"
+              exit 1
+            fi
           fi
         done
         JDK_DIR=$(ls -d "${TMP_DIR}"/jdk*)

--- a/sign.sh
+++ b/sign.sh
@@ -185,8 +185,11 @@ signRelease()
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 1 = $MACSIGNSTRING"
         unzip -vl "${TMP_DIR}/signed.zip"
-        unzip -p . "${TMP_DIR}/signed.zip" jdk-17.0.8+6/Contents/_CodeSignature/CodeResources
+        echo "Debug 2 = $MACSIGNSTRING"
+        unzip -p . "${TMP_DIR}/signed.zip"  jdk-17.0.8+6/Contents/_CodeSignature/CodeResources
+        echo "Debug 3 = $MACSIGNSTRING"
         unzip -dj . "${TMP_DIR}/signed.zip" jdk-17.0.8+6/Contents/_CodeSignature/CodeResources
+        echo "Debug 4 = $MACSIGNSTRING"
         ls
         TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"

--- a/sign.sh
+++ b/sign.sh
@@ -139,7 +139,7 @@ signRelease()
           echo File = "$f"
           TESTMACSIGN=(grep -ic "$MACSIGNSTRING" "$f")
           echo Sign Result = "$TESTMACSIGN"
-          if [[ "$TESTMACSIGN" -gt 0 ]]
+          if [ "$TESTMACSIGN" -gt 0 ]
           then
             echo "Code Signed For File $f"
             chmod --reference="${dir}/unsigned_${file}" "$f"
@@ -150,13 +150,13 @@ signRelease()
             success=false
             errcount=0
             echo "Code Not Signed For File $f"
-            while [[ $iteration -le $max_iterations ]] && [ $success = false ]; do
+            while [ $iteration -le $max_iterations ] && [ $success = false ]; do
               echo $iteration Of $max_iterations
               sleep 1
               curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
               TESTMACSIGN2=(grep -ic "$MACSIGNSTRING" "$f")
               echo TESTMACSIGN2 = "$TESTMACSIGN2"
-              if [[ "$TESTMACSIGN2" -gt 0 ]]
+              if [ "$TESTMACSIGN2" -gt 0 ]
               then
                 echo "$f Signed OK On Attempt $iteration"
                 chmod --reference="${dir}/unsigned_${file}" "$f"
@@ -170,7 +170,7 @@ signRelease()
               fi
             done
           fi
-          if [[ $errcount -gt 0 ]]
+          if [ $errcount -gt 0 ]
           then
             echo "Errors Encountered During Signing"
             echo "Error Count = $errcount"

--- a/sign.sh
+++ b/sign.sh
@@ -185,6 +185,9 @@ signRelease()
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 1 = $MACSIGNSTRING"
         unzip -vl "${TMP_DIR}/signed.zip"
+        unzip -p . "${TMP_DIR}/signed.zip" jdk-17.0.8+6/Contents/_CodeSignature/CodeResources
+        unzip -dj . "${TMP_DIR}/signed.zip" jdk-17.0.8+6/Contents/_CodeSignature/CodeResources
+        ls
         TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]

--- a/sign.sh
+++ b/sign.sh
@@ -181,6 +181,8 @@ signRelease()
         JDK=$(basename "${JDK_DIR}")
         cd "${TMP_DIR}"
         zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
+        echo "Debug 1"
+        zip -vl "${TMP_DIR}/unsigned.zip"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 2 = $MACSIGNSTRING"

--- a/sign.sh
+++ b/sign.sh
@@ -184,7 +184,7 @@ signRelease()
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 2 = $MACSIGNSTRING"
-        TESTMACSIGN=`unzip -l jdk.zip | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
+        TESTMACSIGN=`unzip -l "${TMP_DIR}/signed.zip" | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
         # TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]
@@ -202,7 +202,7 @@ signRelease()
             echo $iteration Of $max_iterations
             sleep 1
             curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-            TESTMACSIGN2=`unzip -l jdk.zip | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
+            TESTMACSIGN2=`unzip -l "${TMP_DIR}/signed.zip" | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
             echo TESTMACSIGN2 = $TESTMACSIGN2
             if [[ $TESTMACSIGN2 -gt 0 ]]
             then

--- a/sign.sh
+++ b/sign.sh
@@ -177,6 +177,7 @@ signRelease()
             fi
           fi
         done
+      fi
         JDK_DIR=$(ls -d "${TMP_DIR}"/jdk*)
         JDK=$(basename "${JDK_DIR}")
         cd "${TMP_DIR}"

--- a/sign.sh
+++ b/sign.sh
@@ -217,18 +217,13 @@ signRelease()
               echo $MACSIGNSTRING >> 3.txt
             fi
           done
-          if [[ $errcount -gt 0 ]]
-          then
+        fi
+        if [[ $errcount -gt 0 ]]
+        then
             echo "Errors Encountered During Signing"
             echo "Error Count = $errcount"
             exit 1
-          fi
-
-
-
-
-
-
+        fi
       else
         # Login to KeyChain
         # shellcheck disable=SC2046

--- a/sign.sh
+++ b/sign.sh
@@ -148,7 +148,6 @@ signRelease()
             max_iterations=20
             iteration=1
             success=false
-            errcount=0
             echo "Code Not Signed For File $f"
             while [ $iteration -le $max_iterations ] && [ $success = false ]; do
               echo $iteration Of $max_iterations
@@ -166,15 +165,13 @@ signRelease()
                 echo "$f Failed Signing On Attempt $iteration"
                 success=false
                 iteration=$((iteration+1))
-                errcount=$((errcount+1))
+                if [ $iteration -gt $max_iterations ]
+                then
+                  echo "Errors Encountered During Signing"
+                  exit 1
+                fi
               fi
             done
-            if [ "$errcount" -gt 0 ]
-            then
-              echo "Errors Encountered During Signing"
-              echo "Error Count = $errcount"
-              exit 1
-            fi
           fi
         done
         JDK_DIR=$(ls -d "${TMP_DIR}"/jdk*)

--- a/sign.sh
+++ b/sign.sh
@@ -183,15 +183,9 @@ signRelease()
         zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-        echo "Debug 1 = $MACSIGNSTRING"
-        unzip -vl "${TMP_DIR}/signed.zip"
         echo "Debug 2 = $MACSIGNSTRING"
-        unzip -p . "${TMP_DIR}/signed.zip"  jdk-17.0.8+6/Contents/_CodeSignature/CodeResources
-        echo "Debug 3 = $MACSIGNSTRING"
-        unzip -dj . "${TMP_DIR}/signed.zip" jdk-17.0.8+6/Contents/_CodeSignature/CodeResources
-        echo "Debug 4 = $MACSIGNSTRING"
-        ls
-        TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
+        TESTMACSIGN=`unzip -p . "${TMP_DIR}/signed.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"|grep -i "$MACSIGNSTRING"|wc -l`
+        # TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]
         then
@@ -208,7 +202,7 @@ signRelease()
             echo $iteration Of $max_iterations
             sleep 1
             curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-            TESTMACSIGN2=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
+            TESTMACSIGN2=`unzip -p . "${TMP_DIR}/signed.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"|grep -i "$MACSIGNSTRING"|wc -l`
             echo TESTMACSIGN2 = $TESTMACSIGN2
             if [[ $TESTMACSIGN2 -gt 0 ]]
             then

--- a/sign.sh
+++ b/sign.sh
@@ -184,7 +184,7 @@ signRelease()
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 1 = $MACSIGNSTRING"
-        cat "${TMP_DIR}/signed.zip"
+        ls -l@ "${TMP_DIR}/signed.zip"
         TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]

--- a/sign.sh
+++ b/sign.sh
@@ -145,10 +145,10 @@ signRelease()
             chmod --reference="${dir}/unsigned_${file}" "$f"
             rm -rf "${dir}/unsigned_${file}"
           else
-            MAX_ITERATIONS=20
-            ITERATION=1
-            SUCCESS=false
-            ERRCOUNT=0
+            max_iterations=20
+            iteration=1
+            success=false
+            errcount=0
             echo "Code Not Signed For File $f"
             while [[ $iteration -le $max_iterations ]] && [ $success = false ]; do
               echo $iteration Of $max_iterations

--- a/sign.sh
+++ b/sign.sh
@@ -183,55 +183,9 @@ signRelease()
         zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-        echo "Debug 1"
-        unzip -p "${TMP_DIR}/unsigned.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources" > adb.txt
-        unzip -p "${TMP_DIR}/signed.zip" "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources" > adb2.txt
-        diff adb.txt adb2.txt
-        echo "File 1"
-        cat adb.txt
-        echo "File 2"
-        cat adb2.txt
-        echo "Debug 2 = $MACSIGNSTRING"
-        TESTMACSIGN=`unzip -l "${TMP_DIR}/signed.zip" | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
-        # TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
-        echo "Sign Result = $TESTMACSIGN"
-        if [[ $TESTMACSIGN -gt 0 ]]
-        then
-          echo "Code Signed For File ${TMP_DIR}/signed.zip"
-          rm -rf "${JDK_DIR}"
-          unzip -q -d "${TMP_DIR}" "${TMP_DIR}/signed.zip"
-        else
-          max_iterations=20
-          iteration=1
-          success=false
-          errcount=0
-          echo "Code Not Signed For File ${TMP_DIR}/signed.zip"
-          while [[ $iteration -le $max_iterations ]] && [ $success = false ]; do
-            echo $iteration Of $max_iterations
-            sleep 1
-            curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-            TESTMACSIGN2=`unzip -l "${TMP_DIR}/signed.zip" | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
-            echo TESTMACSIGN2 = $TESTMACSIGN2
-            if [[ $TESTMACSIGN2 -gt 0 ]]
-            then
-              echo "${TMP_DIR}/signed.zip Signed OK On Attempt $iteration"
-              rm -rf "${JDK_DIR}"
-              unzip -q -d "${TMP_DIR}" "${TMP_DIR}/signed.zip"
-              success=true
-            else
-              echo "${TMP_DIR}/signed.zip Failed Signing On Attempt $iteration"
-              success=false
-              iteration=$((iteration+1))
-              errcount=$((errcount+1))
-            fi
-          done
-          if [[ $errcount -gt 0 ]]
-          then
-              echo "Errors Encountered During Signing"
-              echo "Error Count = $errcount"
-              exit 1
-          fi
-        fi
+        diff "${TMP_DIR}/unsigned.zip" "${TMP_DIR}/signed.zip"
+        rm -rf "${JDK_DIR}"
+        unzip -q -d "${TMP_DIR}" "${TMP_DIR}/signed.zip"
       else
         # Login to KeyChain
         # shellcheck disable=SC2046

--- a/sign.sh
+++ b/sign.sh
@@ -170,12 +170,12 @@ signRelease()
                 echo $MACSIGNSTRING >> 3.txt
               fi
             done
-          fi
-          if [[ $errcount -gt 0 ]]
-          then
-          	echo "Errors Encountered During Signing"
-          	echo "Error Count = $errcount"
-            exit 1
+            if [[ $errcount -gt 0 ]]
+            then
+            	echo "Errors Encountered During Signing"
+            	echo "Error Count = $errcount"
+              exit 1
+            fi
           fi
         done
         JDK_DIR=$(ls -d "${TMP_DIR}"/jdk*)

--- a/sign.sh
+++ b/sign.sh
@@ -184,8 +184,51 @@ signRelease()
         zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
-        rm -rf "${JDK_DIR}"
-        unzip -q -d "${TMP_DIR}" "${TMP_DIR}/signed.zip"
+        TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
+        echo "Sign Result = $TESTMACSIGN"
+        if [[ $TESTMACSIGN -gt 0 ]]
+        then
+          echo "Code Signed For File ${TMP_DIR}/signed.zip"
+          rm -rf "${JDK_DIR}"
+          unzip -q -d "${TMP_DIR}" "${TMP_DIR}/signed.zip"
+        else
+          max_iterations=20
+          iteration=1
+          success=false
+          errcount=0
+          echo "Code Not Signed For File ${TMP_DIR}/signed.zip"
+          while [[ $iteration -le $max_iterations ]] && [ $success = false ]; do
+            echo $iteration Of $max_iterations
+            sleep 1
+            curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
+            TESTMACSIGN2=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
+            echo TESTMACSIGN2 = $TESTMACSIGN2
+            if [[ $TESTMACSIGN2 -gt 0 ]]
+            then
+              echo "${TMP_DIR}/signed.zip Signed OK On Attempt $iteration"
+              rm -rf "${JDK_DIR}"
+              unzip -q -d "${TMP_DIR}" "${TMP_DIR}/signed.zip"
+              success=true
+            else
+              echo "${TMP_DIR}/signed.zip Failed Signing On Attempt $iteration"
+              success=false
+              iteration=$((iteration+1))
+              errcount=$((errcount+1))
+              echo $MACSIGNSTRING >> 3.txt
+            fi
+          done
+          if [[ $errcount -gt 0 ]]
+          then
+            echo "Errors Encountered During Signing"
+            echo "Error Count = $errcount"
+            exit 1
+          fi
+
+
+
+
+
+
       else
         # Login to KeyChain
         # shellcheck disable=SC2046

--- a/sign.sh
+++ b/sign.sh
@@ -134,6 +134,7 @@ signRelease()
           mv "$f" "${dir}/unsigned_${file}"
           curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
           TESTMACSIGN=`grep -i "$MACSIGNSTRING" "$f"|wc -l`
+          grep -i "$MACSIGNSTRING" "$f"
           if [ $TESTMACSIGN -gt 0 ]
           then
             echo "Code Signed"
@@ -148,6 +149,7 @@ signRelease()
               echo "Code Not Signed - Have Another Try"
               sleep 1
               curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
+              grep -i "$MACSIGNSTRING" "$f"
               TESTMACSIGN2=`grep -i "$MACSIGNSTRING" "$f"|wc -l`
               if [ $TESTMACSIGN2 -gt 0 ]
               then

--- a/sign.sh
+++ b/sign.sh
@@ -180,11 +180,11 @@ signRelease()
         JDK_DIR=$(ls -d "${TMP_DIR}"/jdk*)
         JDK=$(basename "${JDK_DIR}")
         cd "${TMP_DIR}"
-        zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
+        zip -r "${TMP_DIR}/unsigned.zip" "${JDK}"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 1"
-        unzip -vl "@${TMP_DIR}/unsigned.zip"
+        unzip -vl "${TMP_DIR}/unsigned.zip"
         echo "Debug 2 = $MACSIGNSTRING"
         TESTMACSIGN=`unzip -l "${TMP_DIR}/signed.zip" | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
         # TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`

--- a/sign.sh
+++ b/sign.sh
@@ -137,7 +137,7 @@ signRelease()
           mv "$f" "${dir}/unsigned_${file}"
           curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
           echo File = "$f"
-          TESTMACSIGN=(grep -ic "$MACSIGNSTRING" "$f")
+          TESTMACSIGN=$(grep -ic "$MACSIGNSTRING" "$f")
           echo Sign Result = "$TESTMACSIGN"
           if [ "$TESTMACSIGN" -gt 0 ]
           then
@@ -154,7 +154,7 @@ signRelease()
               echo $iteration Of $max_iterations
               sleep 1
               curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-              TESTMACSIGN2=(grep -ic "$MACSIGNSTRING" "$f")
+              TESTMACSIGN2=$(grep -ic "$MACSIGNSTRING" "$f")
               echo TESTMACSIGN2 = "$TESTMACSIGN2"
               if [ "$TESTMACSIGN2" -gt 0 ]
               then

--- a/sign.sh
+++ b/sign.sh
@@ -184,7 +184,7 @@ signRelease()
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 1 = $MACSIGNSTRING"
-        ls -l@ "${TMP_DIR}/signed.zip"
+        unzip -vl "${TMP_DIR}/signed.zip"
         TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]

--- a/sign.sh
+++ b/sign.sh
@@ -155,7 +155,7 @@ signRelease()
               sleep 1
               curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
               TESTMACSIGN2=(grep -ic "$MACSIGNSTRING" "$f")
-              echo TESTMACSIGN2 = $TESTMACSIGN2
+              echo TESTMACSIGN2 = "$TESTMACSIGN2"
               if [[ $TESTMACSIGN2 -gt 0 ]]
               then
                 echo "$f Signed OK On Attempt $iteration"

--- a/sign.sh
+++ b/sign.sh
@@ -167,7 +167,6 @@ signRelease()
                 success=false
                 iteration=$((iteration+1))
                 errcount=$((errcount+1))
-                echo $MACSIGNSTRING >> 3.txt
               fi
             done
             if [[ $errcount -gt 0 ]]
@@ -184,6 +183,8 @@ signRelease()
         zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
+        echo "Debug 1 = $MACSIGNSTRING"
+        strings "${TMP_DIR}/signed.zip"
         TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]
@@ -214,7 +215,6 @@ signRelease()
               success=false
               iteration=$((iteration+1))
               errcount=$((errcount+1))
-              echo $MACSIGNSTRING >> 3.txt
             fi
           done
         fi

--- a/sign.sh
+++ b/sign.sh
@@ -181,10 +181,10 @@ signRelease()
         JDK=$(basename "${JDK_DIR}")
         cd "${TMP_DIR}"
         zip -q -r "${TMP_DIR}/unsigned.zip" "${JDK}"
-        echo "Debug 1"
-        zip -vl "${TMP_DIR}/unsigned.zip"
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
+        echo "Debug 1"
+        unzip -vl "@${TMP_DIR}/unsigned.zip"
         echo "Debug 2 = $MACSIGNSTRING"
         TESTMACSIGN=`unzip -l "${TMP_DIR}/signed.zip" | grep -c "jdk-17.0.8+6/Contents/_CodeSignature/CodeResources"`
         # TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`

--- a/sign.sh
+++ b/sign.sh
@@ -184,7 +184,7 @@ signRelease()
         cd -
         curl --fail --silent --show-error -o "${TMP_DIR}/signed.zip" -F file="@${TMP_DIR}/unsigned.zip" https://cbi.eclipse.org/macos/codesign/sign
         echo "Debug 1 = $MACSIGNSTRING"
-        strings "${TMP_DIR}/signed.zip"
+        cat "${TMP_DIR}/signed.zip"
         TESTMACSIGN=`grep -i "$MACSIGNSTRING" "${TMP_DIR}/signed.zip"|wc -l`
         echo "Sign Result = $TESTMACSIGN"
         if [[ $TESTMACSIGN -gt 0 ]]

--- a/sign.sh
+++ b/sign.sh
@@ -136,8 +136,8 @@ signRelease()
           file=$(basename "$f")
           mv "$f" "${dir}/unsigned_${file}"
           curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-          echo File = $f
-          TESTMACSIGN=`grep -i "$MACSIGNSTRING" "$f"|wc -l`
+          echo File = "$f"
+          TESTMACSIGN=(grep -ic "$MACSIGNSTRING" "$f")
           echo "Sign Result = $TESTMACSIGN"
           if [[ $TESTMACSIGN -gt 0 ]]
           then
@@ -154,7 +154,7 @@ signRelease()
               echo $iteration Of $max_iterations
               sleep 1
               curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
-              TESTMACSIGN2=`grep -i "$MACSIGNSTRING" "$f"|wc -l`
+              TESTMACSIGN2==(grep -ic "$MACSIGNSTRING" "$f")
               echo TESTMACSIGN2 = $TESTMACSIGN2
               if [[ $TESTMACSIGN2 -gt 0 ]]
               then

--- a/sign.sh
+++ b/sign.sh
@@ -138,8 +138,8 @@ signRelease()
           curl --fail --silent --show-error -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
           echo File = "$f"
           TESTMACSIGN=(grep -ic "$MACSIGNSTRING" "$f")
-          echo "Sign Result = $TESTMACSIGN"
-          if [[ $TESTMACSIGN -gt 0 ]]
+          echo Sign Result = "$TESTMACSIGN"
+          if [[ "$TESTMACSIGN" -gt 0 ]]
           then
             echo "Code Signed For File $f"
             chmod --reference="${dir}/unsigned_${file}" "$f"
@@ -156,7 +156,7 @@ signRelease()
               curl --fail -o "$f" -F file="@${dir}/unsigned_${file}" -F entitlements="@$ENTITLEMENTS" https://cbi.eclipse.org/macos/codesign/sign
               TESTMACSIGN2=(grep -ic "$MACSIGNSTRING" "$f")
               echo TESTMACSIGN2 = "$TESTMACSIGN2"
-              if [[ $TESTMACSIGN2 -gt 0 ]]
+              if [[ "$TESTMACSIGN2" -gt 0 ]]
               then
                 echo "$f Signed OK On Attempt $iteration"
                 chmod --reference="${dir}/unsigned_${file}" "$f"


### PR DESCRIPTION
Fixes #3428 

Include a 20 retry for each library, when it fails to sign at the first attempt.