### PR TITLE
Add -q option for diff

### DIFF
--- a/tooling/repro_common.sh
+++ b/tooling/repro_common.sh
@@ -26,7 +26,7 @@ function expandJDK() {
 
   mkdir "${JDK_ROOT}_CP"
   cp -R ${JDK_ROOT}/* ${JDK_ROOT}_CP
-  echo "Expanding the 'modules' Image to remove signatures from within.."
+  echo "Expanding the 'modules' Image to compare extracted files"
   modulesFile="${JDK_DIR}/lib/modules"
   mkdir "${JDK_DIR}/lib/modules_extracted"
   extractedDir="${JDK_DIR}/lib/modules_extracted"

--- a/tooling/repro_compare.sh
+++ b/tooling/repro_compare.sh
@@ -51,7 +51,7 @@ echo "Number of files: ${files1}"
 rc=0
 output="repro_diff.out"
 echo "Comparing ${JDK_DIR1} with ${JDK_DIR2} ... output to file: ${output}"
-diff -r "${JDK_DIR1}" "${JDK_DIR2}" > "${output}" || rc=$?
+diff -r -q "${JDK_DIR1}" "${JDK_DIR2}" > "${output}" || rc=$?
 
 num_differences=$(wc -l < "${output}")
 echo "Number of differences: ${num_differences}"


### PR DESCRIPTION
Just print a line when the files differ.  Does not output a list of changes, which can be piped to wc -l to count the number of file different.

Fix #3437 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>