### PR TITLE
aix: use fullpath for (g)make so PATH does not need to be modified 

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -472,7 +472,10 @@ function configDefaults() {
   BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]=""
 
   case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
-    aix | sunos | *bsd )
+    aix )
+      BUILD_CONFIG[MAKE_COMMAND_NAME]="/opt/freeware/bin/make_64"
+      ;;
+    sunos | *bsd )
       BUILD_CONFIG[MAKE_COMMAND_NAME]="gmake"
       ;;
     * )


### PR DESCRIPTION
at system level.

See issue: https://github.com/adoptium/infrastructure/issues/1544

The playbooks have prefixed system level PATH with /opt/freeware/bin. As that contains _coreutils_ certain AIX commands that _coreutils_ has repeatedly denied to add an **AIX** argument (noteablu `-p`) this setting breaks many AIX management commands - even standard boot (ie, called from rcboot) scripts.

In the issue noted above it is stated that this is needed so that `gmake` is found.

This PR points the config at the actual binary `/opt/freeware/bin/make_64` rather than depend on PATH and symbolic links to call the application.