### PR TITLE
Fix SBOM glibc, gcc and bootjdk settings

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -953,7 +953,7 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
 addGCC() {
    local inputConfigFile="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/configure.txt"
 
-   local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "C Compiler: Version" | tr -s " " | cut -d" " -f4)"
+   local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | tr -s " " | grep "C Compiler: Version" | cut -d" " -f4)"
 
    echo "Adding GCC version to SBOM: ${gcc_version}"
    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GCC" "${gcc_version}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -930,7 +930,7 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
    if [[ "$libc_type" == "musl" ]]; then
      # Get musl build ldd version
 echo "CHECKING MUSL"
-     local MUSL_VERSION="$(ldd --version | grep "Version" | tr -s " " | cut -d" " -f2)"
+     local MUSL_VERSION="$(ldd --version 2>&1 | grep "Version" | tr -s " " | cut -d" " -f2)"
      echo "Adding MUSL version to SBOM: ${MUSL_VERSION}"
      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"
    else

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -928,9 +928,8 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
    fi
 
    if [[ "$libc_type" == "musl" ]]; then
-     # This is the only way to print the musl version
-     #local MUSL_VERSION=$("/lib/libc.musl-x86_64.so.1" 2>&1 | grep "Version" | tr -s " " | cut -d" " -f2)
-     local MUSL_VERSION=$(ldd --version)
+     # Get musl build ldd version
+     local MUSL_VERSION=$(ldd --version | grep "Version" | tr -s " " | cut -d" " -f2)
      echo "Adding MUSL version to SBOM: ${MUSL_VERSION}"
      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"
    else

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -953,6 +953,8 @@ addBootJDK() {
    local bootjdk
    # JDK8 BootJDK build versions(jdk7?) vary in format compared to jdk-11+
    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
+     bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed 's/.*(at \([^)]*\)).*/\1/')
+     echo "JDK: ${bootjdk}"
      if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]; then
        bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed -E "s/^.*build ([^),]+).*/\1/")
      else

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -953,10 +953,10 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
 addGCC() {
    local inputConfigFile="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/configure.txt"
 
-   local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "C Compiler: Version" | tr -s" " | cut -d" " -f4)"
+   local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "C Compiler: Version" | tr -s " " | cut -d" " -f4)"
 
    echo "Adding GCC version to SBOM: ${gcc_version}"
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GCC" "${CC_VERSION_NUMBER}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GCC" "${gcc_version}"
 }
 
 addBootJDK() {

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -926,7 +926,8 @@ echo $CC
 echo $CC
    local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
 echo $SYSROOT_CFLAGS
- echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1
+# echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1
+"/lib/libc.musl-x86_64.so.1"
    local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
    local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)
    local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -926,7 +926,7 @@ echo $CC
 echo $CC
    local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
 echo $SYSROOT_CFLAGS
-
+ echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1
    local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
    local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)
    local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -923,7 +923,7 @@ addGLIBCforLinux() {
      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"
    else
      # Get GLIBC from configured build spec.gmk sysroot and features.h definitions
-
+cat /home/jenkins/workspace/build-scripts/jobs/jdk8u/jdk8u-linux-x64-temurin/workspace/build/src/build/linux-x86_64-normal-server-release/spec.gmk
      # Get CC and SYSROOT_CFLAGS from the built build spec.gmk.
      local CC=$(grep "^CC :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk)
      # Remove env=xx from CC, so we can call from bash to get __GLIBC.

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -924,10 +924,10 @@ addGLIBCforLinux() {
    else
      # Get GLIBC from configured build spec.gmk sysroot and features.h definitions
      # Get CC and SYSROOT_CFLAGS from the built build spec.gmk.
-     local CC=$(grep "^CC :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk)
+     local CC=$(grep "^CC[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk)
      # Remove env=xx from CC, so we can call from bash to get __GLIBC.
      CC=$(echo "$CC" | tr -s " " | cut -d" " -f3- | sed -E "s/[^ ]*=[^ ]*//g")
-     local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
+     local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
      local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
      local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)
      local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -923,14 +923,11 @@ addGLIBCforLinux() {
      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"
    else
      # Get GLIBC from configured build spec.gmk sysroot and features.h definitions
-cat /home/jenkins/workspace/build-scripts/jobs/jdk8u/jdk8u-linux-x64-temurin/workspace/build/src/build/linux-x86_64-normal-server-release/spec.gmk
      # Get CC and SYSROOT_CFLAGS from the built build spec.gmk.
      local CC=$(grep "^CC :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk)
      # Remove env=xx from CC, so we can call from bash to get __GLIBC.
      CC=$(echo "$CC" | tr -s " " | cut -d" " -f3- | sed -E "s/[^ ]*=[^ ]*//g")
-echo "$CC"
      local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
-echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1
      local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
      local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)
      local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -928,7 +928,9 @@ cat /home/jenkins/workspace/build-scripts/jobs/jdk8u/jdk8u-linux-x64-temurin/wor
      local CC=$(grep "^CC :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk)
      # Remove env=xx from CC, so we can call from bash to get __GLIBC.
      CC=$(echo "$CC" | tr -s " " | cut -d" " -f3- | sed -E "s/[^ ]*=[^ ]*//g")
+echo "$CC"
      local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
+echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1
      local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
      local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)
      local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -924,7 +924,7 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
    local libc_type="$(grep "checking openjdk-target C library\.\.\." "${inputConfigFile}" | cut -d" " -f5)"
    if [[ "$libc_type" == "default" ]]; then
      # Default libc for linux is gnu gcc
-     libc_type = "gnu"
+     libc_type="gnu"
    fi
 
    if [[ "$libc_type" == "musl" ]]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -921,8 +921,11 @@ addGLIBCforLinux() {
    # Get CC and SYSROOT_CFLAGS from the built build spec.gmk.
    local CC=$(grep "^CC :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk)
    # Remove env=xx from CC, so we can call from bash to get __GLIBC.
+echo $CC
    CC=$(echo "$CC" | tr -s " " | cut -d" " -f3- | sed -E "s/[^ ]*=[^ ]*//g")
+echo $CC
    local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS :=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
+echo $SYSROOT_CFLAGS
 
    local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
    local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -929,20 +929,21 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
 
    if [[ "$libc_type" == "musl" ]]; then
      # Get musl build ldd version
-     local MUSL_VERSION=$(ldd --version | grep "Version" | tr -s " " | cut -d" " -f2)
+echo "CHECKING MUSL"
+     local MUSL_VERSION="$(ldd --version | grep "Version" | tr -s " " | cut -d" " -f2)"
      echo "Adding MUSL version to SBOM: ${MUSL_VERSION}"
      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"
    else
      # Get GLIBC from configured build spec.gmk sysroot and features.h definitions
 
      # Get CC and SYSROOT_CFLAGS from the built build spec.gmk.
-     local CC=$(grep "^CC[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | sed "s/^CC[ ]*:=[ ]*//")
+     local CC="$(grep "^CC[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | sed "s/^CC[ ]*:=[ ]*//")"
      # Remove env=xx from CC, so we can call from bash to get __GLIBC.
      CC=$(echo "$CC" | tr -s " " | sed -E "s/[^ ]*=[^ ]*//g")
-     local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
+     local SYSROOT_CFLAGS="$(grep "^SYSROOT_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)"
 
-     local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
-     local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)
+     local GLIBC_MAJOR="$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)"
+     local GLIBC_MINOR="$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)"
      local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"
 
      echo "Adding GLIBC version to SBOM: ${GLIBC_VERSION}"
@@ -968,7 +969,7 @@ addBootJDK() {
        bootjava="${bootjava}.exe"
    fi
    echo "BootJDK java : ${bootjava}"
-   local bootjdk=$("${bootjava}" -XshowSettings 2>&1 | grep "java\.runtime\.version" | tr -s " " | cut -d" " -f4 | sed "s/\"//g")
+   local bootjdk="$("${bootjava}" -XshowSettings 2>&1 | grep "java\.runtime\.version" | tr -s " " | cut -d" " -f4 | sed "s/\"//g")"
 
    echo "Adding BOOTJDK to SBOM: ${bootjdk}"
    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "BOOTJDK" "${bootjdk}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -949,10 +949,19 @@ addBootJDK() {
    local inputConfigFile="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/configure.txt"
 
    local bootjdk
-   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]; then
-       bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed -E "s/^.*build ([^),]+).*/\1/" | sed "s/\-beta//g" | sed "s/\-.*//g")
+   # JDK8 BootJDK build versions(jdk7?) vary in format compared to jdk-11+
+   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
+     if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]; then
+       bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed -E "s/^.*build ([^),]+).*/\1/")
+     else
+       bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed "s/^.*build \([^),]\+\).*/\1/")
+     fi
    else
+     if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]; then
+       bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed -E "s/^.*build ([^),]+).*/\1/" | sed "s/\-beta//g" | sed "s/\-.*//g")
+     else
        bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed "s/^.*build \([^),]\+\).*/\1/" | sed "s/\-beta//g" | sed "s/\-.*//g")
+     fi
    fi
    echo "Adding BOOTJDK to SBOM: ${bootjdk}"
    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "BOOTJDK" "${bootjdk}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -916,7 +916,7 @@ checkingToolSummary() {
 # Below add versions to sbom | Facilitate reproducible builds
 
 addGLIBCforLinux() {
-cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/linux-x86_64-normal-server-release/spec.gmk
+cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk
 
    # Determine target build LIBC from configure log "target system type" which is consistent for jdk8+
    local inputConfigFile="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/configure.txt"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -953,7 +953,7 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
 addGCC() {
    local inputConfigFile="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/configure.txt"
 
-   local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | tr -s " " | grep "C Compiler: Version" | cut -d" " -f4)"
+   local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | tr -s " " | grep "C Compiler: Version" | cut -d" " -f5)"
 
    echo "Adding GCC version to SBOM: ${gcc_version}"
    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GCC" "${gcc_version}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -934,9 +934,16 @@ addGCC() {
 }
 
 addBootJDK() {
-   echo "Checking and getting BootJDK Version:"
    inputConfigFile="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/configure.txt"
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "BOOTJDK" "$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | tr -s " " | cut -d " " -f 6)"
+
+   local bootjdk
+   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]; then
+       bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed -E "s/^.*build ([^),]+).*/\1/" | sed "s/\-beta//g" | sed "s/\-.*//g")
+   else
+       bootjdk=$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | grep "Boot JDK:" | sed "s/^.*build \([^),]\+\).*/\1/" | sed "s/\-beta//g" | sed "s/\-.*//g")
+   fi
+   echo "Adding BOOTJDK to SBOM: ${bootjdk}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "BOOTJDK" "${bootjdk}"
 }
 
 getGradleJavaHome() {

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -924,7 +924,9 @@ addGLIBCforLinux() {
    else
      # Get GLIBC from configured build spec.gmk sysroot and features.h definitions
      # Get CC and SYSROOT_CFLAGS from the built build spec.gmk.
+cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/linux-x86_64-normal-server-release/spec.gmk
      local CC=$(grep "^CC[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk)
+echo "CC=$CC"
      # Remove env=xx from CC, so we can call from bash to get __GLIBC.
      CC=$(echo "$CC" | tr -s " " | cut -d" " -f3- | sed -E "s/[^ ]*=[^ ]*//g")
      local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -916,8 +916,6 @@ checkingToolSummary() {
 # Below add versions to sbom | Facilitate reproducible builds
 
 addGLIBCforLinux() {
-cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk
-
    # Determine target build LIBC from configure log "target system type" which is consistent for jdk8+
    local inputConfigFile="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/configure.txt"
    # eg: checking openjdk-target C library... musl
@@ -929,7 +927,6 @@ cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[O
 
    if [[ "$libc_type" == "musl" ]]; then
      # Get musl build ldd version
-echo "CHECKING MUSL"
      local MUSL_VERSION="$(ldd --version 2>&1 | grep "Version" | tr -s " " | cut -d" " -f2)"
      echo "Adding MUSL version to SBOM: ${MUSL_VERSION}"
      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -928,6 +928,8 @@ addGLIBCforLinux() {
      # Remove env=xx from CC, so we can call from bash to get __GLIBC.
      CC=$(echo "$CC" | tr -s " " | cut -d" " -f3- | sed -E "s/[^ ]*=[^ ]*//g")
      local SYSROOT_CFLAGS=$(grep "^SYSROOT_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | tr -s " " | cut -d" " -f3-)
+echo "CC=$CC"
+echo "SYSROOT=$SYSROOT_CFLAGS"
      local GLIBC_MAJOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC__" | cut -d" " -f3)
      local GLIBC_MINOR=$(echo "#include <features.h>" | $CC $SYSROOT_CFLAGS -dM -E - 2>&1 | tr -s " " | grep "#define __GLIBC_MINOR__" | cut -d" " -f3)
      local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -968,7 +968,7 @@ addBootJDK() {
        bootjava="${bootjava}.exe"
    fi
    echo "BootJDK java : ${bootjava}"
-   local bootjdk=$("${bootjava}" -XshowSettings 2>&1 | grep "java\.runtime\.version" | tr -s " " | cut -d" " -f4)
+   local bootjdk=$("${bootjava}" -XshowSettings 2>&1 | grep "java\.runtime\.version" | tr -s " " | cut -d" " -f4 | sed "s/\"//g")
 
    echo "Adding BOOTJDK to SBOM: ${bootjdk}"
    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "BOOTJDK" "${bootjdk}"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3445

Currently GLIBC is not being detected correctly.
Bootjdk is also missing the "+build".

- Fixed various grep/sed and invocation issues with getting GLIBC settings from features.h, and ensure works on all platforms.
- Updated to detect libc type from the build configuration, and then handle MUSL or GLIBC accordingly.
- Fixed Bootjdk detect to find btto jdk location from the build configuration, and then obtain the java.runtime.version.
