### PR TITLE
sbom: Use latest LTS JDK (17) for CycloneDX in preference to 8/11

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -773,6 +773,8 @@ setupAntEnv() {
 
   if [ ${JAVA_HOME+x} ] && [ -d "${JAVA_HOME}" ]; then
     javaHome=${JAVA_HOME}
+  elif [ ${JDK17_BOOT_DIR+x} ] && [ -d "${JDK17_BOOT_DIR}" ]; then
+    javaHome=${JDK17_BOOT_DIR}
   elif [ ${JDK8_BOOT_DIR+x} ] && [ -d "${JDK8_BOOT_DIR}" ]; then
     javaHome=${JDK8_BOOT_DIR}
   elif [ ${JDK11_BOOT_DIR+x} ] && [ -d "${JDK11_BOOT_DIR}" ]; then


### PR DESCRIPTION
Fixes an issue with Alpine/aarch64 build pipelines periodically hanging because it's trying to use a buggy JDK11