### PR TITLE
smoketest: fix shenandoah and zgc feature check on linux-riscv

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
@@ -74,6 +74,11 @@ public class FeatureTests {
         if (jdkVersion.isNewerOrEqual(17) && jdkPlatform.runsOn(OperatingSystem.LINUX, Architecture.PPC64LE)) {
         	shouldBePresent = true;
         }
+        if (jdkVersion.isNewerOrEqual(19) || jdkVersion.isNewerOrEqualSameFeature(17, 0, 9)) {
+            if (jdkPlatform.runsOn(OperatingSystem.LINUX, Architecture.RISCV64)) {
+                shouldBePresent = true;
+            }
+        }
 
         LOGGER.info(String.format("Detected %s on %s, expect Shenandoah to be present: %s",
                 jdkVersion, jdkPlatform, shouldBePresent));
@@ -127,6 +132,11 @@ public class FeatureTests {
                      */
                     // || jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.X64)
             ) {
+                shouldBePresent = true;
+            }
+        }
+        if (jdkVersion.isNewerOrEqual(19) || jdkVersion.isNewerOrEqualSameFeature(17, 0, 9)) {
+            if (jdkPlatform.runsOn(OperatingSystem.LINUX, Architecture.RISCV64)) {
                 shouldBePresent = true;
             }
         }


### PR DESCRIPTION
Linux-RISCV comes with support for Shenandoah and ZGC, and it's been merged in Java 19 and backported to Java 17 (starting with 17.0.9)

Fixes https://github.com/adoptium/temurin-build/issues/3454