### PR TITLE
Ensure CCache disabled for all reproducible jdk-17 & jdk-19+ builds

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -100,9 +100,8 @@ configureReproducibleBuildParameter() {
       then
           # TZ issue: https://github.com/adoptium/temurin-build/issues/3075
           export TZ=UTC
-          # Use release date and disable CCache( remove --enable-ccache if exist)
-          addConfigureArg "--with-source-date=version"  " --disable-ccache"
-          CONFIGURE_ARGS="${CONFIGURE_ARGS//--enable-ccache/}"
+          # Use release date
+          addConfigureArg "--with-source-date=" "version" 
       else
           # Use BUILD_TIMESTAMP date
 
@@ -120,6 +119,11 @@ configureReproducibleBuildParameter() {
           # Use supplied date
           addConfigureArg "--with-hotspot-build-time=" "'${BUILD_CONFIG[BUILD_TIMESTAMP]}'"
       fi
+
+      # disable CCache (remove --enable-ccache if exist)
+      addConfigureArg "--disable-ccache"
+      CONFIGURE_ARGS="${CONFIGURE_ARGS//--enable-ccache/}"
+
       # Ensure reproducible and comparable binary with a unique build user identifier
       addConfigureArg "--with-build-user=" "admin"
       if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -98,8 +98,6 @@ configureReproducibleBuildParameter() {
       # Enable reproducible builds implicitly with --with-source-date
       if [ "${BUILD_CONFIG[RELEASE]}" == "true" ]
       then
-          # TZ issue: https://github.com/adoptium/temurin-build/issues/3075
-          export TZ=UTC
           # Use release date
           addConfigureArg "--with-source-date=" "version" 
       else
@@ -119,6 +117,9 @@ configureReproducibleBuildParameter() {
           # Use supplied date
           addConfigureArg "--with-hotspot-build-time=" "'${BUILD_CONFIG[BUILD_TIMESTAMP]}'"
       fi
+
+      # TZ issue: https://github.com/adoptium/temurin-build/issues/3075
+      export TZ=UTC
 
       # disable CCache (remove --enable-ccache if exist)
       addConfigureArg "--disable-ccache"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -122,7 +122,7 @@ configureReproducibleBuildParameter() {
       export TZ=UTC
 
       # disable CCache (remove --enable-ccache if exist)
-      addConfigureArg "--disable-ccache"
+      addConfigureArg "--disable-ccache" ""
       CONFIGURE_ARGS="${CONFIGURE_ARGS//--enable-ccache/}"
 
       # Ensure reproducible and comparable binary with a unique build user identifier


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3469

Ensure reproducible jdk-17 & jdk-19+ builds disable ccache, as it produces non-deterministic binaries: https://github.com/adoptium/temurin-build/issues/2973#issuecomment-1150295701

Also, in similar vane, for nightly builds the TZ needs to always be set to UTC: https://github.com/adoptium/temurin-build/issues/3075
