### PR TITLE
Add code to cross compile x64 jdk8 on arm64 mac

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -132,6 +132,7 @@ CONFIGURE_ARGS_FOR_ANY_PLATFORM=""
 CONFIGURE_ARGS=${CONFIGURE_ARGS:-""}
 BUILD_ARGS=${BUILD_ARGS:-""}
 VARIANT_ARG=""
+MAC_ROSETTA_PREFIX=""
 
 if [ -z "${JDK_BOOT_VERSION}" ]
 then
@@ -245,4 +246,4 @@ echo "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boo
 CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM//\"/temporary_speech_mark_placeholder}"
 
 # shellcheck disable=SC2086
-bash -c "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
+bash -c "$MAC_ROSETTA_PREFIX $PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -22,10 +22,18 @@ source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 export MACOSX_DEPLOYMENT_TARGET=10.9
 export BUILD_ARGS="${BUILD_ARGS}"
 
+## JDK8 only: If, at this point in the build, the architecure of the machine is arm64 while the ARCHITECTURE variable
+## is x64 then we need to add the cross compilation option --openjdk-target=x86_64-apple-darwin
+MACHINEARCHITECURE=$(uname -a)
+
 if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
 then
-  XCODE_SWITCH_PATH="/Applications/Xcode.app"
+  XCODE_SWITCH_PATH="/Applications/Xcode-11.7.app"
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-toolchain-type=clang"
+  if [ "${MACHINEARCHITECURE}" == "arm64" && "${ARCHITECTURE}" == "x64"]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=x86_64-apple-darwin"
+    MAC_ROSETTA_PREFIX="arch -x86_64"
+  fi
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
     export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"


### PR DESCRIPTION
ref https://github.com/adoptium/temurin-build/issues/3487, https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1708716478, https://github.com/adoptium/temurin-build/issues/3354#issuecomment-1743313904

Added the code/steps required to:

- Cross compile mac x64 jdk8 on arm64 mac
- Use Xcode11.7 for mac x64 jdk8 builds on both x64 and arm64 mac machines

Considering the builds in https://github.com/adoptium/infrastructure/issues/2536#issuecomment-1697270848 I could add the `--openjdk-target=x86_64-apple-darwin` option to `$CONFIGURE_ARGS_FOR_ANY_PLATFORM` for any jdk cross compilation build not just jdk8 but thats up for discussion