### PR TITLE
Ensure SBOM FreeType version is set correctly for system and bundled settings

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -929,11 +929,13 @@ addFreeTypeVersionInfo() {
        FREETYPE_TO_USE="$(grep "^FREETYPE_TO_USE[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | sed "s/^FREETYPE_TO_USE[ ]*:=[ ]*//")"
    fi
 
+   echo "FREETYPE_TO_USE=${FREETYPE_TO_USE}"
+
    local version="Unknown"
    local freetypeInclude=""
    if [ "${FREETYPE_TO_USE}" == "system" ]; then
       local FREETYPE_CFLAGS="$(grep "^FREETYPE_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | sed "s/^FREETYPE_CFLAGS[ ]*:=[ ]*//" | sed "s/\-I//g")"
-      echo "FREETYPE_CFLAGS paths=${FREETYPE_CFLAGS}"
+      echo "FREETYPE_CFLAGS include paths=${FREETYPE_CFLAGS}"
 
       # Search freetype include path for freetype.h
       local freetypeIncludeDirs=(${FREETYPE_CFLAGS})

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -941,11 +941,16 @@ addFreeTypeVersionInfo() {
       local freetypeIncludeDirs=(${FREETYPE_CFLAGS})
       for i in "${!freetypeIncludeDirs[@]}"
       do
-          local include="${freetypeIncludeDirs[i]}/freetype/freetype.h"
-          echo "Checking for FreeType include ${include}"
-          if [[ -f "${include}" ]]; then
-              echo "Found ${include}"
-              freetypeInclude="${include}"
+          local include1="${freetypeIncludeDirs[i]}/freetype/freetype.h"
+          local include2="${freetypeIncludeDirs[i]}/freetype.h"
+
+          echo "Checking for FreeType include in path ${freetypeIncludeDirs[i]}"
+          if [[ -f "${include1}" ]]; then
+              echo "Found ${include1}"
+              freetypeInclude="${include1}"
+          elif [[ -f "${include2}" ]]; then
+              echo "Found ${include2}"
+              freetypeInclude="${include2}
           fi
       done
    elif [ "${FREETYPE_TO_USE}" == "bundled" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -950,7 +950,7 @@ addFreeTypeVersionInfo() {
               freetypeInclude="${include1}"
           elif [[ -f "${include2}" ]]; then
               echo "Found ${include2}"
-              freetypeInclude="${include2}
+              freetypeInclude="${include2}"
           fi
       done
    elif [ "${FREETYPE_TO_USE}" == "bundled" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -922,10 +922,10 @@ checkingToolSummary() {
 
 # Determine FreeType version being used in the build from either the system or bundled freetype.h definition
 addFreeTypeVersionInfo() {
-   # Default to "system" the jdk8 only value
+   # Default to "system"
    local FREETYPE_TO_USE="system"
    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" != "${JDK8_CORE_VERSION}" ]; then
-       # Get FreeType used from build spec.gmk, "bundled" or "system"
+       # For jdk-11+ get FreeType used from build spec.gmk, which can be "bundled" or "system"
        FREETYPE_TO_USE="$(grep "^FREETYPE_TO_USE[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | sed "s/^FREETYPE_TO_USE[ ]*:=[ ]*//")"
    fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -932,7 +932,7 @@ addFreeTypeVersionInfo() {
    local version="Unknown"
    local freetypeInclude=""
    if [ "${FREETYPE_TO_USE}" == "system" ]; then
-      local FREETYPE_CFLAGS="$(grep "^FREETYPE_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | sed "s/^FREETYPE_CFLAGS[ ]*:=[ ]*//" | sed "s/\-I//")"
+      local FREETYPE_CFLAGS="$(grep "^FREETYPE_CFLAGS[ ]*:=" ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/*/spec.gmk | sed "s/^FREETYPE_CFLAGS[ ]*:=[ ]*//" | sed "s/\-I//g")"
       echo "FREETYPE_CFLAGS paths=${FREETYPE_CFLAGS}"
 
       # Search freetype include path for freetype.h

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -938,6 +938,7 @@ addFreeTypeVersionInfo() {
       echo "FREETYPE_CFLAGS include paths=${FREETYPE_CFLAGS}"
 
       # Search freetype include path for freetype.h
+      # shellcheck disable=SC2206
       local freetypeIncludeDirs=(${FREETYPE_CFLAGS})
       for i in "${!freetypeIncludeDirs[@]}"
       do

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -471,9 +471,7 @@ checkingAndDownloadingFreeType() {
       ;;
     esac
 
-    # Fetch the sha for the commit we just cloned
     cd freetype || exit
-    FREETYPE_SHA=$(git rev-parse HEAD) || exit
 
     if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
       return

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -450,7 +450,6 @@ checkingAndDownloadingFreeType() {
 
   FOUND_FREETYPE=$(find "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedfreetype/lib/" -name "${FREETYPE_FONT_SHARED_OBJECT_FILENAME}" || true)
 
-  FREETYPE_BUILD_INFO="Unknown"
   if [[ -n "$FOUND_FREETYPE" ]]; then
     echo "Skipping FreeType download"
   else
@@ -475,11 +474,8 @@ checkingAndDownloadingFreeType() {
     # Fetch the sha for the commit we just cloned
     cd freetype || exit
     FREETYPE_SHA=$(git rev-parse HEAD) || exit
-    FREETYPE_BUILD_INFO="https://github.com/freetype/freetype/commit/${FREETYPE_SHA}"
 
     if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-      # Record buildinfo version
-      echo "${FREETYPE_BUILD_INFO}" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_version_freetype.txt"
       return
     fi
 
@@ -534,9 +530,6 @@ checkingAndDownloadingFreeType() {
       fi
     fi
   fi
-
-  # Record buildinfo version
-  echo "${FREETYPE_BUILD_INFO}" > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_version_freetype.txt"
 }
 
 # Recording Build image SHA into docker.txt


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3493

Determines what type of FreeType build it was "system" or "bundled", then look for the freetype.h from that freetype installation/openjdk bundle, to determine the FREETYPE_MAJOR,MINOR,PATCH
