### PR TITLE
switch macOS builds to use M1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
 
   build_macos:
     name: macOS
-    runs-on: macos-11
+    runs-on: macos-13-xlarge
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
testing the new M1 runners (https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/)