### PR TITLE
Add --openjdk-target=x86_64-apple-darwin argument when crosscompiling jdk11+ (Mac)

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -26,12 +26,17 @@ export BUILD_ARGS="${BUILD_ARGS}"
 ## is x64 then we need to add the cross compilation option --openjdk-target=x86_64-apple-darwin
 MACHINEARCHITECTURE=$(uname -m)
 
+if [[ "${MACHINEARCHITECTURE}" == "arm64" ]] && [[ "${ARCHITECTURE}" == "x64" ]]; then
+  # Adds cross compilation arg if building x64 binary on arm64
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=x86_64-apple-darwin"
+fi
+
 if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
 then
   XCODE_SWITCH_PATH="/Applications/Xcode-11.7.app"
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-toolchain-type=clang"
   if [[ "${MACHINEARCHITECTURE}" == "arm64" ]] && [[ "${ARCHITECTURE}" == "x64" ]]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=x86_64-apple-darwin"
+    # Cross compilation config needed only for jdk8
     export MAC_ROSETTA_PREFIX="arch -x86_64"
     export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH
   fi


### PR DESCRIPTION
Moving the if statement outside of the jdk8 only code will ensure that the `--openjdk-target=x86_64-apple-darwin` config argument is added to the build command for all x64 jdks being built on arm64 

related https://github.com/adoptium/ci-jenkins-pipelines/pull/825 and https://github.com/adoptium/temurin-build/pull/3492