### PR TITLE
Freetype: run bash autogen.sh before any ./configure commands

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -477,19 +477,21 @@ checkingAndDownloadingFreeType() {
       return
     fi
 
-    local pngArg=""
-    if ./configure --help | grep "with-png"; then
-      pngArg="--with-png=no"
-    fi
-
     local freetypeEnv=""
     if [[ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "i686" ]] || [[ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "i386" ]]; then
       freetypeEnv="export CC=\"gcc -m32\""
     fi
 
+    eval "${freetypeEnv}" && bash ./autogen.sh 
+
+    local pngArg=""
+    if ./configure --help | grep "with-png"; then
+      pngArg="--with-png=no"
+    fi
+
     # We get the files we need at $WORKING_DIR/installedfreetype
     # shellcheck disable=SC2046
-    if ! (eval "${freetypeEnv}" && bash ./autogen.sh && bash ./configure --prefix="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}"/installedfreetype "${pngArg}" "${BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]}" && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} all && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} install); then
+    if ! (bash ./configure --prefix="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}"/installedfreetype "${pngArg}" "${BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]}" && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} all && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} install); then
       # shellcheck disable=SC2154
       echo "Failed to configure and build libfreetype, exiting"
       exit

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -482,7 +482,7 @@ checkingAndDownloadingFreeType() {
       freetypeEnv="export CC=\"gcc -m32\""
     fi
 
-    eval "${freetypeEnv}" && bash ./autogen.sh 
+    eval "${freetypeEnv}" && bash ./autogen.sh || exit
 
     local pngArg=""
     if ./configure --help | grep "with-png"; then

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -482,7 +482,7 @@ checkingAndDownloadingFreeType() {
       freetypeEnv="export CC=\"gcc -m32\""
     fi
 
-    eval "${freetypeEnv}" && bash ./autogen.sh || exit
+    eval "${freetypeEnv}" && bash ./autogen.sh || exit 1
 
     local pngArg=""
     if ./configure --help | grep "with-png"; then

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -491,6 +491,7 @@ checkingAndDownloadingFreeType() {
 
     # We get the files we need at $WORKING_DIR/installedfreetype
     # shellcheck disable=SC2046
+    echo "pngArg value: ${pngArg}"
     if ! (bash ./configure --prefix="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}"/installedfreetype "${pngArg}" "${BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]}" && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} all && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} install); then
       # shellcheck disable=SC2154
       echo "Failed to configure and build libfreetype, exiting"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -491,7 +491,6 @@ checkingAndDownloadingFreeType() {
 
     # We get the files we need at $WORKING_DIR/installedfreetype
     # shellcheck disable=SC2046
-    echo "pngArg value: ${pngArg}"
     if ! (bash ./configure --prefix="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}"/installedfreetype "${pngArg}" "${BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]}" && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} all && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} install); then
       # shellcheck disable=SC2154
       echo "Failed to configure and build libfreetype, exiting"


### PR DESCRIPTION
ref https://github.com/adoptium/temurin-build/issues/3509#issuecomment-1795762701

if `./configure --help` is run before `bash autogen.sh` then we get
```
* module: psnames   (Postscript & Unicode Glyph name handling)
cd builds/unix; \
	        ./configure 
/bin/sh: ./configure: No such file or directory
make: *** [setup] Error 127
```
and therefore `pngArg="--with-png=no"` does not get set

Running it after the autogen.sh script works
```
bash-3.2$ arch -x86_64 ./configure --help | grep with-png
  --with-png=[yes|no|auto]
```

Needs testing in jenkins