### PR TITLE
Capture CycloneDX JAR SHAs in SBoM

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -473,12 +473,16 @@
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
                   <arg value="--verbose"/>
                   <arg value="--addFormulation"/>
+                  <arg value="--formulaName"/>
+                  <arg value="MyFormula"/>
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
                   <arg value="--verbose"/>
                   <arg value="--addFormulationComp"/>
+                  <arg value="--formulaName"/>
+                  <arg value="MyFormula"/>
                   <arg value="--name"/>
                   <arg value="CycloneDX SHAs"/>
                   <arg value="--jsonFile"/>
@@ -487,6 +491,8 @@
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
                   <arg value="--verbose"/>
                   <arg value="--addFormulationCompProp"/>
+                  <arg value="--formulaName"/>
+                  <arg value="MyFormula"/>
                   <arg value="--compName"/>
                   <arg value="CycloneDX SHAs"/>
                   <arg value="--name"/>

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -478,7 +478,7 @@
                 </java>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
                   <arg value="--verbose"/>
-                  <arg value="--addFormulationComponent"/>
+                  <arg value="--addFormulationComp"/>
                   <arg value="--name"/>
                   <arg value="CycloneDX SHAs"/>
                   <arg value="--jsonFile"/>

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -468,8 +468,35 @@
                   <arg value="--metadataName"/>
                   <arg value="Eclipse Adoptium"/>
                   <arg value="--jsonFile"/>
+                 <arg value="${testSBOMFile}"/>
+                </java>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
+                  <arg value="--addFormulation"/>
+                  <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
+                  <arg value="--addFormulationComponent"/>
+                  <arg value="--name"/>
+                  <arg value="CycloneDX SHAs"/>
+                  <arg value="--jsonFile"/>
+                  <arg value="${testSBOMFile}"/>
+                </java>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <arg value="--verbose"/>
+                  <arg value="--addFormulationCompProp"/>
+                  <arg value="--compName"/>
+                  <arg value="CycloneDX SHAs"/>
+                  <arg value="--name"/>
+                  <arg value="CycloneDX core lib"/>
+                  <arg value="--value"/>
+                  <arg value="sha123"/>
+                  <arg value="--jsonFile"/>
+                  <arg value="${testSBOMFile}"/>
+                </java>
+
         </target>
 
 	<macrodef name="download-file" description="Use curl to download a file">

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -327,7 +327,7 @@ public final class TemurinGenSBOM {
         return bom;
     }
 
-    static Bom addFormulation(final String fileName, String name) {          // Method to store Formulation
+    static Bom addFormulation(final String fileName, final String name) {
         Bom bom = readJSONfile(fileName);
         List<Formula> formulation = bom.getFormulation();
         if (formulation == null) {
@@ -341,19 +341,19 @@ public final class TemurinGenSBOM {
         return bom;
     }
 
-   static Bom addFormulationComp(final String fileName, final String formulaName, final String name, final String type/*, final String version, final String description */) {
+   static Bom addFormulationComp(final String fileName, final String formulaName, final String name, final String type) {
         Bom bom = readJSONfile(fileName);
-        if ( formulaName == null ) {
+        if (formulaName == null) {
            System.out.println("addFormulationComp: formulaName is null");
            return bom;
-        } else if ( name == null ) {
+        } else if (name == null) {
            System.out.println("addFormulationComp: name is null");
            return bom;
         }
         List<Formula> formulation = bom.getFormulation();
         // Look for the formula, and add the new component to it
         boolean found = false;
-        for ( Formula item : formulation ) {
+        for (Formula item : formulation) {
           if (item.getBomRef().equals(formulaName)) {
             found = true;
             Component comp = new Component();
@@ -368,29 +368,29 @@ public final class TemurinGenSBOM {
             item.setComponents(components);
           }
         }
-        if (found == false) {
+        if (!found) {
           System.out.println("addFormulationComp could not add component as it couldn't find an entry for formula " + formulaName);
         }
         return bom;
     }
 
-    static Bom addFormulationCompProp(final String fileName, final String formulaName, final String componentName, final String name, final String value) {     // Method to store metadata --> Properties List --> name-values
+    static Bom addFormulationCompProp(final String fileName, final String formulaName, final String componentName, final String name, final String value) {
         Bom bom = readJSONfile(fileName);
-        boolean foundFormula=false;
-        boolean foundComponent=false;
+        boolean foundFormula = false;
+        boolean foundComponent = false;
         List<Formula> formulation = bom.getFormulation();
         // Look for the formula, and add the new component to it
-        for ( Formula item : formulation ) {
+        for (Formula item : formulation) {
           if (item.getBomRef().equals(formulaName)) {
-            foundFormula=true;
+            foundFormula = true;
             // Search for the component in the formula and add new component to it
             List<Component> components = item.getComponents();
-            if ( components == null ) {
+            if (components == null) {
               System.out.println("addFormulationCompProp: Components is null - has addFormulationComp been called?");
             } else {
               for (Component comp : components) {
                 if (comp.getName().equals(componentName)) {
-                  foundComponent=true;
+                  foundComponent = true;
                   Property prop1 = new Property();
                   prop1.setName(name);
                   prop1.setValue(value);
@@ -401,9 +401,9 @@ public final class TemurinGenSBOM {
             }
           }
         }
-        if (foundFormula == false) {
+        if (!foundFormula) {
           System.out.println("addFormulationCompProp could not add add property as it couldn't find an entry for formula " + formulaName);
-        } else if (foundComponent == false) {
+        } else if (!foundComponent) {
           System.out.println("addFormulationCompProp could not add add property as it couldn't find an entry for component " + componentName);
         }
         return bom;

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -105,7 +105,6 @@ public final class TemurinGenSBOM {
                 cmd = "addMetadataTools";
             } else if (args[i].equals("--addFormulation")) {        // Formulation Component. We can set "name" for Formulation.
                 cmd = "addFormulation";
-                System.out.println("SXAEC: Found addFormulation command");
             } else if (args[i].equals("--addFormulationComp")) {        // Formulation Component. We can set "name" for Formulation.
                 cmd = "addFormulationComp";
             } else if (args[i].equals("--addFormulationCompProp")) {    // Formulation --> Component --> Property --> name-value
@@ -136,7 +135,6 @@ public final class TemurinGenSBOM {
                 break;
 
             case "addFormulation":                              // Adds Formulation --> name
-            System.out.println("SXAEC: Calling addFormulation");
                 bom = addFormula(fileName);
                 writeJSONfile(bom, fileName);
                 break;
@@ -144,7 +142,6 @@ public final class TemurinGenSBOM {
             case "addFormulationComp":                   // Adds Formulation --> Component--> name
                 bom = addFormulaComponent(fileName, name, type);
                 writeJSONfile(bom, fileName);
-                System.out.println("SXAEC: Writing JSON file");
                 break;
             case "addFormulationCompProp":                     // Adds Formulation--> Property --> name-value:
                 bom = addFormulaComponentProperty(fileName, compName, name, value);
@@ -295,9 +292,7 @@ public final class TemurinGenSBOM {
     }
 
     static Bom addFormula(final String fileName) {          // Method to store Formulation
-        System.out.println("SXAEC: addFormula");
         Bom bom = readJSONfile(fileName);
-        if ( bom == null ) System.out.println("SXAEC: bom object is null");
         List<Formula> formulation = bom.getFormulation();
         if ( formulation == null ) {
           System.out.println("formulation in bom is null, creating one");
@@ -314,9 +309,7 @@ public final class TemurinGenSBOM {
 
    static Bom addFormulaComponent(final String fileName, final String name, final String type/*, final String version, final String description */) {
 // START OF SECTION FROM addFormula
-        System.out.println("SXAEC: addFormula");
         Bom bom = readJSONfile(fileName);
-        if ( bom == null ) System.out.println("SXAEC: bom object is null");
         List<Formula> formulation = bom.getFormulation();
         if ( formulation == null ) {
           formulation = new LinkedList<Formula>();
@@ -331,27 +324,19 @@ public final class TemurinGenSBOM {
 //        List<Formula> formulation = bom.getFormulation();
         // SXA TODO: Not ideal to just be pulling the first entry here
         // But the formula is currently unnamed
-if ( formulation==null ) System.out.println("formulation in the bom is null");
         Formula formula = formulation.get(0);
-if ( formula==null ) System.out.println("formula in the bom is null");
         Component comp = new Component();
         Component.Type compType = Component.Type.FRAMEWORK;
         comp.setType(compType);
         comp.setName(name);
         List<Component> components = formula.getComponents();
         if ( components == null ) {
-          System.out.println("SXAEC: INITIAL FORMULATION COMPONENTS IS NULL");
           components = new LinkedList<Component>();
-        } else if ( components.isEmpty() ) {
-          System.out.println("SXAEC: INITIAL FORMULATION COMPONENTS IS PRESENT BUT EMPTY");
         }
         components.add(comp);
         formula.setComponents(components);
         formulation.set(0,formula);
-        bom.setFormulation(formulation); // Not really required
-if ( bom.getFormulation().get(0).getComponents().get(0) == null ) System.out.println("Object retrieval was null");
-else System.out.println("Retrieved name: " + bom.getFormulation().get(0).getComponents().get(0).getName());
-System.out.println("SXAEC: Everything set");
+        bom.setFormulation(formulation);
         return bom;
     }
 

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -331,7 +331,7 @@ public final class TemurinGenSBOM {
         }
         components.add(comp);
         formula.setComponents(components);
-        formulation.set(0,formula);
+        formulation.set(0, formula);
         bom.setFormulation(formulation);
         return bom;
     }

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -101,6 +101,10 @@ public final class TemurinGenSBOM {
                 cmd = "addComponentExternalReference";
             } else if (args[i].equals("--addMetadataTools")) {
                 cmd = "addMetadataTools";
+            } else if (args[i].equals("--addFormulation")) {        // Formulation Component. We can set "name" for Formulation.
+                cmd = "addFormulation";
+            } else if (args[i].equals("--addFormulationProp")) {    // Formulation --> Property -> name-value
+                cmd = "addFormulationProperty";
             } else if (args[i].equals("--verbose")) {
                 verbose = true;
             }
@@ -123,6 +127,22 @@ public final class TemurinGenSBOM {
 
             case "addMetadataProperty":                     // Adds MetaData--> Property --> name-value:
                 bom = addMetadataProperty(fileName, name, value);
+                writeJSONfile(bom, fileName);
+                break;
+
+            case "addFormulation":                              // Adds Formulation --> name
+                bom = addFormulation(fileName);
+                writeJSONfile(bom, fileName);
+                break;
+
+/*
+            case "addFormulationComponent":                   // Adds Formulation --> Component--> name
+                bom = addFormulationComponent(fileName, name, type, version, description);
+                writeJSONfile(bom, fileName);
+                break;
+*/
+            case "addFormulationProperty":                     // Adds Formulation--> Property --> name-value:
+                bom = addFormulationProperty(fileName, name, value);
                 writeJSONfile(bom, fileName);
                 break;
 
@@ -269,6 +289,37 @@ public final class TemurinGenSBOM {
         return bom;
     }
 
+    static Bom addFormulation(final String fileName) {          // Method to store Formulation -->  name
+        Bom bom = readJSONfile(fileName);
+        Formulation formulation  = new Formulation();
+        bom.setFormula(formulation);
+        return bom;
+    }
+/*
+    static Bom addFormulaDependency(final String fileName, final String name, final String type, final String version, final String description) {
+        Bom bom = readJSONfile(fileName);
+        Formulation formulation = new Formulation();
+        Component comp = new Component();
+        Component.Type compType = Component.Type.FRAMEWORK;
+        comp.setType(compType); // required e.g Component.Type.FRAMEWORK
+        comp.setName(name); // required
+        comp.setVersion(version);
+        formulation.setComponent(comp);
+        bom.setMetadata(formulation);
+        return bom;
+    }
+*/
+    static Bom addFormulationProperty(final String fileName, final String name, final String value) {     // Method to store metadata --> Properties List --> name-values
+        Bom bom = readJSONfile(fileName);
+        Formulation formulation = new Formulation();
+        Property prop1 = new Property();
+        formulation = bom.getFormulation();
+        prop1.setName(name);
+        prop1.setValue(value);
+        formulation.addProperty(prop1);
+        bom.setMetadata(formulation);
+        return bom;
+    }
     static String generateBomJson(final Bom bom) {
         // Use schema v14: https://cyclonedx.org/schema/bom-1.4.schema.json
         BomJsonGenerator bomGen = BomGeneratorFactory.createJson(CycloneDxSchema.Version.VERSION_14, bom);

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -136,17 +136,17 @@ public final class TemurinGenSBOM {
                 writeJSONfile(bom, fileName);
                 break;
 
-            case "addFormulation":                              // Adds Formulation --> name
-                bom = addFormula(fileName);
+            case "addFormulation":                                   // Adds Formulation --> name
+                bom = addFormulation(fileName);
                 writeJSONfile(bom, fileName);
                 break;
 
-            case "addFormulationComp":                   // Adds Formulation --> Component--> name
-                bom = addFormulaComponent(fileName, name, type);
+            case "addFormulationComp":                               // Adds Formulation --> Component--> name
+                bom = addFormulationComp(fileName, name, type);
                 writeJSONfile(bom, fileName);
                 break;
-            case "addFormulationCompProp":                     // Adds Formulation--> Property --> name-value:
-                bom = addFormulaComponentProperty(fileName, compName, name, value);
+            case "addFormulationCompProp":                           // Adds Formulation --> Component -> name-value:
+                bom = addFormulationCompProp(fileName, compName, name, value);
                 writeJSONfile(bom, fileName);
                 break;
 
@@ -324,7 +324,7 @@ public final class TemurinGenSBOM {
         return bom;
     }
 
-    static Bom addFormula(final String fileName) {          // Method to store Formulation
+    static Bom addFormulation(final String fileName) {          // Method to store Formulation
         Bom bom = readJSONfile(fileName);
         List<Formula> formulation = bom.getFormulation();
         if (formulation == null) {
@@ -336,21 +336,9 @@ public final class TemurinGenSBOM {
         return bom;
     }
 
-   static Bom addFormulaComponent(final String fileName, final String name, final String type/*, final String version, final String description */) {
-// START OF SECTION FROM addFormula
+   static Bom addFormulationComp(final String fileName, final String name, final String type/*, final String version, final String description */) {
         Bom bom = readJSONfile(fileName);
         List<Formula> formulation = bom.getFormulation();
-        if (formulation == null) {
-          formulation = new LinkedList<Formula>();
-          Formula formula  = new Formula();
-          formulation.add(formula);
-          bom.setFormulation(formulation);
-        } else {
-          System.out.println("addFormula() has done nothing as there is a already a formulation object in the BoM");
-        }
-// END OF SECTION FROM addFormula
-//        Bom bom = readJSONfile(fileName);
-//        List<Formula> formulation = bom.getFormulation();
         // SXA TODO: Not ideal to just be pulling the first entry here
         // But the formula is currently unnamed
         Formula formula = formulation.get(0);
@@ -369,7 +357,7 @@ public final class TemurinGenSBOM {
         return bom;
     }
 
-    static Bom addFormulaComponentProperty(final String fileName, final String componentName, final String name, final String value) {     // Method to store metadata --> Properties List --> name-values
+    static Bom addFormulationCompProp(final String fileName, final String componentName, final String name, final String value) {     // Method to store metadata --> Properties List --> name-values
         Bom bom = readJSONfile(fileName);
         List<Formula> formulation = bom.getFormulation();
         Formula formula = formulation.get(0);
@@ -378,8 +366,8 @@ public final class TemurinGenSBOM {
         List<Component> components = formulation.get(0).getComponents();
         for (Component item : components) {
 
-// What if the name wasn't found - this won't create a new one
-// Should we skip the "already exists" case and just issue an add?
+        // What if the name wasn't found - this won't create a new one
+        // Should we skip the "already exists" case and just issue an add?
             if (item.getName().equals(componentName)) {
                     Property prop1 = new Property();
                     prop1.setName(name);

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -20,6 +20,7 @@ import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.formulation.Formula;
 import org.cyclonedx.model.Hash;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.model.OrganizationalContact;
@@ -291,7 +292,7 @@ public final class TemurinGenSBOM {
 
     static Bom addFormulation(final String fileName) {          // Method to store Formulation -->  name
         Bom bom = readJSONfile(fileName);
-        Formulation formulation  = new Formulation();
+        Formula formulation  = new Formula();
         bom.setFormula(formulation);
         return bom;
     }
@@ -311,13 +312,13 @@ public final class TemurinGenSBOM {
 */
     static Bom addFormulationProperty(final String fileName, final String name, final String value) {     // Method to store metadata --> Properties List --> name-values
         Bom bom = readJSONfile(fileName);
-        Formulation formulation = new Formulation();
+        Formula formulation = new Formula();
         Property prop1 = new Property();
         formulation = bom.getFormulation();
         prop1.setName(name);
         prop1.setValue(value);
         formulation.addProperty(prop1);
-        bom.setMetadata(formulation);
+        bom.setFormulation(formulation);
         return bom;
     }
     static String generateBomJson(final Bom bom) {

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -61,7 +61,7 @@ public final class TemurinGenSBOM {
         String url = null;
         String value = null;
         String version = null;
-        
+
         for (int i = 0; i < args.length; i++) {
             if (args[i].equals("--jsonFile")) {
                 fileName = args[++i];
@@ -294,15 +294,11 @@ public final class TemurinGenSBOM {
     static Bom addFormula(final String fileName) {          // Method to store Formulation
         Bom bom = readJSONfile(fileName);
         List<Formula> formulation = bom.getFormulation();
-        if ( formulation == null ) {
-          System.out.println("formulation in bom is null, creating one");
+        if (formulation == null) {
           formulation = new LinkedList<Formula>();
           Formula formula  = new Formula();
           formulation.add(formula);
           bom.setFormulation(formulation);
-          if ( bom.getFormulation() == null ) System.out.println("Formulation is apparently still null :eyeroll:");
-        } else {
-          System.out.println("addFormula() has done nothing as there is a already a formulation object in the BoM");
         }
         return bom;
     }
@@ -311,7 +307,7 @@ public final class TemurinGenSBOM {
 // START OF SECTION FROM addFormula
         Bom bom = readJSONfile(fileName);
         List<Formula> formulation = bom.getFormulation();
-        if ( formulation == null ) {
+        if (formulation == null) {
           formulation = new LinkedList<Formula>();
           Formula formula  = new Formula();
           formulation.add(formula);
@@ -330,7 +326,7 @@ public final class TemurinGenSBOM {
         comp.setType(compType);
         comp.setName(name);
         List<Component> components = formula.getComponents();
-        if ( components == null ) {
+        if (components == null) {
           components = new LinkedList<Component>();
         }
         components.add(comp);

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -138,11 +138,11 @@ public final class TemurinGenSBOM {
                 writeJSONfile(bom, fileName);
                 break;
 
-            case "addFormulationComponent":                   // Adds Formulation --> Component--> name
+            case "addFormulationComp":                   // Adds Formulation --> Component--> name
                 bom = addFormulaComponent(fileName, name, type);
                 writeJSONfile(bom, fileName);
                 break;
-            case "addFormulationProperty":                     // Adds Formulation--> Property --> name-value:
+            case "addFormulationCompProp":                     // Adds Formulation--> Property --> name-value:
                 bom = addFormulaComponentProperty(fileName, compName, name, value);
                 writeJSONfile(bom, fileName);
                 break;

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -869,6 +869,7 @@ generateSBoM() {
 
   # Set default SBOM formulation
   addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}"
+  addSBOMFormulationComponent "${javaHome}" "${classpath}" "${sbomJson}"
 
   # Add Tool Summary section from configure.txt
   checkingToolSummary
@@ -988,9 +989,9 @@ addCycloneDXVersions() {
    else
        # This should probably cycle over all jars in the directory and include them
        # but this is an initial PoC for discussion ...
-       # Also - should we do somethign if the sha256sum fails? Currently SHA will show blank
+       # Also - should we do something if the sha256sum fails? Currently SHA will show blank
        local JarSha=$(sha256sum "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
-       addSBOMFormulationProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX core java JAR SHA" "${JarSha}"
+       addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX SHAs" "CycloneDX core java JAR SHA" "${JarSha}"
    fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -877,38 +877,9 @@ generateSBoM() {
   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS version" "${BUILD_CONFIG[OS_FULL_VERSION]^}"
   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
 
-  # Create JDK Component
-  addSBOMComponent "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "${fullVer}" "${BUILD_CONFIG[BUILD_VARIANT]^} JDK Component"
-
-  # Below add different properties to JDK component
-  # Add variant as JDK Component Property
-  addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "JDK Variant" "${BUILD_CONFIG[BUILD_VARIANT]^}"
-  # Add scmRef as JDK Component Property
-  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "SCM Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
-  # Add OpenJDK source ref commit as JDK Component Property
-  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "OpenJDK Source Commit" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"
-  # Add buildRef as JDK Component Property
-  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "Temurin Build Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
-
-  # Add build timestamp
-  addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "Build Timestamp" "${BUILD_CONFIG[BUILD_TIMESTAMP]}"
-
   # Set default SBOM formulation
   addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}"
-  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX SHAs"
-
-  # Add Tool Summary section from configure.txt
-  checkingToolSummary
-  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "Build Tools Summary" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_tool_sum.txt"
-  # Add builtConfig JDK Component Property, load as Json string
-  built_config=$(createConfigToJsonString)
-  addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "Build Config" "${built_config}"
-  # Add full_version_output JDK Component Property
-  addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "full_version_output" "${fullVerOutput}"
-  # Add makejdk_any_platform_args JDK Component Property
-  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "makejdk_any_platform_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/config/makejdk-any-platform.args"
-  # Add make_command_args JDK Component Property
-  addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
+  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX jar SHAs"
 
   # Below add build tools into metadata tools
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ]; then
@@ -1094,7 +1065,7 @@ addCycloneDXVersions() {
          else
             JarSha=$(sha256sum "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
          fi
-         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX SHAs" "${JarName}" "${JarSha}"
+         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX jar SHAs" "${JarName}" "${JarSha}"
        done
    fi
 }

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -894,6 +894,8 @@ generateSBoM() {
   addFreeTypeVersionInfo
   # Add FreeMarker 3rd party (openj9)
   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "FreeMarker" "$(cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_version_freemarker.txt)"
+  # Add CycloneDX versions
+  addCycloneDXVersions
   
   # Add Build Docker image SHA1
   buildimagesha=$(cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/docker.txt)
@@ -974,6 +976,19 @@ addFreeTypeVersionInfo() {
    fi
 
    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "FreeType" "${version}"
+}
+
+# Determine and store CycloneDX SHAs that have been used to provide the SBOMs
+addCycloneDXVersions() {
+   if [ ! -d "${BUILD_CONFIG[WORKSPACE_DIR]}/cyclonedx-lib/build/jar" ]; then
+      echo "ERROR: CycloneDX jar directory not found at ${BUILD_CONFIG[WORKSPACE_DIR]}/cyclonedx-lib/build/jar - cannot store checksums in SBOM"
+   else
+       # This should probably cycle over all jars in the directory and include them
+       # but this is an initial PoC for discussion ...
+       # Also - should we do somethign if the sha256sum fails? Currently SHA will show blank
+       local JarSha=$(sha256sum "${BUILD_CONFIG[WORKSPACE_DIR]}/cyclonedx-lib/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
+       addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX core java JAR SHA" "${JarSha}"
+   fi
 }
 
 # Below add versions to sbom | Facilitate reproducible builds

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -869,7 +869,7 @@ generateSBoM() {
 
   # Set default SBOM formulation
   addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}"
-  addSBOMFormulationComponent "${javaHome}" "${classpath}" "${sbomJson}"
+  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX SHAs"
 
   # Add Tool Summary section from configure.txt
   checkingToolSummary

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -878,8 +878,8 @@ generateSBoM() {
   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
 
   # Set default SBOM formulation
-  addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}"
-  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX jar SHAs"
+  addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX"
+  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar SHAs"
 
   # Below add build tools into metadata tools
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ]; then
@@ -1065,7 +1065,7 @@ addCycloneDXVersions() {
          else
             JarSha=$(sha256sum "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
          fi
-         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX jar SHAs" "${JarName}" "${JarSha}"
+         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar SHAs" "${JarName}" "${JarSha}"
        done
    fi
 }

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1086,11 +1086,16 @@ addCycloneDXVersions() {
    if [ ! -d "${CYCLONEDB_DIR}/build/jar" ]; then
       echo "ERROR: CycloneDX jar directory not found at ${CYCLONEDB_DIR}/build/jar - cannot store checksums in SBOM"
    else
-       # This should probably cycle over all jars in the directory and include them
-       # but this is an initial PoC for discussion ...
-       # Also - should we do something if the sha256sum fails? Currently SHA will show blank
-       local JarSha=$(sha256sum "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
-       addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX SHAs" "CycloneDX core java JAR SHA" "${JarSha}"
+       # Should we do something special if the sha256sum fails?
+       for JAR in "${CYCLONEDB_DIR}/build/jar"/*.jar; do
+         JarName=$(basename "$JAR")
+         if [ "$(uname)" = "Darwin" ]; then
+            JarSha=$(shasum -a 256 "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
+         else
+            JarSha=$(sha256sum "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
+         fi
+         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX SHAs" "${JarName}" "${JarSha}"
+       done
    fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -867,6 +867,9 @@ generateSBoM() {
   # Add build timestamp
   addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "Build Timestamp" "${BUILD_CONFIG[BUILD_TIMESTAMP]}"
 
+  # Set default SBOM formulation
+  addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}"
+
   # Add Tool Summary section from configure.txt
   checkingToolSummary
   addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "Build Tools Summary" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_tool_sum.txt"
@@ -987,7 +990,7 @@ addCycloneDXVersions() {
        # but this is an initial PoC for discussion ...
        # Also - should we do somethign if the sha256sum fails? Currently SHA will show blank
        local JarSha=$(sha256sum "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
-       addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX core java JAR SHA" "${JarSha}"
+       addSBOMFormulationProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX core java JAR SHA" "${JarSha}"
    fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -980,13 +980,13 @@ addFreeTypeVersionInfo() {
 
 # Determine and store CycloneDX SHAs that have been used to provide the SBOMs
 addCycloneDXVersions() {
-   if [ ! -d "${BUILD_CONFIG[WORKSPACE_DIR]}/cyclonedx-lib/build/jar" ]; then
-      echo "ERROR: CycloneDX jar directory not found at ${BUILD_CONFIG[WORKSPACE_DIR]}/cyclonedx-lib/build/jar - cannot store checksums in SBOM"
+   if [ ! -d "${CYCLONEDB_DIR}/build/jar" ]; then
+      echo "ERROR: CycloneDX jar directory not found at ${CYCLONEDB_DIR}/build/jar - cannot store checksums in SBOM"
    else
        # This should probably cycle over all jars in the directory and include them
        # but this is an initial PoC for discussion ...
        # Also - should we do somethign if the sha256sum fails? Currently SHA will show blank
-       local JarSha=$(sha256sum "${BUILD_CONFIG[WORKSPACE_DIR]}/cyclonedx-lib/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
+       local JarSha=$(sha256sum "${CYCLONEDB_DIR}/build/jar/cyclonedx-core-java.jar" | cut -d' ' -f1)
        addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX core java JAR SHA" "${JarSha}"
    fi
 }

--- a/sbin/common/sbom.sh
+++ b/sbin/common/sbom.sh
@@ -53,12 +53,12 @@ addSBOMFormulation() {
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulation --jsonFile "${jsonFile}"
 }
 
-addSBOMFormulationComponent() {
+addSBOMFormulationComp() {
   local javaHome="${1}"
   local classpath="${2}"
   local jsonFile="${3}"
   local name="${4}"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationCompoment --jsonFile "${jsonFile}" --name "${name}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationComp --jsonFile "${jsonFile}" --name "${name}"
 }  
 
 # Ref: https://cyclonedx.org/docs/1.4/json/#formulation
@@ -70,7 +70,7 @@ addSBOMFormulationComponentProperty() {
   local compName="${4}"
   local name="${5}"
   local value="${6}"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationCompProp --jsonFile "${jsonFile}" --compName --name "${name}" --value "${value}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationCompProp --jsonFile "${jsonFile}" --compName "${compName}" --name "${name}" --value "${value}"
 }
 
 

--- a/sbin/common/sbom.sh
+++ b/sbin/common/sbom.sh
@@ -44,6 +44,30 @@ addSBOMMetadataProperty() {
   fi
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addMetadataProp --jsonFile "${jsonFile}" --name "${name}" --value "${value}"
 }
+
+# Set basic SBoM formulation
+addSBOMFormulation() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulation --jsonFile "${jsonFile}"
+}
+
+# Ref: https://cyclonedx.org/docs/1.4/json/#formulation
+# Add the given Property name & value to the SBOM Formulation
+addSBOMFormulationProperty() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  local name="${4}"
+  local value="${5}"
+  if [ -z "${value}" ]; then
+    value="N.A"
+  fi
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationProp --jsonFile "${jsonFile}" --name "${name}" --value "${value}"
+}
+
+
 # Ref: https://cyclonedx.org/docs/1.4/json/#metadata
 # If the given property file exists and size over 2bytes, then add the given Property name with the given file contents value to the SBOM Metadata
 addSBOMMetadataPropertyFromFile() {

--- a/sbin/common/sbom.sh
+++ b/sbin/common/sbom.sh
@@ -50,15 +50,17 @@ addSBOMFormulation() {
   local javaHome="${1}"
   local classpath="${2}"
   local jsonFile="${3}"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulation --jsonFile "${jsonFile}"
+  local formulaName="${4}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulation --formulaName "${formulaName}" --jsonFile "${jsonFile}"
 }
 
 addSBOMFormulationComp() {
   local javaHome="${1}"
   local classpath="${2}"
   local jsonFile="${3}"
-  local name="${4}"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationComp --jsonFile "${jsonFile}" --name "${name}"
+  local formulaName="${4}"
+  local name="${5}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationComp --jsonFile "${jsonFile}" --formulaName "${formulaName}" --name "${name}"
 }  
 
 # Ref: https://cyclonedx.org/docs/1.4/json/#formulation
@@ -67,10 +69,11 @@ addSBOMFormulationComponentProperty() {
   local javaHome="${1}"
   local classpath="${2}"
   local jsonFile="${3}"
-  local compName="${4}"
-  local name="${5}"
-  local value="${6}"
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationCompProp --jsonFile "${jsonFile}" --compName "${compName}" --name "${name}" --value "${value}"
+  local formulaName="${4}"
+  local compName="${5}"
+  local name="${6}"
+  local value="${7}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationCompProp --jsonFile "${jsonFile}" --formulaName "${formulaName}" --compName "${compName}" --name "${name}" --value "${value}"
 }
 
 

--- a/sbin/common/sbom.sh
+++ b/sbin/common/sbom.sh
@@ -53,18 +53,24 @@ addSBOMFormulation() {
   "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulation --jsonFile "${jsonFile}"
 }
 
-# Ref: https://cyclonedx.org/docs/1.4/json/#formulation
-# Add the given Property name & value to the SBOM Formulation
-addSBOMFormulationProperty() {
+addSBOMFormulationComponent() {
   local javaHome="${1}"
   local classpath="${2}"
   local jsonFile="${3}"
   local name="${4}"
-  local value="${5}"
-  if [ -z "${value}" ]; then
-    value="N.A"
-  fi
-  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationProp --jsonFile "${jsonFile}" --name "${name}" --value "${value}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationCompoment --jsonFile "${jsonFile}" --name "${name}"
+}  
+
+# Ref: https://cyclonedx.org/docs/1.4/json/#formulation
+# Add the given Property name & value to the SBOM Formulation
+addSBOMFormulationComponentProperty() {
+  local javaHome="${1}"
+  local classpath="${2}"
+  local jsonFile="${3}"
+  local compName="${4}"
+  local name="${5}"
+  local value="${6}"
+  "${javaHome}"/bin/java -cp "${classpath}" temurin.sbom.TemurinGenSBOM --addFormulationCompProp --jsonFile "${jsonFile}" --compName --name "${name}" --value "${value}"
 }
 
 


### PR DESCRIPTION
**Note to reviewers: please allow me to merge this when approved.**

This is a test of including the CycloneDX jars (downloaded during the build process) into the SBoM.
There are several JAR files associated with the CycloneDX tool and this only covers one of them so is a "discussion starter" (hence raising this as a draft) as to how we should move forward if we want to capture this information in the SBoM. Is this the right place for it to be stored? Do we definitely need it? Would we exclude it if we downloaded this onto the machines via the playbooks? If we capture all of the JAR SHAs then what should the format be?
```
      {
        "name" : "FreeMarker",
        "version" : "N.A"
      },
      {
        "name" : "CycloneDX core java JAR SHA",
        "version" : "88193228f85a955127dc73e1c72efc9e08e18a01d227df47d0865dc20eceffd1"
      },
      {
        "name" : "Docker image SHA1",
        "version" : "adoptopenjdk/centos7_build_image@sha256:0dcc7d6c846a7ca4fa7814e0721c05e14a5a88f4bf67c43202586610
      }
```
Cc @andrew-m-leonard @netomi - this is part of satisfying https://github.com/adoptium/temurin-build/issues/3535

References to the new Formula stuff in CycloneDX 1.5 used in this PR:
- https://cyclonedx.org/docs/1.5/json/#formulation_items_bom-ref
- https://cyclonedx.github.io/cyclonedx-core-java/