### PR TITLE
RISC-V: Avoid using JDK20 as boot JDK for JDK21 

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -147,6 +147,10 @@ then
     # To support reproducible-builds the jar/jmod --date option is required
     # which is only available in jdk-17 and from jdk-19 so we cannot bootstrap with JDK16
     JDK_BOOT_VERSION="17"
+  elif [ "${JAVA_FEATURE_VERSION}" == "21" ] && [ "${ARCHITECTURE}" == "riscv64" ]; then
+    # JDK20 has issues. No RVV fix for C910/C920 systems and
+    # does not run well in in docker containers
+    JDK_BOOT_VERSION="21"
   elif [ "${JAVA_FEATURE_VERSION}" == "19" ]; then
     JDK_BOOT_VERSION="19"
   fi


### PR DESCRIPTION
It doesn't work reliably in a docker image, so bootstrap with the (maintained) cross-built (for now) JDK21.0.1+12.1

Note this has been tested on multiple systems so is good to go live ASAP.