### PR TITLE
pin JDK11 x64 build to XCode rather than commandline tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,12 +109,15 @@ jobs:
 
   build_macos:
     name: macOS
-    runs-on: macos-11
+    runs-on: ${{ matrix.version.distro }}
     strategy:
       fail-fast: false
       matrix:
         os: [macOS]
-        version: [jdk8u, jdk11u]
+        version: [
+          { name: jdk8u, distro: macos-11 },
+          { name: jdk11u, distro: macos-13 },
+        ]
         variant: [temurin]
 
     steps:
@@ -129,19 +132,25 @@ jobs:
       with:
         java-version: 7
         distribution: 'zulu'
-      if: matrix.version == 'jdk8u'
+      if: matrix.version.name == 'jdk8u'
       
-    - name: Select correct Xcode
+    - name: Select correct Xcode (JDK8)
+      if: matrix.version.name == 'jdk8u'
       run: |
         rm -rf /Applications/Xcode.app
         ln -s /Applications/Xcode_11.7.app /Applications/Xcode.app
-        ln -s /Applications/Xcode_11.7.app /Applications/Xcode-11.7.app
+
+    - name: Select correct Xcode (JDK11+)
+      if: matrix.version.name != 'jdk8u'
+      run: |
+        rm -rf /Applications/Xcode.app
+        ln -s /Applications/Xcode_15.0.1.app /Applications/Xcode.app
 
     - name: Build macOS
       run: |
         export JAVA_HOME=$JAVA_HOME_11_X64
         # Skip freetype build on jdk11+
-        if [ ${{ matrix.version }} != "jdk8u" ]; then
+        if [ ${{ matrix.version.name }} != "jdk8u" ]; then
           export BUILD_ARGS="--skip-freetype --make-exploded-image --create-sbom"
           ./build-farm/make-adopt-build-farm.sh
           export BUILD_ARGS="--assemble-exploded-image --create-sbom"
@@ -151,7 +160,7 @@ jobs:
           ./build-farm/make-adopt-build-farm.sh
         fi
       env:
-        JAVA_TO_BUILD: ${{ matrix.version }}
+        JAVA_TO_BUILD: ${{ matrix.version.name }}
         ARCHITECTURE: x64
         VARIANT: ${{ matrix.variant }}
         TARGET_OS: mac
@@ -161,7 +170,7 @@ jobs:
     - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       name: Collect and Archive Artifacts
       with:
-        name: ${{matrix.version}}-${{matrix.os}}-${{matrix.variant}}
+        name: ${{matrix.version.name}}-${{matrix.os}}-${{matrix.variant}}
         path: workspace/target/*
 
     - name: Unpack jdk
@@ -185,7 +194,7 @@ jobs:
       name: Collect and Archive SmokeTest Results
       if: failure()
       with:
-        name: "${{matrix.version}}-${{matrix.os}}-${{matrix.variant}}_test_output"
+        name: "${{matrix.version.name}}-${{matrix.os}}-${{matrix.variant}}_test_output"
         path: ./**/output_*/
 
   build_windows:

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -47,11 +47,12 @@ then
     export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
   fi
 else
-  if [[ "$JAVA_FEATURE_VERSION" -ge 17 ]] || [[ "${ARCHITECTURE}" == "aarch64" ]]; then
+  if [[ "$JAVA_FEATURE_VERSION" -ge 11 ]]; then
     # JDK17 requires metal (included in full xcode) as does JDK11 on aarch64
+    # JDK11 on x64 is matched for consistency
     XCODE_SWITCH_PATH="/Applications/Xcode.app"
   else
-    # Command line tools used from JDK9-JDK16
+    # Command line tools used from JDK9-JDK10
     XCODE_SWITCH_PATH="/";
   fi
   export PATH="/Users/jenkins/ccache-3.2.4:$PATH"


### PR DESCRIPTION
Switching JDK11 to a pinned Xcode version rather than command line tools for consistency