### PR TITLE
Add workaround for brew update failure when running aqa smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      # https://github.com/actions/runner-images/issues/6817
+    # https://github.com/actions/runner-images/issues/6817
     - name: (Mac) Workaround for homebrew
       shell: bash
       if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,22 @@ jobs:
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
+      # https://github.com/actions/runner-images/issues/6817
+    - name: (Mac) Workaround for homebrew
+      shell: bash
+      if: runner.os == 'macOS'
+      run: |
+          rm /usr/local/bin/2to3 || true
+          rm /usr/local/bin/2to3-3.11 || true
+          rm /usr/local/bin/idle3 || true
+          rm /usr/local/bin/idle3.11 || true
+          rm /usr/local/bin/pydoc3 || true
+          rm /usr/local/bin/pydoc3.11 || true
+          rm /usr/local/bin/python3 || true
+          rm /usr/local/bin/python3.11 || true
+          rm /usr/local/bin/python3-config || true
+          rm /usr/local/bin/python3.11-config || true
+            
     - name: Install Dependencies
       run: |
         brew install automake bash binutils freetype gnu-sed nasm


### PR DESCRIPTION
The tests for macos-13 fail due to an error when setting up the smoke tests.

This seems to be a pretty common problem, e.g. as documented here:

https://github.com/actions/runner-images/issues/6817

Workaround seems to be to either ignore the error or remove the files before running brew if they are present.