### PR TITLE
Add required library for Configure to work on Ubuntu 22 onwards.

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -194,6 +194,21 @@ function downloadBootJDK()
 if [ "${ARCHITECTURE}" == "x64" ]
 then
   export PATH=/opt/rh/devtoolset-2/root/usr/bin:$PATH
+  ## Fix For Issue https://github.com/adoptium/temurin-build/issues/3547
+  ## Add Missing Library Path For Ubuntu 22+
+  if [ -e /etc/os-release ]; then
+    ## source the os -release file if present
+    . /etc/os-release
+    INT_VERSION_ID=$(echo "$VERSION_ID" | awk -F'.' '{print $1'})
+    if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
+      echo "Ubuntu 22+"
+      export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
+    else
+      echo "Not Ubuntu 22+"
+    fi
+  else
+    echo "Unable To Determine The O/S"
+  fi
 fi
 
 if [ "${ARCHITECTURE}" == "s390x" ]

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -197,8 +197,8 @@ then
   ## Fix For Issue https://github.com/adoptium/temurin-build/issues/3547
   ## Add Missing Library Path For Ubuntu 22+
   if [ -e /etc/os-release ]; then
-    ID=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2'})
-    INT_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | awk -F'"' '{print $2'} | awk -F'.' '{print $1}')
+    ID=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2}')
+    INT_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | awk -F'"' '{print $2}' | awk -F'.' '{print $1}')
     if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
       export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
     fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -197,8 +197,8 @@ then
   ## Fix For Issue https://github.com/adoptium/temurin-build/issues/3547
   ## Add Missing Library Path For Ubuntu 22+
   if [ -e /etc/os-release ]; then
-    ID=$(cat /etc/os-release | grep ^ID= | awk -F'=' '{print $2'})
-    INT_VERSION_ID=$(cat /etc/os-release | grep ^VERSION_ID= | awk -F'"' '{print $2'} | awk -F'.' '{print $1}')
+    ID=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2'})
+    INT_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | awk -F'"' '{print $2'} | awk -F'.' '{print $1}')
     if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
       export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
     fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -197,17 +197,11 @@ then
   ## Fix For Issue https://github.com/adoptium/temurin-build/issues/3547
   ## Add Missing Library Path For Ubuntu 22+
   if [ -e /etc/os-release ]; then
-    ## source the os -release file if present
-    . /etc/os-release
-    INT_VERSION_ID=$(echo "$VERSION_ID" | awk -F'.' '{print $1'})
+    ID=$(cat /etc/os-release | grep ^ID= | awk -F'=' '{print $2'})
+    INT_VERSION_ID=$(cat /etc/os-release | grep ^VERSION_ID= | awk -F'"' '{print $2'} | awk -F'.' '{print $1}')
     if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
-      echo "Ubuntu 22+"
       export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
-    else
-      echo "Not Ubuntu 22+"
     fi
-  else
-    echo "Unable To Determine The O/S"
   fi
 fi
 


### PR DESCRIPTION
Fixes #3547 

On Ubuntu 22.04 onwards, the object files required for autoconf/configure are in a new path, due to a change relating to multiarch implementations in Ubuntu.

The new path required to be added to LIBRARY_PATH is : /usr/lib/x86_64-linux-gnu

In order to get configure to work, the new path is appended to the LIBRARY_PATH.

