### PR TITLE
Add required library for Configure to work on Ubuntu 22 onwards. ( for both Arm64 & x64 )

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -201,9 +201,9 @@ fi
 if [ -e /etc/os-release ]; then
   ID=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2}')
   INT_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | awk -F'"' '{print $2}' | awk -F'.' '{print $1}')
-  LIB_ARCH=$(uname -m)
+  LIB_ARCH=$(uname -m)-linux-gnu
   if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
-      export LIBRARY_PATH=/usr/lib/$(uname -m)-linux-gnu:$LIBRARY_PATH
+      export LIBRARY_PATH=/usr/lib/$LIB_ARCH:$LIBRARY_PATH
   fi
 fi
 

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -194,16 +194,26 @@ function downloadBootJDK()
 if [ "${ARCHITECTURE}" == "x64" ]
 then
   export PATH=/opt/rh/devtoolset-2/root/usr/bin:$PATH
+fi
+
+if [ "${ARCHITECTURE}" == "aarch64" ] || [ "${ARCHITECTURE}" == "x64" ]
+then
   ## Fix For Issue https://github.com/adoptium/temurin-build/issues/3547
   ## Add Missing Library Path For Ubuntu 22+
   if [ -e /etc/os-release ]; then
     ID=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2}')
     INT_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | awk -F'"' '{print $2}' | awk -F'.' '{print $1}')
+    
     if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
-      export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
+      if [ "${ARCHITECTURE}" == "x64" ]; then
+        export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
+      else
+        export LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:$LIBRARY_PATH
+      fi
     fi
   fi
 fi
+
 
 if [ "${ARCHITECTURE}" == "s390x" ]
 then

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -196,24 +196,16 @@ then
   export PATH=/opt/rh/devtoolset-2/root/usr/bin:$PATH
 fi
 
-if [ "${ARCHITECTURE}" == "aarch64" ] || [ "${ARCHITECTURE}" == "x64" ]
-then
-  ## Fix For Issue https://github.com/adoptium/temurin-build/issues/3547
-  ## Add Missing Library Path For Ubuntu 22+
-  if [ -e /etc/os-release ]; then
-    ID=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2}')
-    INT_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | awk -F'"' '{print $2}' | awk -F'.' '{print $1}')
-    
-    if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
-      if [ "${ARCHITECTURE}" == "x64" ]; then
-        export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
-      else
-        export LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:$LIBRARY_PATH
-      fi
-    fi
+## Fix For Issue https://github.com/adoptium/temurin-build/issues/3547
+## Add Missing Library Path For Ubuntu 22+
+if [ -e /etc/os-release ]; then
+  ID=$(grep "^ID=" /etc/os-release | awk -F'=' '{print $2}')
+  INT_VERSION_ID=$(grep "^VERSION_ID=" /etc/os-release | awk -F'"' '{print $2}' | awk -F'.' '{print $1}')
+  LIB_ARCH=$(uname -m)
+  if [ "$ID" == "ubuntu" ] && [ "$INT_VERSION_ID" -ge "22" ]; then
+      export LIBRARY_PATH=/usr/lib/$(uname -m)-linux-gnu:$LIBRARY_PATH
   fi
 fi
-
 
 if [ "${ARCHITECTURE}" == "s390x" ]
 then


### PR DESCRIPTION
Extends the fix for https://github.com/adoptium/temurin-build/issues/3547

On Ubuntu 22.04 onwards, the object files required for autoconf/configure are in a new path, due to a change relating to multiarch implementations in Ubuntu.

The new path required to be added to LIBRARY_PATH is : /usr/lib/x86_64-linux-gnu for x64
The new path required to be added to LIBRARY_PATH is : /usr/lib/aarch64-linux-gnu for arm64

In order to get configure to work, the new path is appended to the LIBRARY_PATH.