### PR TITLE
Ensure python3 installs for ant-contrib dependencies on macos13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,9 +189,13 @@ jobs:
         rm -f '/usr/local/bin/2to3'
         rm -f '/usr/local/bin/2to3-3.11'
         rm -f '/usr/local/bin/idle3'
+        rm -f '/usr/local/bin/idle3.11'
         rm -f '/usr/local/bin/pydoc3'
+        rm -f '/usr/local/bin/pydoc3.11'
         rm -f '/usr/local/bin/python3'
+        rm -f '/usr/local/bin/python3.11'
         rm -f '/usr/local/bin/python3-config'
+        rm -f '/usr/local/bin/python3.11-config'
 
     - name: Smoke test
       uses: adoptium/run-aqa@6bacb4e732ad546eda1b09665b9067cdc87651f4 # v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,10 +187,10 @@ jobs:
       run: |
         # See: https://github.com/adoptium/temurin-build/issues/3550#issuecomment-1833369679
         rm -f '/usr/local/bin/2to3'
-        rm -f '/usr/local/bin/2to3-3.11'
         rm -f '/usr/local/bin/idle3'
         rm -f '/usr/local/bin/pydoc3'
         rm -f '/usr/local/bin/python3'
+        rm -f '/usr/local/bin/python3-config'
 
     - name: Smoke test
       uses: adoptium/run-aqa@6bacb4e732ad546eda1b09665b9067cdc87651f4 # v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,9 @@ jobs:
         # See: https://github.com/adoptium/temurin-build/issues/3550#issuecomment-1833369679
         rm -f '/usr/local/bin/2to3'
         rm -f '/usr/local/bin/2to3-3.11'
+        rm -f '/usr/local/bin/idle3'
+        rm -f '/usr/local/bin/pydoc3'
+        rm -f '/usr/local/bin/python3'
 
     - name: Smoke test
       uses: adoptium/run-aqa@6bacb4e732ad546eda1b09665b9067cdc87651f4 # v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,12 @@ jobs:
       run: |
         imageroot=$(find "${HOME}/JDK" -name release -type f)
         echo "TEST_JDK_HOME=$(dirname "${imageroot}")" >> "$GITHUB_ENV"
+
+    - name: Clean /usr/local to avoid python3 install link failure
+      run: |
+        # See: https://github.com/adoptium/temurin-build/issues/3550#issuecomment-1833369679
+        rm -f '/usr/local/bin/2to3'
+
     - name: Smoke test
       uses: adoptium/run-aqa@6bacb4e732ad546eda1b09665b9067cdc87651f4 # v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,10 +183,11 @@ jobs:
         imageroot=$(find "${HOME}/JDK" -name release -type f)
         echo "TEST_JDK_HOME=$(dirname "${imageroot}")" >> "$GITHUB_ENV"
 
-    - name: Clean /usr/local to avoid python3 install link failure
+    - name: Clean /usr/local/bin/2to3.. to avoid python3 install link failure
       run: |
         # See: https://github.com/adoptium/temurin-build/issues/3550#issuecomment-1833369679
         rm -f '/usr/local/bin/2to3'
+        rm -f '/usr/local/bin/2to3-3.11'
 
     - name: Smoke test
       uses: adoptium/run-aqa@6bacb4e732ad546eda1b09665b9067cdc87651f4 # v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,7 @@ jobs:
       run: |
         # See: https://github.com/adoptium/temurin-build/issues/3550#issuecomment-1833369679
         rm -f '/usr/local/bin/2to3'
+        rm -f '/usr/local/bin/2to3-3.11'
         rm -f '/usr/local/bin/idle3'
         rm -f '/usr/local/bin/pydoc3'
         rm -f '/usr/local/bin/python3'


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3550

We need to ensure any pre-existing '/usr/local/bin/..' python related symlinks are removed prior to github action for mac.

Not an ideal fix, but as a workaround, these need removing, ref https://github.com/actions/setup-python/issues/577#issuecomment-1365231810:
```
        rm -f '/usr/local/bin/2to3'
        rm -f '/usr/local/bin/2to3-3.11'
        rm -f '/usr/local/bin/idle3'
        rm -f '/usr/local/bin/idle3.11'
        rm -f '/usr/local/bin/pydoc3'
        rm -f '/usr/local/bin/pydoc3.11'
        rm -f '/usr/local/bin/python3'
        rm -f '/usr/local/bin/python3.11'
        rm -f '/usr/local/bin/python3-config'
        rm -f '/usr/local/bin/python3.11-config'
```
