### PR TITLE
Make autotriage only run in pull requests

### DIFF
--- a/.github/workflows/build-autotriage.yml
+++ b/.github/workflows/build-autotriage.yml
@@ -6,14 +6,15 @@ name: "Build Autotriage"
 on:
   schedule:
     - cron: '0 0 * * MON'
-  push:
+  pull_request:
+    branches: [master]
     paths:
       - '**build-autotriage.yml'
       - '**build_autotriage.sh'
       - '**autotriage_regexes.sh'
-      
+
 env:
-  TRIAGE_SCRIPT: "${PWD}/tooling/build_autotriage/build_autotriage.sh"
+  TRIAGE_SCRIPT: "tooling/build_autotriage/build_autotriage.sh"
 
 jobs:
   Label:
@@ -22,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Run Build Auto Triage"
-        run: bash "${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk22head
+        run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk22head
 
       - name: Create Issue From File
         env:


### PR DESCRIPTION
This should prevent accidental triggering when someone fetches a commit containing a change to these files and pushes it to their fork.

Also moving a pwd envvar as its current location may cause problems in some forks.

Fixes https://github.com/adoptium/temurin-build/issues/3554