### PR TITLE
Default Temurin jdk-21+ to use bundled FreeType

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,9 +165,9 @@ jobs:
     - name: Build macOS
       run: |
         export JAVA_HOME=$JAVA_HOME_11_X64
-        # Skip freetype build on jdk11+
+        # jdk11u+ uses two part exploded & assemble build
         if [ ${{ matrix.version.name }} != "jdk8u" ]; then
-          export BUILD_ARGS="--skip-freetype --make-exploded-image --create-sbom"
+          export BUILD_ARGS="--make-exploded-image --create-sbom"
           ./build-farm/make-adopt-build-farm.sh
           export BUILD_ARGS="--assemble-exploded-image --create-sbom"
           ./build-farm/make-adopt-build-farm.sh

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -61,7 +61,7 @@ fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin jdk-21+ uses "bundled" FreeType
-  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
 fi

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -59,6 +59,7 @@ then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread"
 fi
 
+# shellcheck disable=SC2109
 if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -59,8 +59,8 @@ then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread"
 fi
 
-if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
-  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
+if [[ "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
+  # jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -59,7 +59,7 @@ then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread"
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -59,8 +59,7 @@ then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread"
 fi
 
-# shellcheck disable=SC2109
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -59,7 +59,7 @@ then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread"
 fi
 
-if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -69,7 +69,7 @@ fi
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
   export LDR_CNTRL=MAXDATA=0x80000000
 fi
-echo LDR_CNTRL=$LDR_CNTRL
+echo LDR_CNTRL="$LDR_CNTRL"
 
 BOOT_JDK_VARIABLE="JDK${JDK_BOOT_VERSION}_BOOT_DIR"
 if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -59,8 +59,8 @@ then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread"
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
-  # Temurin jdk-21+ uses "bundled" FreeType
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -59,7 +59,12 @@ then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-lpthread --with-extra-cflags=-lpthread --with-extra-cxxflags=-lpthread"
 fi
 
-export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin jdk-21+ uses "bundled" FreeType
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+else
+  export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
   export LDR_CNTRL=MAXDATA=0x80000000

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -28,8 +28,13 @@ fi
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
-# We don't bundle freetype on alpine anymore, and expect the user to have it.
-export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin jdk-21+ uses "bundled" FreeType
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+else
+  # We don't bundle freetype on alpine anymore, and expect the user to have it.
+  export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+fi
 
 BOOT_JDK_VARIABLE="JDK${JDK_BOOT_VERSION}_BOOT_DIR"
 if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -28,8 +28,8 @@ fi
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
-  # Temurin jdk-21+ uses "bundled" FreeType
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   # We don't bundle freetype on alpine anymore, and expect the user to have it.

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -30,7 +30,7 @@ export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --dis
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin jdk-21+ uses "bundled" FreeType
-  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   # We don't bundle freetype on alpine anymore, and expect the user to have it.
   export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -28,8 +28,8 @@ fi
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
-if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
-  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
+if [[ "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
+  # jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   # We don't bundle freetype on alpine anymore, and expect the user to have it.

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -28,7 +28,8 @@ fi
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
-if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+# shellcheck disable=SC2109
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -28,7 +28,7 @@ fi
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -28,8 +28,7 @@ fi
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
-# shellcheck disable=SC2109
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -19,8 +19,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
-if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
-  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
+if [[ "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
+  # jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   # Bundling our own freetype can cause problems, so we skip that on linux.

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -19,8 +19,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
-  # Temurin jdk-21+ uses "bundled" FreeType
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   # Bundling our own freetype can cause problems, so we skip that on linux.

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -18,8 +18,14 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
-# Bundling our own freetype can cause problems, so we skip that on linux.
-export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin jdk-21+ uses "bundled" FreeType
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+else
+  # Bundling our own freetype can cause problems, so we skip that on linux.
+  export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+fi
 
 NATIVE_API_ARCH=$(uname -m)
 if [ "${NATIVE_API_ARCH}" = "x86_64" ]; then NATIVE_API_ARCH=x64; fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -19,7 +19,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
-if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+# shellcheck disable=SC2109
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -21,7 +21,7 @@ source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin jdk-21+ uses "bundled" FreeType
-  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else
   # Bundling our own freetype can cause problems, so we skip that on linux.
   export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -19,8 +19,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
-# shellcheck disable=SC2109
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 else

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -68,8 +68,7 @@ else
   fi
 fi
 
-# shellcheck disable=SC2109
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -68,6 +68,11 @@ else
   fi
 fi
 
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin jdk-21+ uses "bundled" FreeType
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+fi
+
 # The configure option '--with-macosx-codesign-identity' is supported in JDK8 OpenJ9 and JDK11 and JDK14+
 if [[ ( "$JAVA_FEATURE_VERSION" -eq 11 ) || ( "$JAVA_FEATURE_VERSION" -ge 14 ) ]]
 then

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -68,7 +68,7 @@ else
   fi
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -68,8 +68,8 @@ else
   fi
 fi
 
-if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
-  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
+if [[ "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
+  # jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi
 

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -68,7 +68,8 @@ else
   fi
 fi
 
-if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+# shellcheck disable=SC2109
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -68,8 +68,8 @@ else
   fi
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
-  # Temurin jdk-21+ uses "bundled" FreeType
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi
 

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -70,7 +70,7 @@ fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin jdk-21+ uses "bundled" FreeType
-  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi
 
 # The configure option '--with-macosx-codesign-identity' is supported in JDK8 OpenJ9 and JDK11 and JDK14+

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -231,8 +231,8 @@ then
   fi
 fi
 
-if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
-  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
+if [[ "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
+  # jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi
 

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -231,7 +231,8 @@ then
   fi
 fi
 
-if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+# shellcheck disable=SC2109
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -231,7 +231,7 @@ then
   fi
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}"] || ["${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -231,8 +231,8 @@ then
   fi
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
-  # Temurin jdk-21+ uses "bundled" FreeType
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi
 

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -231,8 +231,7 @@ then
   fi
 fi
 
-# shellcheck disable=SC2109
-if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+if [[ ("${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" || "${VARIANT}" == "${BUILD_VARIANT_HOTSPOT}") && "$JAVA_FEATURE_VERSION" -ge 21 ]]; then
   # Temurin/hotspot jdk-21+ uses "bundled" FreeType
   export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -233,7 +233,7 @@ fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
   # Temurin jdk-21+ uses "bundled" FreeType
-  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir bundled"
 fi
 
 if [ "${ARCHITECTURE}" == "aarch64" ]; then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -231,6 +231,11 @@ then
   fi
 fi
 
+if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ]; then
+  # Temurin jdk-21+ uses "bundled" FreeType
+  export BUILD_ARGS="${BUILD_ARGS} --freetype-dir=bundled"
+fi
+
 if [ "${ARCHITECTURE}" == "aarch64" ]; then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache --openjdk-target=aarch64-unknown-cygwin"
 fi

--- a/test/functional/buildAndPackage/src/net/adoptium/test/BundledFreetypeTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/BundledFreetypeTest.java
@@ -74,8 +74,8 @@ public class BundledFreetypeTest {
                 .filter(name -> freetypePattern.matcher(name).matches())
                 .collect(Collectors.toSet());
 
-        if (!jdkVersion.usesVM(VM.OPENJ9) && jdkVersion.isNewerOrEqual(21)) {
-            // Temurin/hotspot jdk-21+ uses "bundled" FreeType
+        if (jdkVersion.isNewerOrEqual(21)) {
+            // jdk-21+ uses "bundled" FreeType
             assertTrue(freetypeFiles.size() > 0,
               "Expected libfreetype.dylib to be bundled but it is not.");
         } else if (jdkPlatform.runsOn(OperatingSystem.MACOS)) {

--- a/test/functional/buildAndPackage/src/net/adoptium/test/BundledFreetypeTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/BundledFreetypeTest.java
@@ -74,7 +74,11 @@ public class BundledFreetypeTest {
                 .filter(name -> freetypePattern.matcher(name).matches())
                 .collect(Collectors.toSet());
 
-        if (jdkPlatform.runsOn(OperatingSystem.MACOS)) {
+        if (!jdkVersion.usesVM(VM.OPENJ9) && jdkVersion.isNewerOrEqual(21)) {
+            // Temurin/hotspot jdk-21+ uses "bundled" FreeType
+            assertTrue(freetypeFiles.size() > 0,
+              "Expected libfreetype.dylib to be bundled but it is not.");
+        } else if (jdkPlatform.runsOn(OperatingSystem.MACOS)) {
             assertTrue(freetypeFiles.size() > 0,
               "Expected libfreetype.dylib to be bundled but it is not.");
         } else if (jdkPlatform.runsOn(OperatingSystem.WINDOWS)) {


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3504

PMC confirmed moving Temurin jdk21u to using "bundled" FreeType, to provide "consistent" and "reproducible" builds with FreeType.
