### PR TITLE
Update CycloneDX core jar to 8.0.3 for 1.5 spec

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -43,7 +43,7 @@
                 <echo message="Downloading cyclonedx-core-java"/>
                 <download-file
                   destfile="cyclonedx-core-java.jar"
-                  checksum="88193228f85a955127dc73e1c72efc9e08e18a01d227df47d0865dc20eceffd1"
+                  checksum="ecc371d12808dfe76047f87f8235665d74dd6cf8ec12c41d052715a3fd79e0b5"
                   srcurl="https://ci.adoptium.net/view/all/job/build.getDependency/lastSuccessfulBuild/artifact/sbom_dependencies/cyclonedx-core-java.jar"
                   />
 	      </target>

--- a/cyclonedx-lib/getDependencies
+++ b/cyclonedx-lib/getDependencies
@@ -22,8 +22,11 @@ def fetchDeps() {
     timeout(time: time_limit, unit: 'HOURS') {
         try {
             sh 'mkdir sbom_dependencies'
-
-            def cyclonedx_core_java_version = "7.3.2"
+            
+       
+            # These versions come from https://github.com/CycloneDX/cyclonedx-core-java/tags
+            # Version->spec mappings are in https://github.com/CycloneDX/cyclonedx-core-java#cyclonedx-schema-support
+            def cyclonedx_core_java_version = "8.0.3"
             def jackson_core_version = "2.14.2"
             def jackson_annotations_version = "2.14.2"
             def jackson_databind_version = "2.14.2"
@@ -32,7 +35,7 @@ def fetchDeps() {
             def commons_io_version = "2.11.0"
             def github_package_url_version = "1.4.1"
 
-            fetchSingleFile("cyclonedx-core-java.jar", "88193228f85a955127dc73e1c72efc9e08e18a01d227df47d0865dc20eceffd1", "org/cyclonedx/cyclonedx-core-java/${cyclonedx_core_java_version}/cyclonedx-core-java-${cyclonedx_core_java_version}.jar")
+            fetchSingleFile("cyclonedx-core-java.jar", "ecc371d12808dfe76047f87f8235665d74dd6cf8ec12c41d052715a3fd79e0b5", "org/cyclonedx/cyclonedx-core-java/${cyclonedx_core_java_version}/cyclonedx-core-java-${cyclonedx_core_java_version}.jar")
             fetchSingleFile("jackson-core.jar", "b5d37a77c88277b97e3593c8740925216c06df8e4172bbde058528df04ad3e7a", "com/fasterxml/jackson/core/jackson-core/${jackson_core_version}/jackson-core-${jackson_core_version}.jar")
             fetchSingleFile("jackson-dataformat-xml.jar", "edbda6c775a36049cf0088b111ab958cca0dc70cb9326918d6cf153cb3fa426b", "com/fasterxml/jackson/dataformat/jackson-dataformat-xml/${jackson_databind_version}/jackson-dataformat-xml-${jackson_databind_version}.jar")
             fetchSingleFile("jackson-databind.jar", "501d3abce4d18dcc381058ec593c5b94477906bba6efbac14dae40a642f77424", "com/fasterxml/jackson/core/jackson-databind/${jackson_databind_version}/jackson-databind-${jackson_databind_version}.jar")


### PR DESCRIPTION
I've verified that the `ant build` phase works ok with this upgrade.

This is a prerequisite to using the code to generate the `Formulation` section of the CycloneDX SBoM

Ref: https://github.com/adoptium/temurin-build/pull/3538 https://github.com/adoptium/temurin-build/issues/3535