### PR TITLE
Stop showing full SBoM output in build log

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -976,10 +976,8 @@ generateSBoM() {
     addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
   done
 
-  # Print SBOM json
-  echo "CycloneDX SBOM:"
-  cat  "${sbomJson}"
-  echo ""
+  # Print SBOM location
+  echo "CycloneDX SBOM has been created in ${sbomJson}"
 }
 
 # Generate build tools info into dependency file


### PR DESCRIPTION
Discussions starter: I personally find that the display of the SBoM content is overly verbose, and it typically makes it harder to find what I want in the log because I have to start at the bottom and scroll back to the "good bits". This PR suggests changing it so that it prints the location on the file system instead of printing it out. While this may be useful for debug/development I don't think it should print it by default. Bear in mind this content will also be archived afterwards along with the build itself.
In addition we print the metadata out in the pipelines job at https://github.com/adoptium/ci-jenkins-pipelines/blob/833a06de53ae21ffec043863600a88a5dbbb6529/pipelines/build/common/openjdk_build_pipeline.groovy#L1275 which should probably be removed too, but I'm looking for feedback before creating a second PR for that.