### PR TITLE
Add amount of disk space used by build to the log

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -255,5 +255,6 @@ CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM//\"/temporary
 bash -c "$MAC_ROSETTA_PREFIX $PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
 
 if [ -d "${WORKSPACE}" ]; then
-  echo "Total disk space in Kb consumed by build process:" "$(du -sk "$WORKSPACE")"
+  SPACEUSED=$(du -sk "$WORKSPACE")
+  echo "Total disk space in Kb consumed by build process: $SPACEUSED"
 fi

--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -254,4 +254,6 @@ CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM//\"/temporary
 # shellcheck disable=SC2086
 bash -c "$MAC_ROSETTA_PREFIX $PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
 
-[ -d "${WORKSPACE}" ] && echo "Total disk space in Kb consumed by build process:" "$(du -sk "$WORKSPACE")"
+if [ -d "${WORKSPACE}" ]; then
+  echo "Total disk space in Kb consumed by build process:" "$(du -sk "$WORKSPACE")"
+fi

--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -253,3 +253,5 @@ CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM//\"/temporary
 
 # shellcheck disable=SC2086
 bash -c "$MAC_ROSETTA_PREFIX $PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"
+
+[ -d "${WORKSPACE}" ] && echo "Total disk space in Kb consumed by build process:" "$(du -sk "$WORKSPACE")"


### PR DESCRIPTION
This will help log information that we can give to end users to tell how much space is required for builds, and also help with capacity planning on machines