### PR TITLE
Fix joinPathOS method that fails on solaris

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -98,7 +98,7 @@ function setDockerVolumeSuffix() {
 
 # Joins multiple parts to a valid file path for the current OS
 function joinPathOS() {
-  local path=$(printf '/%s' "${@}" | sed 's|/\+|/|g')
+  local path=$(IFS=/; echo "/$*" | tr -s /)
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
       path=$(cygpath -w "${path}")
   fi


### PR DESCRIPTION
Previously printf was used which behaves differently on solaris it seems.

Using a method that should work anywhere.

Use IFS='/' to separate path elements and remove duplicate slashes afterwards using tr.