### PR TITLE
Replace build-autotriage action version number with SHA

### DIFF
--- a/.github/workflows/build-autotriage.yml
+++ b/.github/workflows/build-autotriage.yml
@@ -16,13 +16,13 @@ jobs:
     name: Run Build Triage
     if: github.repository == 'adoptium/temurin-build'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: "Run Build Auto Triage"
         run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk22 jdk23head
 
       - name: Create Issue From File
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@e27dddc79c92bc6e4562f268fffa5ed752639abd # v2
         with:
           filename: ./build_triage_output.md


### PR DESCRIPTION
ref https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

For the JasonEtco/create-an-issue action, the commit points to https://github.com/JasonEtco/create-an-issue/commit/e27dddc79c92bc6e4562f268fffa5ed752639abd. Bit odd looking, just alot of deleted files. 

And though the commit says `This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.`, this tag is the same as the [release v2.9.1](https://github.com/JasonEtco/create-an-issue/releases/tag/v2.9.1) which is verified
