### PR TITLE
Temporarily patch architecture confusion when cross-compiling on mac

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -31,7 +31,6 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "DEBUG: Running Adam's build script copy."
 
 # shellcheck source=sbin/prepareWorkspace.sh
 source "$SCRIPT_DIR/prepareWorkspace.sh"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -881,7 +881,7 @@ generateSBoM() {
   # and that confuses things when cross-compiling an x64 mac build on arm mac.
   #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]; then
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "X86_64"
   else
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   fi
@@ -1360,14 +1360,19 @@ cleanAndMoveArchiveFiles() {
     #   Windows: lib/static/windows-amd64/
     #
     osArch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-    # TODO: Replace this "if" condition with its predecessor (commented out below) once 
-    # OS_ARCHITECTURE has been replaced by the new target architecture variable.
-    # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
-    # and that confuses things when cross-compiling an x64 mac build on arm mac.
-    # if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "x86_64" ]; then
-    if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]; then
+    if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "x86_64" ]; then
       osArch="amd64"
     fi
+
+    # TODO: Remove the "if" below once OS_ARCHITECTURE has been replaced.
+    # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
+    # and that confuses things when cross-compiling an x64 mac build on arm mac.
+    if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "arm64" ]; then
+      if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]; then
+        osArch="amd64"
+      fi
+    fi
+
     pushd ${staticLibsImagePath}
       case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
       *cygwin*)

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -884,7 +884,7 @@ generateSBoM() {
   echo "DEBUG 1"
   if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
     echo "DEBUG 2"
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "X86_64"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
   else
     echo "DEBUG 3"
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -882,7 +882,6 @@ generateSBoM() {
   #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   echo "DEBUG 1"
   if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
-    echo "DEBUG 2"
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
   else
     echo "DEBUG 3"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -884,7 +884,7 @@ generateSBoM() {
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
   else
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
-  endif
+  fi
 
   # Set default SBOM formulation
   addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -880,7 +880,6 @@ generateSBoM() {
   # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
   # and that confuses things when cross-compiling an x64 mac build on arm mac.
   #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
-  echo "DEBUG 1"
   if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
   else

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -31,6 +31,7 @@ set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+echo "DEBUG: Running Adam's build script copy."
 
 # shellcheck source=sbin/prepareWorkspace.sh
 source "$SCRIPT_DIR/prepareWorkspace.sh"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -884,7 +884,6 @@ generateSBoM() {
   if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
   else
-    echo "DEBUG 3"
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -880,7 +880,7 @@ generateSBoM() {
   # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
   # and that confuses things when cross-compiling an x64 mac build on arm mac.
   #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
-  if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]; then
+  if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "X86_64"
   else
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
@@ -1368,7 +1368,7 @@ cleanAndMoveArchiveFiles() {
     # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
     # and that confuses things when cross-compiling an x64 mac build on arm mac.
     if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "arm64" ]; then
-      if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]; then
+      if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
         osArch="amd64"
       fi
     fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -880,7 +880,7 @@ generateSBoM() {
   # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
   # and that confuses things when cross-compiling an x64 mac build on arm mac.
   #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
-  if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_mac_.* ]; then
+  if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]; then
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
   else
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
@@ -1360,7 +1360,12 @@ cleanAndMoveArchiveFiles() {
     #   Windows: lib/static/windows-amd64/
     #
     osArch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-    if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "x86_64" ]; then
+    # TODO: Replace this "if" condition with its predecessor (commented out below) once 
+    # OS_ARCHITECTURE has been replaced by the new target architecture variable.
+    # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
+    # and that confuses things when cross-compiling an x64 mac build on arm mac.
+    # if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "x86_64" ]; then
+    if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]; then
       osArch="amd64"
     fi
     pushd ${staticLibsImagePath}
@@ -1371,16 +1376,7 @@ cleanAndMoveArchiveFiles() {
         ;;
       darwin)
         # On MacOSX the layout is: Contents/Home/lib/static/darwin-[target architecture]/
-        # TODO: Replace this "if" with its predecessor (commented out below) once 
-        # OS_ARCHITECTURE has been replaced by the new target architecture variable.
-        # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
-        # and that confuses things when cross-compiling an x64 mac build on arm mac.
-        # staticLibsDir="Contents/Home/lib/static/darwin-${osArch}"
-        if [ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_mac_.* ]; then
-          staticLibsDir="Contents/Home/lib/static/darwin-amd64"
-        else
-          staticLibsDir="Contents/Home/lib/static/darwin-${osArch}"
-        fi
+        staticLibsDir="Contents/Home/lib/static/darwin-${osArch}"
         ;;
       linux)
         # on Linux the layout is: lib/static/linux-amd64/glibc

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -880,9 +880,12 @@ generateSBoM() {
   # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
   # and that confuses things when cross-compiling an x64 mac build on arm mac.
   #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
+  echo "DEBUG 1"
   if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
+    echo "DEBUG 2"
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "X86_64"
   else
+    echo "DEBUG 3"
     addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   fi
 


### PR DESCRIPTION
Currently, when we build an x64 mac build on an arm64 machine, we put arm64 all over the place by mistake.

This change is to partially compensate for that mistake until such time as we can implement a comprehensive separation of build architecture and target architecture in our build scripts.