### PR TITLE
Update GNUPGHOME variable more broadly

### DIFF
--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -36,6 +36,16 @@ else
   export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
 fi
 
+## This affects Alpine docker images and also evaluation pipelines
+if [ "$(pwd | wc -c)" -gt 83 ]; then
+  # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
+  # Alpine also cannot create ~/.gpg-temp within a docker context
+  GNUPGHOME="$(mktemp --directory /tmp/.gpg-temp.XXXXX)"
+else
+  GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
+fi
+export GNUPGHOME
+
 BOOT_JDK_VARIABLE="JDK${JDK_BOOT_VERSION}_BOOT_DIR"
 if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
   bootDir="$PWD/jdk-$JDK_BOOT_VERSION"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -319,15 +319,6 @@ checkingAndDownloadingAlsa() {
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
 
-    ## This affects Alpine docker images and also evaluation pipelines
-    if [ "$(pwd | wc -c)" -gt 83 ]; then
-      # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
-      # Alpine also cannot create ~/.gpg-temp within a docker context
-      export GNUPGHOME="/tmp/.gpg-temp.$$"
-    else
-      export GNUPGHOME="${WORKSPACE:-$PWD}/.gpg-temp"
-    fi
-
     echo "GNUPGHOME=$GNUPGHOME"
     mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
     # Should we clear this directory up after checking?


### PR DESCRIPTION
It's an issue on linux-riscv64 valuation pipelines for jdk23. See https://ci.adoptium.net/job/build-scripts/job/jobs/job/evaluation/job/jobs/job/jdk23/job/jdk23-evaluation-linux-riscv64-temurin/2/console for example.

Should normally fix https://github.com/adoptium/temurin-build/issues/3378