### PR TITLE
Correct check for alpine when setting up GNUPGHOME

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -320,7 +320,7 @@ checkingAndDownloadingAlsa() {
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
 
     ## This affects Alpine docker images and also evaluation pipelines
-    if [ "$OPERATING_SYSTEM" == "alpine-linux" ] && [ "$(pwd | wc -c)" -gt 83 ]; then
+    if [ -r /etc/alpine-release ] && [ "$(pwd | wc -c)" -gt 83 ]; then
         # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
         # Alpine also cannot create ~/.gpg-temp within a docker context
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -324,10 +324,15 @@ checkingAndDownloadingAlsa() {
         # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
         # Alpine also cannot create ~/.gpg-temp within a docker context
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
+    else
+        GNUPGHOME="${BUILD_CONFIG[WORKSPACE_DIR]:-$PWD}/.gpg-temp"
     fi
+    if [ ! -d "$GNUPGHOME" ]; then
+        mkdir -m 700 "$GNUPGHOME"
+    fi
+    export GNUPGHOME
 
     echo "GNUPGHOME=$GNUPGHOME"
-    mkdir -p "$GNUPGHOME" && chmod og-rwx "$GNUPGHOME"
     # Should we clear this directory up after checking?
     # Would this risk removing anyone's existing dir with that name?
     # Erring on the side of caution for now


### PR DESCRIPTION
When build using makejdk-any-platform.sh, OPERATING_SYSTEM is not set:
```
build/sbin/prepareWorkspace.sh: line 323: OPERATING_SYSTEM: unbound variable
```
Need to check for Alpine like it does in https://github.com/adoptium/temurin-build/blob/c78dc6cf2d1f1ddbe689220afd80eb957ac6d2a5/build-farm/make-adopt-build-farm.sh#L46

Also GNUPGHOME setup for Alsa not correct if run directly from makejdk-any-platform.sh