### PR TITLE
Fixes to download + SBOM validation scripts

### DIFF
--- a/tooling/release_download_test.sh
+++ b/tooling/release_download_test.sh
@@ -156,11 +156,13 @@ download_release_files() {
 
   # Parse the releases list for the one we want and download everything in it
   # shellcheck disable=SC2013
+  echo `date +%T` : Starting downloads ...
   for url in $(grep "${filter}" "${jdk_releases}" | awk -F'"' '/browser_download_url/{print$4}'); do
     # shellcheck disable=SC2046
     print_verbose "IVT : Downloading $(basename "$url")"
     curl -LORsS -C - "$url"
   done
+  echo `date +%T` : Finished downloads ...
 }
 
 ########################################################################################################################
@@ -230,9 +232,9 @@ verify_valid_archives() {
       print_error "Failed to verify that ${A} can be extracted"
       RC=4
     fi
-    # NOTE: 40 chosen because the static-libs is in the 40s - maybe switch for different tarballs in the future?
-    if [ "$(tar tfz "${A}" | wc -l)" -lt 40 ]; then
-      print_error "Less than 40 files in ${A} - that does not seem correct"
+    # NOTE: 38 chosen because the static-libs is 38 for JDK21/AIX - maybe switch for different tarballs in the future?
+    if [ "$(tar tfz "${A}" | wc -l)" -lt 38 ]; then
+      print_error "Less than 38 files in ${A} - that does not seem correct"
       RC=4
     fi
   done

--- a/tooling/release_download_test.sh
+++ b/tooling/release_download_test.sh
@@ -156,13 +156,13 @@ download_release_files() {
 
   # Parse the releases list for the one we want and download everything in it
   # shellcheck disable=SC2013
-  echo $(date +%T) : Starting downloads ...
-  grep "${filter}" "${jdk_releases}" | awk -F'"' '/browser_download_url/{print$4}' | while read url; do
+  echo "$(date +%T) : Starting downloads ..."
+  grep "${filter}" "${jdk_releases}" | awk -F'"' '/browser_download_url/{print$4}' | while read -r url; do
     # shellcheck disable=SC2046
     print_verbose "IVT : Downloading $(basename "$url")"
     curl -LORsS -C - "$url"
   done
-  echo $(date +%T) : Finished downloads ...
+  echo "$(date +%T) : Finished downloads ..."
 }
 
 ########################################################################################################################

--- a/tooling/release_download_test.sh
+++ b/tooling/release_download_test.sh
@@ -200,7 +200,7 @@ verify_gpg_signatures() {
   for A in OpenJDK*.tar.gz OpenJDK*.zip *.msi *.pkg *sbom*[0-9].json; do
     print_verbose "IVT : Verifying signature of file ${A}"
 
-    if ! gpg -q --verify "${A}.sig" "${A}" > /dev/null; then
+    if ! gpg -q --verify "${A}.sig" "${A}" 2> /dev/null; then
       print_error "GPG signature verification failed for ${A}"
       RC=2
     fi

--- a/tooling/release_download_test.sh
+++ b/tooling/release_download_test.sh
@@ -20,7 +20,6 @@
 set -euo pipefail
 
 WORKSPACE=${WORKSPACE:-"$PWD"}
-VERBOSE=false
 KEEP_STAGING=false
 SKIP_DOWNLOADING=false
 USE_ANSI=false
@@ -226,7 +225,7 @@ verify_valid_archives() {
 
   for A in OpenJDK*.tar.gz; do
     print_verbose "IVT : Counting files in tarball ${A}"
-
+    ls -l "${A}"
     if ! tar tfz "${A}" > /dev/null; then
       print_error "Failed to verify that ${A} can be extracted"
       RC=4

--- a/tooling/release_download_test.sh
+++ b/tooling/release_download_test.sh
@@ -156,13 +156,13 @@ download_release_files() {
 
   # Parse the releases list for the one we want and download everything in it
   # shellcheck disable=SC2013
-  echo `date +%T` : Starting downloads ...
-  for url in $(grep "${filter}" "${jdk_releases}" | awk -F'"' '/browser_download_url/{print$4}'); do
+  echo $(date +%T) : Starting downloads ...
+  grep "${filter}" "${jdk_releases}" | awk -F'"' '/browser_download_url/{print$4}' | while read url; do
     # shellcheck disable=SC2046
     print_verbose "IVT : Downloading $(basename "$url")"
     curl -LORsS -C - "$url"
   done
-  echo `date +%T` : Finished downloads ...
+  echo $(date +%T) : Finished downloads ...
 }
 
 ########################################################################################################################

--- a/tooling/release_download_test.sh
+++ b/tooling/release_download_test.sh
@@ -200,7 +200,7 @@ verify_gpg_signatures() {
   for A in OpenJDK*.tar.gz OpenJDK*.zip *.msi *.pkg *sbom*[0-9].json; do
     print_verbose "IVT : Verifying signature of file ${A}"
 
-    if ! gpg -q --verify "${A}.sig" "${A}"; then
+    if ! gpg -q --verify "${A}.sig" "${A}" > /dev/null; then
       print_error "GPG signature verification failed for ${A}"
       RC=2
     fi
@@ -227,7 +227,6 @@ verify_valid_archives() {
 
   for A in OpenJDK*.tar.gz; do
     print_verbose "IVT : Counting files in tarball ${A}"
-    ls -l "${A}"
     if ! tar tfz "${A}" > /dev/null; then
       print_error "Failed to verify that ${A} can be extracted"
       RC=4

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -58,8 +58,9 @@ elif echo "$SBOMFILE" | grep _x64_windows_; then
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2017 - CURRENTLY NOT WORKING)"
   elif [ "${MAJORVERSION}" -ge 20 ]; then
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2022)"
-  else
+  else # JDK11 and 17
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2019)"
+    EXPECTED_FREETYPE=Unknown
   fi
 elif echo "$SBOMFILE" | grep _x86-32_windows_; then
   EXPECTED_FREETYPE=2.5.3
@@ -67,16 +68,18 @@ elif echo "$SBOMFILE" | grep _x86-32_windows_; then
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2013)"
   elif [ "${MAJORVERSION}" = "11" ]; then
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2017)"
-  else
+  else # JDK 11 and 17
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2019)"
+    EXPECTED_FREETYPE=Unknown
   fi
 elif echo "$SBOMFILE" | grep _mac_; then
   # NOTE: mac/x64 native builds >=11 were using "clang (clang/LLVM from Xcode 10.3)"
+  EXPECTED_FREETYPE=Unknown
   EXPECTED_COMPILER="clang (clang/LLVM from Xcode 15.0.1)"
   # shellcheck disable=SC2166
   if [ "${MAJORVERSION}" = "8" -o "${MAJORVERSION}" = "11" ] && echo "$SBOMFILE" | grep _x64_; then
     EXPECTED_COMPILER="clang (clang/LLVM)"
-    EXPECTED_FREETYPE=2.9.1
+    [ "${MAJORVERSION}" = "8" ] && EXPECTED_FREETYPE=2.9.1
   fi
 fi
 

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -24,7 +24,8 @@ EXPECTED_GCC=""
 EXPECTED_ALSA=N.A
 #EXPECTED_FREETYPE=N.A # https://github.com/adoptium/temurin-build/issues/3493
 #EXPECTED_FREETYPE=https://github.com/freetype/freetype/commit/86bc8a95056c97a810986434a3f268cbe67f2902
-EXPECTED_FREETYPE=Unknown
+if 
+EXPECTED_FREETYPE=2.8.0
 if echo "$SBOMFILE" | grep _solaris_; then
   #EXPECTED_FREETYPE=N.A
   EXPECTED_COMPILER="solstudio (Oracle Solaris Studio)"
@@ -45,7 +46,7 @@ elif echo "$SBOMFILE" | grep _linux_; then
   [ "${MAJORVERSION}" = "8" ] && EXPECTED_GCC=7.5.0
   [ "${MAJORVERSION}" = "11" ] && EXPECTED_GCC=7.5.0
   [ "${MAJORVERSION}" = "17" ] && EXPECTED_GCC=10.3.0
-  [ "${MAJORVERSION}" -ge 20 ] && EXPECTED_GCC=11.2.0
+  [ "${MAJORVERSION}" -ge 20 ] && EXPECTED_GCC=11.2.0 && EXPECTED_FREETYPE=UNknown
   EXPECTED_ALSA=1.1.6
   #EXPECTED_FREETYPE=N.A
 #elif echo $SBOMFILE | grep _mac_; then

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -106,7 +106,7 @@ echo -n "Checking for JDK source SHA validity: "
 GITSHA=$(jq '.components[].properties[] | select(.name|test("OpenJDK Source Commit")) | .value' "$1" | tr -d \" | uniq)
 GITREPO=$(echo "$GITSHA" | cut -d/ -f1-5)
 GITSHA=$( echo "$GITSHA" | cut -d/ -f7)
-if [ -z "$(git ls-remote ${GITREPO} | grep ${GITSHA})" ]; then
+if ! git ls-remote "${GITREPO}" | grep "${GITSHA}"; then
   echo "ERROR: git sha of source repo not found"
   RC=1
 fi
@@ -118,7 +118,7 @@ GITREPO=$(echo "$GITSHA" | cut -d/ -f1-5)
 GITSHA=$(echo  "$GITSHA" | cut -d/ -f7)
 echo "Checking for temurin-build SHA $GITSHA in ${GITREPO}"
 
-if [ -z "$(git ls-remote ${GITREPO} | grep ${GITSHA})" ]; then
+if ! git ls-remote "${GITREPO}" | grep "2D${GITSHA}" ]; then
    echo "WARNING: temurin-build SHA check failed. This can happen if it was not a tagged level"
    if echo "$1" | grep '[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9]' 2>/dev/null; then
      echo "Ignoring return code as filename looks like a nightly"

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -63,23 +63,23 @@ elif echo "$SBOMFILE" | grep _x64_windows_; then
     EXPECTED_FREETYPE=Unknown
   fi
 elif echo "$SBOMFILE" | grep _x86-32_windows_; then
-  EXPECTED_FREETYPE=2.5.3
+  EXPECTED_FREETYPE=Unknown
   if [ "${MAJORVERSION}" = "8"  ]; then
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2013)"
+    EXPECTED_FREETYPE=2.5.3
   elif [ "${MAJORVERSION}" = "11" ]; then
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2017)"
   else # JDK 11 and 17
     EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2019)"
-    EXPECTED_FREETYPE=Unknown
   fi
 elif echo "$SBOMFILE" | grep _mac_; then
   # NOTE: mac/x64 native builds >=11 were using "clang (clang/LLVM from Xcode 10.3)"
   EXPECTED_FREETYPE=Unknown
   EXPECTED_COMPILER="clang (clang/LLVM from Xcode 15.0.1)"
   # shellcheck disable=SC2166
-  if [ "${MAJORVERSION}" = "8" -o "${MAJORVERSION}" = "11" ] && echo "$SBOMFILE" | grep _x64_; then
+  if [ "${MAJORVERSION}" = "8" ] && echo "$SBOMFILE" | grep _x64_; then
     EXPECTED_COMPILER="clang (clang/LLVM)"
-    [ "${MAJORVERSION}" = "8" ] && EXPECTED_FREETYPE=2.9.1
+    EXPECTED_FREETYPE=2.9.1
   fi
 fi
 

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -118,7 +118,7 @@ GITREPO=$(echo "$GITSHA" | cut -d/ -f1-5)
 GITSHA=$(echo  "$GITSHA" | cut -d/ -f7)
 echo "Checking for temurin-build SHA $GITSHA in ${GITREPO}"
 
-if ! git ls-remote "${GITREPO}" | grep "2D${GITSHA}" ]; then
+if ! git ls-remote "${GITREPO}" | grep "${GITSHA}"; then
    echo "WARNING: temurin-build SHA check failed. This can happen if it was not a tagged level"
    if echo "$1" | grep '[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9]' 2>/dev/null; then
      echo "Ignoring return code as filename looks like a nightly"

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -x
+echo SXAEC: VERBOSE=${VERBOSE}
 [ "$VERBOSE" = "true" ] && set -x
 if [ $# -lt 3 ]; then
   echo "Usage: $0 file.json majorversion fullversion"
@@ -95,7 +95,7 @@ echo "BOOTJDK is ${BOOTJDK}"
 echo "FREETYPE is ${FREETYPE}"
 # shellcheck disable=SC3037
 echo -n "Checking for JDK source SHA validity: "
-if GITSHA=$(jq '.components[].properties[] | select(.name|test("OpenJDK Source Commit")) | .value' "$1" | tr -d \")
+GITSHA=$(jq '.components[].properties[] | select(.name|test("OpenJDK Source Commit")) | .value' "$1" | tr -d \" | uniq)
 GITREPO=$(echo "$GITSHA" | cut -d/ -f1-5)
 GITSHA=$( echo "$GITSHA" | cut -d/ -f7)
 if -z $(git ls-remote "${GITREPO}" | grep "${GITSHA}"); then
@@ -105,11 +105,12 @@ fi
 
 # shellcheck disable=SC3037
 echo -n "Checking for temurin-build SHA validity: "
-GITSHA=$(jq '.components[].properties[] | select(.name|test("Temurin Build Ref")) | .value' "$1" | tr -d \")
+GITSHA=$(jq '.components[].properties[] | select(.name|test("Temurin Build Ref")) | .value' "$1" | tr -d \" | uniq)
 GITREPO=$(echo "$GITSHA" | cut -d/ -f1-5)
 GITSHA=$(echo  "$GITSHA" | cut -d/ -f7)
-echo "Checking for temurin-build SHA $GITSHA"
-if -z $(git ls-remote "${GITREPO}" | grep "${GITSHA}"); then
+echo "Checking for temurin-build SHA $GITSHA in ${GITREPO}"
+
+if [ -z "$(git ls-remote ${GITREPO} | grep ${GITSHA})" ]; then
    echo "WARNING: temurin-build SHA check failed. This can happen if it was not a tagged level"
    if echo "$1" | grep '[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9]' 2>/dev/null; then
      echo "Ignoring return code as filename looks like a nightly"


### PR DESCRIPTION
Post-GA fixes to the download + SBoM validation scripting introduced via https://github.com/adoptium/temurin-build/issues/3484. Note that this does not address the other issues with this as per #3621 #3565

- Stop forcing VERBOSE to false
- Show start/end times for downloads because ... it's interesting to note
- Stop displaying the GPG output in the log because it's just noise
- Fix minimum number of artifacts in tarballs (AIX static libs has 38)
- Stop checking for FREEMARKER as we don't use it
- Freetype version is now appearing as "Unknown" since [we started using bundled freetype](https://github.com/adoptium/temurin-build/pull/3557) - Raised at https://github.com/adoptium/temurin-build/issues/3661
- Multiple other freetype versions corrected.
- `OpenJDK Source Commit` in the SBoM appears multiple times - this dedups before trying to use it in a `grep` operation (!)
- Adjust detection of git SHA in the remote repository

Note that jdk8u402-b02 does not pass the tests due to an issue with the Win32 MSI checksum which has a path prefix on the filename. This has been raised at https://github.com/adoptium/temurin-build/issues/3662

Related (and not addressed by this PR):
- https://github.com/adoptium/temurin-build/issues/3565
- https://github.com/adoptium/temurin-build/issues/3621