### PR TITLE
Ensure GPG temp dir can be created for long build folder paths on linux riscv64

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -324,7 +324,7 @@ checkingAndDownloadingAlsa() {
         # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
         # Alpine also cannot create ~/.gpg-temp within a docker context
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
-    elif [ "${BUILD_CONFIG[TARGET_OS]}" == "linux" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] && [ "$(pwd | wc -c)" -gt 83 ]; then
+    elif [[ "${BUILD_CONFIG[TARGET_OS]}" == "linux" ]] && [[ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]] && [[ "$(pwd | wc -c)" -gt 83 ]]; then
         # linux riscv64 also has gpg pathlength issue
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
     else

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -324,6 +324,9 @@ checkingAndDownloadingAlsa() {
         # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
         # Alpine also cannot create ~/.gpg-temp within a docker context
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
+    elif [ "${BUILD_CONFIG[TARGET_OS]}" == "linux" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] && [ "$(pwd | wc -c)" -gt 83 ]; then
+        # linux riscv64 also has gpg pathlength issue
+        GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
     else
         GNUPGHOME="${BUILD_CONFIG[WORKSPACE_DIR]:-$PWD}/.gpg-temp"
     fi

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -319,13 +319,11 @@ checkingAndDownloadingAlsa() {
     curl -o "alsa-lib.tar.bz2" "$ALSA_BUILD_URL"
     curl -o "alsa-lib.tar.bz2.sig" "https://www.alsa-project.org/files/pub/lib/alsa-lib-${ALSA_LIB_VERSION}.tar.bz2.sig"
 
-    ## This affects Alpine docker images and also evaluation pipelines
-    if [ -r /etc/alpine-release ] && [ "$(pwd | wc -c)" -gt 83 ]; then
-        # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
-        # Alpine also cannot create ~/.gpg-temp within a docker context
-        GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
-    elif [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] && [ "$(pwd | wc -c)" -gt 83 ]; then
-        # linux riscv64 also has gpg pathlength issue
+    ## This affects riscv64 & Alpine docker images and also evaluation pipelines
+    if ( [ -r /etc/alpine-release ] && [ "$(pwd | wc -c)" -gt 83 ] ) || \
+       ( [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] && [ "$(pwd | wc -c)" -gt 83 ] ); then
+        # Use /tmp in preference to $HOME as fails gpg operation if PWD > 83 characters
+        # Also cannot create ~/.gpg-temp within a docker context
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
     else
         GNUPGHOME="${BUILD_CONFIG[WORKSPACE_DIR]:-$PWD}/.gpg-temp"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -324,7 +324,7 @@ checkingAndDownloadingAlsa() {
         # Use /tmp for alpine in preference to $HOME as Alpine fails gpg operation if PWD > 83 characters
         # Alpine also cannot create ~/.gpg-temp within a docker context
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
-    elif [[ "${BUILD_CONFIG[TARGET_OS]}" == "linux" ]] && [[ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]] && [[ "$(pwd | wc -c)" -gt 83 ]]; then
+    elif [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] && [ "$(pwd | wc -c)" -gt 83 ]; then
         # linux riscv64 also has gpg pathlength issue
         GNUPGHOME="$(mktemp -d /tmp/.gpg-temp.XXXXXX)"
     else

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2155,SC1091,SC2196
+# shellcheck disable=SC2155,SC1091,SC2196,SC2235
 
 ################################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3659

linux riscv64 GPG has folder path length limitations, similar to Alpine.

Successful GPG creation test: https://ci.adoptium.net/job/build-scripts/job/jobs/job/evaluation/job/jobs/job/jdk21u/job/jdk21u-evaluation-linux-riscv64-temurin/142/
