### PR TITLE
Ensure FreeType include header uses WORKSPACE PATH to source

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1050,7 +1050,7 @@ addFreeTypeVersionInfo() {
    elif [ "${FREETYPE_TO_USE}" == "bundled" ]; then
       # jdk-11+ supports "bundled"
       # freetype.h location for jdk-11+
-      local include="src/java.desktop/share/native/libfreetype/include/freetype/freetype.h"
+      local include="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/src/java.desktop/share/native/libfreetype/include/freetype/freetype.h"
       echo "Checking for FreeType include ${include}"
       if [[ -f "${include}" ]]; then
           echo "Found ${include}"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3661

Path to openjdk source was missing

test build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-aarch64-temurin/100/artifact/workspace/target/OpenJDK21U-sbom_aarch64_linux_hotspot_2024-02-20-16-44.json