### PR TITLE
Correct --release build_args parsing

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -320,7 +320,7 @@ function parseConfigurationArguments() {
         BUILD_CONFIG[REPOSITORY]="$1"; shift;;
 
         "--release" )
-        BUILD_CONFIG[RELEASE]=true; shift;;
+        BUILD_CONFIG[RELEASE]=true;;
 
         "--source" | "-s" )
         BUILD_CONFIG[WORKING_DIR]="$1"; shift;;


### PR DESCRIPTION
Incorrect "shift" when parsing --release
Fixes https://github.com/adoptium/temurin-build/issues/3667

In our release builds the next option happened to be --clean-libs, which was being ignored!
