### PR TITLE
Update linux-riscv64 jdk11u pipeline to temurin

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -142,7 +142,7 @@ then
   if [ "${JAVA_FEATURE_VERSION}" == "11" ] && [ "${VARIANT}" == "openj9" ]; then
     # OpenJ9 only supports building jdk-11 with jdk-11
     JDK_BOOT_VERSION="11"
-  elif [ "${JAVA_FEATURE_VERSION}" == "11" ] && [ "${VARIANT}" == "hotspot" ] && [ "${ARCHITECTURE}" == "riscv64" ]; then
+  elif [ "${JAVA_FEATURE_VERSION}" == "11" ] && [ "${ARCHITECTURE}" == "riscv64" ]; then
     # RISC-V isn't supported on (and isn't planned to support) anything before JDK 11
     JDK_BOOT_VERSION="11"
   elif [ "${JAVA_FEATURE_VERSION}" == "17" ]; then

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -191,6 +191,8 @@ setRepository() {
     suffix="openjdk/aarch32-port-jdk8u";
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [[ "${BUILD_CONFIG[OS_FULL_VERSION]}" == *"Alpine"* ]] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
     suffix="adoptium/alpine-jdk8u";
+  elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] && [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
+    suffix="adoptium/riscv-jdk11u"
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ]] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
     if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] \
       || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_CORE_VERSION}" ]; then


### PR DESCRIPTION
The backport has been merged upstream with [1].

[1] https://github.com/openjdk/riscv-port-jdk11u/commit/309291f166821443393818beed364de6f2de5c52