### PR TITLE
Reproducible jdk21u linux build fixes and updates for debug symbols

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,12 +134,16 @@ jobs:
           rm /usr/local/bin/2to3-3.12 || true
           rm /usr/local/bin/idle3 || true
           rm /usr/local/bin/idle3.11 || true
+          rm /usr/local/bin/idle3.12 || true
           rm /usr/local/bin/pydoc3 || true
           rm /usr/local/bin/pydoc3.11 || true
+          rm /usr/local/bin/pydoc3.12 || true
           rm /usr/local/bin/python3 || true
           rm /usr/local/bin/python3.11 || true
+          rm /usr/local/bin/python3.12 || true
           rm /usr/local/bin/python3-config || true
           rm /usr/local/bin/python3.11-config || true
+          rm /usr/local/bin/python3.12-config || true
             
     - name: Install Dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
       run: |
           rm /usr/local/bin/2to3 || true
           rm /usr/local/bin/2to3-3.11 || true
+          rm /usr/local/bin/2to3-3.12 || true
           rm /usr/local/bin/idle3 || true
           rm /usr/local/bin/idle3.11 || true
           rm /usr/local/bin/pydoc3 || true

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -332,40 +332,44 @@ if [ $executedJavaVersion -ne 0 ]; then
     exit 1
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ] && [ "${ARCHITECTURE}" == "aarch64" ]; then
-  # GCC9 rather than 10 requested by Alibaba for now
-  # Ref https://github.com/adoptium/temurin-build/issues/2250#issuecomment-732958466
-  export PATH=/usr/local/gcc9/bin:$PATH
-  export CC=/usr/local/gcc9/bin/gcc-9.3
-  export CXX=/usr/local/gcc9/bin/g++-9.3
-  # Enable GCC 10 for Java 17+ for repeatable builds, but not for our supported releases
-  # Ref https://github.com/adoptium/temurin-build/issues/2787
-elif [ "${ARCHITECTURE}" == "riscv64" ] && [ -r /usr/bin/gcc-10 ]; then
-  # Enable GCC 10 for RISC-V, given the rapid evolution of RISC-V, the newer the GCC toolchain, the better
-  [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
-  [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
-elif [ "$JAVA_FEATURE_VERSION" -ge 19 ] && [ -r /usr/local/gcc11/bin/gcc-11.2 ]; then
-  export PATH=/usr/local/gcc11/bin:$PATH
-  [ -r /usr/local/gcc11/bin/gcc-11.2 ] && export  CC=/usr/local/gcc11/bin/gcc-11.2
-  [ -r /usr/local/gcc11/bin/g++-11.2 ] && export CXX=/usr/local/gcc11/bin/g++-11.2
-  export LD_LIBRARY_PATH=/usr/local/gcc11/lib64:/usr/local/gcc11/lib
-elif [ "$JAVA_FEATURE_VERSION" -ge 17 ] && [ -r /usr/local/gcc10/bin/gcc-10.3 ]; then
-  export PATH=/usr/local/gcc10/bin:$PATH
-  [ -r /usr/local/gcc10/bin/gcc-10.3 ] && export  CC=/usr/local/gcc10/bin/gcc-10.3
-  [ -r /usr/local/gcc10/bin/g++-10.3 ] && export CXX=/usr/local/gcc10/bin/g++-10.3
-  export LD_LIBRARY_PATH=/usr/local/gcc10/lib64:/usr/local/gcc10/lib
-elif [ "$JAVA_FEATURE_VERSION" -gt 17 ] && [ -r /usr/bin/gcc-10 ]; then
-  [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
-  [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
-# Continue to use GCC 7 if present for JDK<=17 and where 10 does not exist
-elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
-  export PATH=/usr/local/gcc/bin:$PATH
-  [ -r /usr/local/gcc/bin/gcc-7.5 ] && export  CC=/usr/local/gcc/bin/gcc-7.5
-  [ -r /usr/local/gcc/bin/g++-7.5 ] && export CXX=/usr/local/gcc/bin/g++-7.5
-  export LD_LIBRARY_PATH=/usr/local/gcc/lib64:/usr/local/gcc/lib
-elif [ -r /usr/bin/gcc-7 ]; then
-  [ -r /usr/bin/gcc-7 ] && export  CC=/usr/bin/gcc-7
-  [ -r /usr/bin/g++-7 ] && export CXX=/usr/bin/g++-7
+if [[ "${CONFIGURE_ARGS}" =~ .*"--with-devkit=".* ]]; then
+  echo "Using gcc from DevKit toolchain specified in configure args"
+else 
+  if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ] && [ "${ARCHITECTURE}" == "aarch64" ]; then
+    # GCC9 rather than 10 requested by Alibaba for now
+    # Ref https://github.com/adoptium/temurin-build/issues/2250#issuecomment-732958466
+    export PATH=/usr/local/gcc9/bin:$PATH
+    export CC=/usr/local/gcc9/bin/gcc-9.3
+    export CXX=/usr/local/gcc9/bin/g++-9.3
+    # Enable GCC 10 for Java 17+ for repeatable builds, but not for our supported releases
+    # Ref https://github.com/adoptium/temurin-build/issues/2787
+  elif [ "${ARCHITECTURE}" == "riscv64" ] && [ -r /usr/bin/gcc-10 ]; then
+    # Enable GCC 10 for RISC-V, given the rapid evolution of RISC-V, the newer the GCC toolchain, the better
+    [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
+    [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
+  elif [ "$JAVA_FEATURE_VERSION" -ge 19 ] && [ -r /usr/local/gcc11/bin/gcc-11.2 ]; then
+    export PATH=/usr/local/gcc11/bin:$PATH
+    [ -r /usr/local/gcc11/bin/gcc-11.2 ] && export  CC=/usr/local/gcc11/bin/gcc-11.2
+    [ -r /usr/local/gcc11/bin/g++-11.2 ] && export CXX=/usr/local/gcc11/bin/g++-11.2
+    export LD_LIBRARY_PATH=/usr/local/gcc11/lib64:/usr/local/gcc11/lib
+  elif [ "$JAVA_FEATURE_VERSION" -ge 17 ] && [ -r /usr/local/gcc10/bin/gcc-10.3 ]; then
+    export PATH=/usr/local/gcc10/bin:$PATH
+    [ -r /usr/local/gcc10/bin/gcc-10.3 ] && export  CC=/usr/local/gcc10/bin/gcc-10.3
+    [ -r /usr/local/gcc10/bin/g++-10.3 ] && export CXX=/usr/local/gcc10/bin/g++-10.3
+    export LD_LIBRARY_PATH=/usr/local/gcc10/lib64:/usr/local/gcc10/lib
+  elif [ "$JAVA_FEATURE_VERSION" -gt 17 ] && [ -r /usr/bin/gcc-10 ]; then
+    [ -r /usr/bin/gcc-10 ] && export  CC=/usr/bin/gcc-10
+    [ -r /usr/bin/g++-10 ] && export CXX=/usr/bin/g++-10
+  # Continue to use GCC 7 if present for JDK<=17 and where 10 does not exist
+  elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
+    export PATH=/usr/local/gcc/bin:$PATH
+    [ -r /usr/local/gcc/bin/gcc-7.5 ] && export  CC=/usr/local/gcc/bin/gcc-7.5
+    [ -r /usr/local/gcc/bin/g++-7.5 ] && export CXX=/usr/local/gcc/bin/g++-7.5
+    export LD_LIBRARY_PATH=/usr/local/gcc/lib64:/usr/local/gcc/lib
+  elif [ -r /usr/bin/gcc-7 ]; then
+    [ -r /usr/bin/gcc-7 ] && export  CC=/usr/bin/gcc-7
+    [ -r /usr/bin/g++-7 ] && export CXX=/usr/bin/g++-7
+  fi
 fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -155,7 +155,7 @@ configureReproducibleBuildDebugMapping() {
 
     local buildOutputDir="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/${OUTPUT_DIR}/"
     # Ensure directory is correctly formed so is mapped, with no ./ or //
-    buildOutputDir=$("echo ${buildOutputDir}| sed 's,\./,,' | sed 's,//,,'")
+    buildOutputDir=$(echo ${buildOutputDir} | sed 's,\./,,' | sed 's,//,,')
     local fdebug_flags="-fdebug-prefix-map=${buildOutputDir}="
 
     addConfigureArg "--with-extra-cflags=" "'${fdebug_flags}'"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -155,7 +155,7 @@ configureReproducibleBuildDebugMapping() {
 
     local buildOutputDir="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/${OUTPUT_DIR}/"
     # Ensure directory is correctly formed so is mapped, with no ./ or //
-    buildOutputDir=$(echo ${buildOutputDir} | sed 's,\./,,' | sed 's,//,,')
+    buildOutputDir=$(echo ${buildOutputDir} | sed 's,\./,,' | sed 's,//,/,')
     local fdebug_flags="-fdebug-prefix-map=${buildOutputDir}="
 
     addConfigureArg "--with-extra-cflags=" "'${fdebug_flags}'"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -131,35 +131,6 @@ configureReproducibleBuildParameter() {
          addConfigureArg "--with-extra-cflags=" "-qnotimestamps"
          addConfigureArg "--with-extra-cxxflags=" "-qnotimestamps"
       fi
-
-      # For jdk21u a workaround is required for debug symbol mapping
-      # until https://bugs.openjdk.org/browse/JDK-8326685 is backported
-      if [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -eq 21 ]]
-      then
-         configureReproducibleBuildDebugMapping
-      fi
-  fi
-}
-
-# For reproducible builds we need to add debug mappings for the build/OUTPUTDIR
-# so that debug symbol files (and thus libraries) are deterministic
-configureReproducibleBuildDebugMapping() {
-  # Workaround until https://bugs.openjdk.org/browse/JDK-8326685 is backported to jdk21u
-  if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ]; then
-    local OUTPUT_DIR
-    if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "armv7l" ]; then
-      OUTPUT_DIR="linux-arm-serverANDclient-release"
-    else
-      OUTPUT_DIR="linux-${BUILD_CONFIG[OS_ARCHITECTURE]}-server-release"
-    fi
-
-    local buildOutputDir="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/${OUTPUT_DIR}/"
-    # Ensure directory is correctly formed so is mapped, with no ./ or //
-    buildOutputDir=$(echo ${buildOutputDir} | sed 's,\./,,' | sed 's,//,/,')
-    local fdebug_flags="-fdebug-prefix-map=${buildOutputDir}="
-
-    addConfigureArg "--with-extra-cflags=" "'${fdebug_flags}'"
-    addConfigureArg "--with-extra-cxxflags=" "'${fdebug_flags}'"
   fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -154,6 +154,8 @@ configureReproducibleBuildDebugMapping() {
     fi
 
     local buildOutputDir="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/build/${OUTPUT_DIR}/"
+    # Ensure directory is correctly formed so is mapped, with no ./ or //
+    buildOutputDir=$("echo ${buildOutputDir}| sed 's,\./,,' | sed 's,//,,'")
     local fdebug_flags="-fdebug-prefix-map=${buildOutputDir}="
 
     addConfigureArg "--with-extra-cflags=" "'${fdebug_flags}'"

--- a/tooling/reproducible/comparable_patch.sh
+++ b/tooling/reproducible/comparable_patch.sh
@@ -86,9 +86,10 @@ echo "  PATCH_VS_VERSION_INFO=$PATCH_VS_VERSION_INFO"
 # Remove excluded files known to differ
 #  NOTICE - Vendor specfic notice text file
 #  cacerts - Vendors use different cacerts
+#  classlist - Used to generate CDS archives, can vary due to different build machine environment
 #  classes.jsa, classes_nocoops.jsa - CDS archive caches will differ due to Vendor string differences
 function removeExcludedFiles() {
-  excluded="NOTICE cacerts classes.jsa classes_nocoops.jsa"
+  excluded="NOTICE cacerts classlist classes.jsa classes_nocoops.jsa"
 
   echo "Removing excluded files known to differ: ${excluded}"
   for exclude in $excluded
@@ -97,7 +98,7 @@ function removeExcludedFiles() {
       for f in $FILES
         do
           echo "Removing $f"
-          rm "$f"
+          rm -f "$f"
         done
     done
 
@@ -109,9 +110,8 @@ function removeExcludedFiles() {
 #   - ModuleResolution:
 #   - ModuleTarget:
 # java.base also requires the dependent module "hash:" values to be excluded
-# as they differ due to the Signatures
+# as they differ due to the Signatures and Vendor string differences
 function processModuleInfo() {
-  if [[ "$OS" =~ CYGWIN* ]] || [[ "$OS" =~ Darwin* ]]; then
     echo "Normalizing ModuleAttributes order in module-info.class, converting to javap"
 
     moduleAttr="ModuleResolution ModuleTarget"
@@ -180,7 +180,6 @@ function processModuleInfo() {
         rm -f "$f.javap.$attr"
       done
     done
-  fi
 }
 
 # Process SystemModules classes to remove ModuleHashes$Builder differences due to Signatures
@@ -531,10 +530,10 @@ processModuleInfo
 if [[ "$OS" =~ CYGWIN* ]] && [[ "$PATCH_VS_VERSION_INFO" = true ]]; then
   # Neutralise COMPANY_NAME
   neutraliseVsVersionInfo
-
-  # SystemModules$*.class's differ due to hash differences from COMPANY_NAME
-  removeSystemModulesHashBuilderParams
 fi
+
+# SystemModules$*.class's differ due to hash differences from COMPANY_NAME
+removeSystemModulesHashBuilderParams
 
 if [[ "$OS" =~ CYGWIN* ]]; then
    removeWindowsNonComparableData

--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -65,6 +65,14 @@ function expandJDK() {
   unzip -d "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs-expanded" "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs.jar" 1> /dev/null
   rm "${JDK_DIR}/jmods/expanded_java.base.jmod/lib/jrt-fs.jar"
 
+  echo "Expanding 'ct.sym' to workaround zip timestamp differences (https://bugs.openjdk.org/browse/JDK-8327466)"
+  mkdir "${JDK_DIR}/lib/ct-sym-expanded"
+  unzip -d "${JDK_DIR}/lib/ct-sym-expanded" "${JDK_DIR}/lib/ct.sym" 1> /dev/null
+  rm "${JDK_DIR}/lib/ct.sym"
+  mkdir -p "${JDK_DIR}/jmods/expanded_jdk.compiler.jmod/lib/ct-sym-expanded"
+  unzip -d "${JDK_DIR}/jmods/expanded_jdk.compiler.jmod/lib/ct-sym-expanded" "${JDK_DIR}/jmods/expanded_jdk.compiler.jmod/lib/ct.sym" 1> /dev/null
+  rm "${JDK_DIR}/jmods/expanded_jdk.compiler.jmod/lib/ct.sym"
+
   rm -rf "${JDK_ROOT}_CP"
 }
 


### PR DESCRIPTION
Updates to the comparable build scripts to support Linux comparisons, and also recent changes due to backports for debug symbol mapping:
- Removal of linux debug symbol mapping for https://bugs.openjdk.org/browse/JDK-8323667 which is now backported to jdk21u and can be removed
- Fixes to the comparable build scripts to support Linux comparisons

