### PR TITLE
cacert: auto update smoke test counter

### DIFF
--- a/.github/workflows/ca-cert-updater.yml
+++ b/.github/workflows/ca-cert-updater.yml
@@ -26,8 +26,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ADOPTIUM_TEMURIN_BOT_TOKEN }}
         with:
+          branch: ca-certs-updater
           title: "Update CA Certs"
           body: "See details in the Meta Bug linked from the *Root Cert Inclusions into Mozilla Product Releases* section of https://wiki.mozilla.org/NSS:Release_Versions"
-          path: "security/"
           commit-message: "cacerts: pull in updated certs from Mozilla"
           author: "eclipse-temurin-bot <temurin-bot@eclipse.org>"

--- a/security/mk-ca-bundle.pl
+++ b/security/mk-ca-bundle.pl
@@ -608,3 +608,25 @@ if($opt_u && -e $txt && !unlink($txt)) {
 }
 report "Done ($certnum CA certs processed, $skipnum skipped).";
 print $certnum;
+
+# Update test/functional/buildAndPackage/src/net/adoptium/test/VerifyCACertsTest.java
+# to private static final int EXPECTED_COUNT = $certnum
+my $filename = '../test/functional/buildAndPackage/src/net/adoptium/test/VerifyCACertsTest.java';
+open my $fh, '<', $filename or die "Couldn't open file: $!";
+
+# Read the entire file into an array
+my @lines = <$fh>;
+close $fh;
+
+# Open the same file for writing (this clears the file)
+open $fh, '>', $filename or die "Couldn't open file: $!";
+
+# Process each line
+foreach my $line (@lines) {
+  if ($line =~ /private static final int EXPECTED_COUNT = \d+/) {
+    $line = "    private static final int EXPECTED_COUNT = $certnum;\n";
+  }
+  print $fh $line;
+}
+
+close $fh;


### PR DESCRIPTION
As noted in https://github.com/adoptium/temurin-build/pull/3697, we still have to manually update the total cert count