### PR TITLE
Add getDependentLibs for smoke test

### DIFF
--- a/test/functional/buildAndPackage/build.xml
+++ b/test/functional/buildAndPackage/build.xml
@@ -27,13 +27,15 @@
     <!--Properties for this particular build-->
     <property name="src" location="./src"/>
     <property name="build" location="./bin"/>
+    <property name="LIB" value="testng"/>
+    <import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
     <target name="init">
         <mkdir dir="${DEST}"/>
         <mkdir dir="${build}"/>
     </target>
 
-    <target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source  ">
+    <target name="compile" depends="init,getDependentLibs" description="Using java ${JDK_VERSION} to compile the source  ">
         <echo>Ant version is ${ant.version}</echo>
         <echo>============COMPILER SETTINGS============</echo>
         <echo>===fork: yes</echo>


### PR DESCRIPTION
- Add getDependentLibs for smoke test
- Related Issus: https://github.com/eclipse-openj9/openj9/issues/19122