### PR TITLE
Removing also dash "-" and underscore "_" from repository name

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -33,7 +33,7 @@ function setOpenJdkVersion() {
     BUILD_CONFIG[OPENJDK_CORE_VERSION]=${BUILD_CONFIG[OPENJDK_FOREST_NAME]%?}
   fi
 
-  local featureNumber=$(echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | tr -d "[:alpha:]")
+  local featureNumber=$(echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | sed "s/[a-zA-Z_-]//g")
 
   if [ -z "${featureNumber}" ]
   then

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -33,7 +33,7 @@ function setOpenJdkVersion() {
     BUILD_CONFIG[OPENJDK_CORE_VERSION]=${BUILD_CONFIG[OPENJDK_FOREST_NAME]%?}
   fi
 
-  local featureNumber=$(echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | sed "s/[a-zA-Z_-]//g")
+  local featureNumber=$(echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | sed "s/[a-zA-Z_-\.]//g")
 
   if [ -z "${featureNumber}" ]
   then


### PR DESCRIPTION
this is partially bound to https://github.com/adoptium/temurin-build/pull/3724, where dash and underscore are one of major delimiters in directory names jdk11u-my_feature

May, or may have not sense without the 3724