### PR TITLE
Added check to prevent input of invalid repo as main argument

### DIFF
--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -26,7 +26,7 @@ that you are building for further details.
 
 This will start a Docker container and build you the latest Java 8 Temurin
 binary from the source at https://github.com/adoptium/openjdk-jdk8u
-Note that the main argumenr, in this case jdk8, is comapred enforced
+Note that the main argument, in this case jdk8, is compared and enforced
 to be an enumeration - jdk8, jdk8u, ... jdk21, jdk21u, ...jdk. Nothing else.
 You can workaround this by \-\-version switch.
 

--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -27,7 +27,7 @@ that you are building for further details.
 This will start a Docker container and build you the latest Java 8 Temurin
 binary from the source at https://github.com/adoptium/openjdk-jdk8u
 Note that the main argument, in this case jdk8, is compared and enforced
-to be an enumeration - jdk8, jdk8u, ... jdk21, jdk21u, ...jdk. Nothing else.
+against an enumeration - jdk8, jdk8u, ... jdk21, jdk21u, ...jdk. Nothing else.
 You can workaround this by \-\-version switch.
 
 Please visit https://www.adoptium.net for further support

--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -26,6 +26,9 @@ that you are building for further details.
 
 This will start a Docker container and build you the latest Java 8 Temurin
 binary from the source at https://github.com/adoptium/openjdk-jdk8u
+Note that the main argumenr, in this case jdk8, is comapred enforced
+to be an enumeration - jdk8, jdk8u, ... jdk21, jdk21u, ...jdk. Nothing else.
+You can workaround this by \-\-version switch.
 
 Please visit https://www.adoptium.net for further support
 

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -26,7 +26,7 @@ function setOpenJdkVersion() {
   echo "$forest_name" | grep -q -e "^jdk$" -e "^jdk[0-9]\\{1,3\\}[u]\\{0,1\\}$" || forest_name_check=$?
   if [ ${forest_name_check} -ne 0 ]; then
     echo "The mandatory repo argument has a very strict format 'jdk[0-9]{1,3}[u]{0,1}' or just plain 'jdk' for tip. '$forest_name' does not match."
-    echo "This can be workarounded by '--version jdkXYu'. If set (and matching) then main argument can have any value."
+    echo "This can be worked around by using '--version jdkXYu'. If set (and matching) then the main argument can have any value."
     exit 1
   fi
 

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -17,7 +17,7 @@
 function setOpenJdkVersion() {
   local forest_name=$1
 
-  # the argument passed here have actually very strict format of jdk8, jdk8u..., jdk
+  # The argument passed here have actually very strict format of jdk8, jdk8u..., jdk
   # the build may fail later if this is not honoured.
   # If your repository has a different name, you can use --version or build from dir/snapshot
   local forest_name_check=0

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -19,6 +19,17 @@
 function setOpenJdkVersion() {
   local forest_name=$1
 
+  # the argument passed here have actually very strict format of jdk8, jdk8u...,jdk
+  # the build may fail later if this is not honoured.
+  # If your repository have different name, have to go with --version or build from dir/snapshot
+  local forest_name_check=0
+  echo "$forest_name" | grep -q -e "^jdk$" -e "^jdk[0-9]\\{1,3\\}[u]\\{0,1\\}$" || forest_name_check=$?
+  if [ ${forest_name_check} -ne 0 ]; then
+    echo "The mandatory repo argument have very strict format 'jdk[0-9]{1,3}[u]{0,1}' or jsut plain 'jdk' for tip. '$forest_name' do not match."
+    echo "This can be workarounded by '--version jdkXYu'. If set (and matching) then main argument can have any value."
+    exit 1
+  fi
+
   # Derive the openjdk_core_version from the forest name.
   local openjdk_core_version=${forest_name}
   if [[ ${forest_name} == *u ]]; then

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -21,7 +21,7 @@ function setOpenJdkVersion() {
 
   # the argument passed here have actually very strict format of jdk8, jdk8u..., jdk
   # the build may fail later if this is not honoured.
-  # If your repository have different name, have to go with --version or build from dir/snapshot
+  # If your repository has a different name, you can use --version or build from dir/snapshot
   local forest_name_check=0
   echo "$forest_name" | grep -q -e "^jdk$" -e "^jdk[0-9]\\{1,3\\}[u]\\{0,1\\}$" || forest_name_check=$?
   if [ ${forest_name_check} -ne 0 ]; then

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -25,7 +25,7 @@ function setOpenJdkVersion() {
   local forest_name_check=0
   echo "$forest_name" | grep -q -e "^jdk$" -e "^jdk[0-9]\\{1,3\\}[u]\\{0,1\\}$" || forest_name_check=$?
   if [ ${forest_name_check} -ne 0 ]; then
-    echo "The mandatory repo argument have very strict format 'jdk[0-9]{1,3}[u]{0,1}' or jsut plain 'jdk' for tip. '$forest_name' do not match."
+    echo "The mandatory repo argument has a very strict format 'jdk[0-9]{1,3}[u]{0,1}' or just plain 'jdk' for tip. '$forest_name' does not match."
     echo "This can be workarounded by '--version jdkXYu'. If set (and matching) then main argument can have any value."
     exit 1
   fi

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -19,7 +19,7 @@
 function setOpenJdkVersion() {
   local forest_name=$1
 
-  # the argument passed here have actually very strict format of jdk8, jdk8u...,jdk
+  # the argument passed here have actually very strict format of jdk8, jdk8u..., jdk
   # the build may fail later if this is not honoured.
   # If your repository have different name, have to go with --version or build from dir/snapshot
   local forest_name_check=0


### PR DESCRIPTION
the main argument have actually very strict format of jdk8, jdk8u...,jdk, the build may fail later if this is not honoured.

If your repository have different name, have to go with --version or build from dir/snapshot
