### PR TITLE
comparable_patch.sh: Zero out .gnu_debuglink CRCs (#3730)

### DIFF
--- a/tooling/reproducible/ReproducibleBuilds.md
+++ b/tooling/reproducible/ReproducibleBuilds.md
@@ -48,6 +48,7 @@ The patching process involves:
 - Remove Vendor strings embedded in executables, classes and text files.
 - Remove module-info differences due to "hash" of Signed module executables
 - Remove any non-deterministic build process artifact strings, like Manifest Created-By stamps.
+- Zero out CRC in .gnu_debuglink ELF sections to eliminate .debuginfo-induced differences.
 
 ### How to setup and run comparable_patch.sh on Windows
 


### PR DESCRIPTION
This pull request replaces https://github.com/adoptium/temurin-build/pull/3732.  Instead of removing the .gnu_debuglink section, this patch set changes just the four CRC bytes in that ELF section to 0.