### PR TITLE
Enable checking for /usr/local/devkit matching required Adoptium DevKit

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -76,7 +76,7 @@ addConfigureArgIfValueIsNotEmpty() {
 # Configure the DevKit if required
 configureDevKitConfigureParameter() {
   if [[ -n "${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" ]]; then
-    addConfigureArg "--with-devkit=" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit"
+    addConfigureArg "--with-devkit=" "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}"
   fi
 } 
 

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -29,6 +29,7 @@
 # (because of GPL3), we therefore have to name the indexes of the CONFIG_PARAMS
 # map. This is why we can't have nice things.
 CONFIG_PARAMS=(
+ADOPTIUM_DEVKIT_LOCATION
 ADOPT_PATCHES
 ASSEMBLE_EXPLODED_IMAGE
 OPENJDK_BUILD_REPO_BRANCH
@@ -604,6 +605,7 @@ function configDefaults() {
 
   # Default to no Adoptium DevKit
   BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]=""
+  BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]=""
 
   # By default dont backport JEP318 certs to < Java 10
   BUILD_CONFIG[USE_JEP319_CERTS]=false

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -603,6 +603,7 @@ downloadDevkit() {
         echo "Attempting to download the required DevKit instead"
       else
         # Found a matching DevKit
+        echo "Using matching DevKit from location ${USR_LOCAL_DEVKIT}"
         BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]="${USR_LOCAL_DEVKIT}"
       fi
     fi

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -589,6 +589,8 @@ downloadDevkit() {
 
     BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]=""
 
+    local devkit_target="${BUILD_CONFIG[OS_ARCHITECTURE]}-linux-gnu"
+
     local USR_LOCAL_DEVKIT="/usr/local/devkit"
     if [[ -d "${USR_LOCAL_DEVKIT}" ]]; then
       local usrLocalDevkitInfo="${USR_LOCAL_DEVKIT}/devkit.info"
@@ -613,7 +615,6 @@ downloadDevkit() {
 
       # Determine DevKit tarball to download for this arch and release
       local devkitUrl="https://github.com/adoptium/devkit-binaries/releases/download/${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
-      local devkit_target="${BUILD_CONFIG[OS_ARCHITECTURE]}-linux-gnu"
       local devkit="devkit-${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}-${devkit_target}"
 
       # Download tarball and GPG sig

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -591,7 +591,7 @@ downloadDevkit() {
 
     local devkit_target="${BUILD_CONFIG[OS_ARCHITECTURE]}-linux-gnu"
 
-    local USR_LOCAL_DEVKIT="/usr/local/devkit"
+    local USR_LOCAL_DEVKIT="/usr/local/devkit/${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
     if [[ -d "${USR_LOCAL_DEVKIT}" ]]; then
       local usrLocalDevkitInfo="${USR_LOCAL_DEVKIT}/devkit.info"
        if ! grep "ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" "${usrLocalDevkitInfo}" || ! grep "ADOPTIUM_DEVKIT_TARGET=${devkit_target}" "${usrLocalDevkitInfo}"; then

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -581,44 +581,67 @@ setupGpg() {
     echo "GNUPGHOME=$GNUPGHOME"
 }
 
-# Download the required DevKit if necessary
+# Download the required DevKit if necessary and not available in /usr/local/devkit
 downloadDevkit() {
   if [[ -n "${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" ]]; then
     rm -rf "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit"
     mkdir -p "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit"
 
-    local devkit_tar="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit/devkit.tar.xz"
+    BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]=""
 
-    setupGpg
+    local USR_LOCAL_DEVKIT="/usr/local/devkit"
+    if [[ -d "${USR_LOCAL_DEVKIT}" ]]; then
+      local usrLocalDevkitInfo="${USR_LOCAL_DEVKIT}/devkit.info"
+       if ! grep "ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" "${usrLocalDevkitInfo}" || ! grep "ADOPTIUM_DEVKIT_TARGET=${devkit_target}" "${usrLocalDevkitInfo}"; then
+        echo "WARNING: Devkit ${usrLocalDevkitInfo} does not match required release and architecture:"
+        echo "       Required:   ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
+        echo "       ${USR_LOCAL_DEVKIT}: $(grep ADOPTIUM_DEVKIT_RELEASE= "${usrLocalDevkitInfo}")"
+        echo "       Required:   ADOPTIUM_DEVKIT_TARGET=${devkit_target}"
+        echo "       ${USR_LOCAL_DEVKIT}: $(grep ADOPTIUM_DEVKIT_TARGET= "${usrLocalDevkitInfo}")"
+        echo "Attempting to download the required DevKit instead"
+      else
+        # Found a matching DevKit
+        BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]="${USR_LOCAL_DEVKIT}"
+      fi
+    fi
 
-    # Determine DevKit tarball to download for this arch and release
-    local devkitUrl="https://github.com/adoptium/devkit-binaries/releases/download/${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
-    local devkit_target="${BUILD_CONFIG[OS_ARCHITECTURE]}-linux-gnu"
-    local devkit="devkit-${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}-${devkit_target}"
+    # Download from adoptium/devkit-runtimes if we have not found a matching one locally
+    if [[ -z "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}" ]]; then
+      local devkit_tar="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit/devkit.tar.xz"
 
-    # Download tarball and GPG sig
-    echo "Downloading DevKit : ${devkitUrl}/${devkit}.tar.xz"
-    curl -L --fail --silent --show-error -o "${devkit_tar}" "${devkitUrl}/${devkit}.tar.xz"
-    curl -L --fail --silent --show-error -o "${devkit_tar}.sig" "${devkitUrl}/${devkit}.tar.xz.sig"
+      setupGpg
 
-    # GPG verify
-    gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
-    echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
-    gpg --verify "${devkit_tar}.sig" "${devkit_tar}" || exit 1
+      # Determine DevKit tarball to download for this arch and release
+      local devkitUrl="https://github.com/adoptium/devkit-binaries/releases/download/${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
+      local devkit_target="${BUILD_CONFIG[OS_ARCHITECTURE]}-linux-gnu"
+      local devkit="devkit-${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}-${devkit_target}"
 
-    tar xpJf "${devkit_tar}" -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit"
-    rm "${devkit_tar}"
-    rm "${devkit_tar}.sig"
+      # Download tarball and GPG sig
+      echo "Downloading DevKit : ${devkitUrl}/${devkit}.tar.xz"
+      curl -L --fail --silent --show-error -o "${devkit_tar}" "${devkitUrl}/${devkit}.tar.xz"
+      curl -L --fail --silent --show-error -o "${devkit_tar}.sig" "${devkitUrl}/${devkit}.tar.xz.sig"
 
-    # Validate devkit.info matches value passed in and current architecture
-    local devkitInfo="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit/devkit.info"
-    if ! grep "ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" "${devkitInfo}" || ! grep "ADOPTIUM_DEVKIT_TARGET=${devkit_target}" "${devkitInfo}"; then
+      # GPG verify
+      gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B
+      echo -e "5\ny\n" |  gpg --batch --command-fd 0 --expert --edit-key 3B04D753C9050D9A5D343F39843C48A565F8F04B trust;
+      gpg --verify "${devkit_tar}.sig" "${devkit_tar}" || exit 1
+
+      tar xpJf "${devkit_tar}" -C "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit"
+      rm "${devkit_tar}"
+      rm "${devkit_tar}.sig"
+
+      # Validate devkit.info matches value passed in and current architecture
+      local devkitInfo="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit/devkit.info"
+      if ! grep "ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" "${devkitInfo}" || ! grep "ADOPTIUM_DEVKIT_TARGET=${devkit_target}" "${devkitInfo}"; then
         echo "ERROR: Devkit does not match required release and architecture:"
         echo "       Required:   ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
         echo "       Downloaded: $(grep ADOPTIUM_DEVKIT_RELEASE= "${devkitInfo}")"
         echo "       Required:   ADOPTIUM_DEVKIT_TARGET=${devkit_target}"
         echo "       Downloaded: $(grep ADOPTIUM_DEVKIT_TARGET= "${devkitInfo}")"
         exit 1
+      fi
+
+      BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/devkit"
     fi
   fi
 }


### PR DESCRIPTION
Check and verify /usr/local/devkit for the required matching Adoptium DevKit
If not found then it will defer to downloading from devkit-runtimes
