### PR TITLE
Using proper laud countdown before cleaning of repository

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -250,6 +250,6 @@ function verboseSleep() {
   else
     local i="${1}"
   fi
-  while [ $i -gt 0 ] ; do echo -n " $i " && sleep 1 && i=$(($i-1)) ; done && echo " $i"
+  while [ "$i" -gt 0 ] ; do echo -n " $i " && sleep 1s && i=$((i-1)) ; done && echo " $i"
 }
 

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -250,6 +250,6 @@ function verboseSleep() {
   else
     local i="${1}"
   fi
-  while [ $i -gt 0 ] ; do echo -n " $i " && sleep 1s && i=$(($i-1)) ; done && echo " $i"
+  while [ $i -gt 0 ] ; do echo -n " $i " && sleep 1 && i=$(($i-1)) ; done && echo " $i"
 }
 

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -243,7 +243,7 @@ function isFromJdk21LTS() {
   [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 21 ]] && [[ $(((BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]-21) % 4)) == 0 ]]
 }
 
-# waits N second (10 by default), printing countdown every second.
+# Waits N seconds (10 by default), printing a countdown every second.
 function verboseSleep() {
   if [[ -z "${1}" ]] ; then
     local i=10

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -243,3 +243,13 @@ function isFromJdk21LTS() {
   [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 21 ]] && [[ $(((BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]-21) % 4)) == 0 ]]
 }
 
+# waits N second (10 by default), printing countdown every second.
+function verboseSleep() {
+  if [[ -z "${1}" ]] ; then
+    local i=10
+  else
+    local i="${1}"
+  fi
+  while [ $i -gt 0 ] ; do echo -n " $i " && sleep 1s && i=$(($i-1)) ; done && echo " $i"
+}
+

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -28,6 +28,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/common/constants.sh"
 
+# shellcheck source=sbin/common/common.sh
+source "$SCRIPT_DIR/common/common.sh"
+
 # Set default versions for 3 libraries that OpenJDK relies on to build
 
 ALSA_LIB_VERSION=${ALSA_LIB_VERSION:-1.1.6}
@@ -65,7 +68,7 @@ checkoutAndCloneOpenJDKGitRepo() {
     if [ "${isValidGitRepo}" == "0" ]; then
       cd "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
       echo "Resetting the git openjdk source repository at $PWD in 10 seconds..."
-      sleep 10
+      verboseSleep 10
       echo "Pulling latest changes from git openjdk source repository"
     elif [ "${BUILD_CONFIG[CLEAN_GIT_REPO]}" == "true" ]; then
       echo "Removing current git repo as it is the wrong type"
@@ -343,7 +346,7 @@ checkingAndDownloadingAlsa() {
         break
       elif [[ ${i} -lt 10 ]]; then
         echo "gpg recv-keys attempt has failed. Retrying after 10 second pause..."
-        sleep 10s
+        verboseSleep 10
       else
         echo "ERROR: gpg recv-keys final attempt has failed. Will not try again."
       fi


### PR DESCRIPTION
There is couple of
```
echo  "doing osmething terrible in Xs"
sleep X
```

here in log only the `doing osmething terrible in Xs` appear. 

I think it may be better to print out proper dynamic countdown instead of just dark screen. WDYT?

I had put it to commn.sh, but some other place may be better. Also I had used it as example only on two places in prepareWorkspace, where there definitely is more applicable places over scripts.

WDYT?