### PR TITLE
Remove 's' from sleep commands as unecessary and not universal

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -101,7 +101,7 @@ then
         then
             echo "RETRYWARNING: Query ${retryCount} failed. Retrying in 30 seconds (max retries = ${retryMax})..."
             retryCount=$((retryCount+1))
-            sleep 30s
+            sleep 30
         else
             echo "JAVA_FEATURE_VERSION FOUND: ${JAVA_FEATURE_VERSION}" && break
         fi

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -48,7 +48,7 @@ function setOpenJdkVersion() {
         then
             echo "RETRYWARNING: Query ${retryCount} failed. Retrying in 30 seconds (max retries = ${retryMax})..."
             retryCount=$((retryCount+1)) 
-            sleep 30s
+            sleep 30
         else
             echo "featureNumber FOUND: ${featureNumber}" && break
         fi

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -343,7 +343,7 @@ checkingAndDownloadingAlsa() {
         break
       elif [[ ${i} -lt 10 ]]; then
         echo "gpg recv-keys attempt has failed. Retrying after 10 second pause..."
-        sleep 10s
+        sleep 10
       else
         echo "ERROR: gpg recv-keys final attempt has failed. Will not try again."
       fi


### PR DESCRIPTION
Syntax in a few places is invalid for Solaris:
```
-bash-3.2$ sleep 5s
sleep: bad character in argument
-bash-3.2$ 
```
Identified as part of https://github.com/adoptium/temurin-build/pull/3744