### PR TITLE
No source file header for serverTimestamp.properties

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -47,3 +47,4 @@ header:
     - '.github/linters/*'
     - 'cyclonedx-lib/getDependencies'
     - 'makejdk-any-platform.1'
+    - serverTimestamp.properties

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -47,4 +47,4 @@ header:
     - '.github/linters/*'
     - 'cyclonedx-lib/getDependencies'
     - 'makejdk-any-platform.1'
-    - serverTimestamp.properties
+    - 'serverTimestamp.properties'

--- a/serverTimestamp.properties
+++ b/serverTimestamp.properties
@@ -1,16 +1,3 @@
-# ********************************************************************************
-# Copyright (c) 2021 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made
-# available under the terms of the Apache Software License 2.0
-# which is available at https://www.apache.org/licenses/LICENSE-2.0.
-#
-# SPDX-License-Identifier: Apache-2.0
-# ********************************************************************************
-
 comodaca=http://timestamp.comodoca.com/authenticode
 globalsign=http://timestamp.globalsign.com/scripts/timstamp.dll
 isectigo=http://timestamp.sectigo.com


### PR DESCRIPTION
Regression caused by https://github.com/adoptium/temurin-build/pull/3721 

Don't add source file header to the `serverTimestamp.properties`