### PR TITLE
Fix failing jdk11 macos CI checks due to Xcode 15 dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
         os: [macOS]
         version: [
           { name: jdk8u, distro: macos-11 },
-          { name: jdk11u, distro: macos-13 },
+          { name: jdk11u, distro: macos-14 },
           { name: jdk17u, distro: macos-14 }
         ]
         variant: [temurin]
@@ -185,8 +185,6 @@ jobs:
       run: |
         rm -rf /Applications/Xcode.app
         ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
-        sw_vers -productVersion
-        ls -l /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
 
     - name: Build macOS
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,7 @@ jobs:
       if: matrix.version.name != 'jdk8u'
       run: |
         rm -rf /Applications/Xcode.app
+        ls -l /Applications
         ln -s /Applications/Xcode_15.0.1.app /Applications/Xcode.app
 
     - name: Build macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,7 @@ jobs:
         rm -rf /Applications/Xcode.app
         ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
         sw_vers -productVersion
+        ls -l /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
 
     - name: Build macOS
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,8 +184,7 @@ jobs:
       if: matrix.version.name != 'jdk8u'
       run: |
         rm -rf /Applications/Xcode.app
-        ls -l /Applications
-        ln -s /Applications/Xcode_15.0.1.app /Applications/Xcode.app
+        ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
 
     - name: Build macOS
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,7 @@ jobs:
       run: |
         rm -rf /Applications/Xcode.app
         ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
+        ls -l /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
 
     - name: Build macOS
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
       run: |
         rm -rf /Applications/Xcode.app
         ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
-        ls -l /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+        sw_vers -productVersion
 
     - name: Build macOS
       run: |


### PR DESCRIPTION
- Xcode 15 prereqs at least OSX >13.5, hence jdk11+ are now built on OSX 14
- We are also building using Xcode 15.2 now, that has bug fixes
