### PR TITLE
dependency_data files do not need licenses

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -46,5 +46,6 @@ header:
     - 'sbin/*.template'
     - '.github/linters/*'
     - 'cyclonedx-lib/getDependencies'
+    - 'cyclonedx-lib/dependency_data/**'
     - 'makejdk-any-platform.1'
     - 'serverTimestamp.properties'


### PR DESCRIPTION
...on the basis that they only contain version strings, jar names, and SHAs that are obtained from external sources.