### PR TITLE
Solaris sleep does not support suffix 's'

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -62,7 +62,7 @@ function setOpenJdkVersion() {
         then
             echo "RETRYWARNING: Query ${retryCount} failed. Retrying in 30 seconds (max retries = ${retryMax})..."
             retryCount=$((retryCount+1)) 
-            sleep 30s
+            sleep 30
         else
             echo "featureNumber FOUND: ${featureNumber}" && break
         fi
@@ -264,6 +264,6 @@ function verboseSleep() {
   else
     local i="${1}"
   fi
-  while [ "$i" -gt 0 ] ; do echo -n " $i " && sleep 1s && i=$((i-1)) ; done && echo " $i"
+  while [ "$i" -gt 0 ] ; do echo -n " $i " && sleep 1 && i=$((i-1)) ; done && echo " $i"
 }
 


### PR DESCRIPTION
Fix for jdk8u Solaris build break:
```
11:02:11  Resetting the git openjdk source repository at /export/home/jenkins/workspace/build-scripts/jobs/jdk8u/jdk8u-solaris-sparcv9-temurin/workspace/build/src in 10 seconds...
11:02:11   10 sleep: bad character in argument
```

Solaris does not support the time duration suffix
