### PR TITLE
Ensure SBOM makejdk-any-platform quotes args when necessary

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -51,7 +51,17 @@ configure_build "$@"
 writeConfigToFile
 
 # Store params to this script as "buildinfo"
-echo "$@" > ./workspace/config/makejdk-any-platform.args
+# Ensure arguments containing "spaces" are quoted
+makeJdkArgs=""
+for arg in "$@"; do
+  # Quote the argument if it contains spaces
+  if [[ "${arg}" =~ .*" ".* ]]; then
+    makeJdkArgs="${makeJdkArgs} \"${arg}\""
+  else
+    makeJdkArgs="${makeJdkArgs} ${arg}"
+  fi
+done
+echo "${makeJdkArgs}" > ./workspace/config/makejdk-any-platform.args
 
 # Let's build and test the (Adoptium) OpenJDK binary in Docker or natively
 if [ "${BUILD_CONFIG[USE_DOCKER]}" == "true" ] ; then


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3834

Ensure makejdk-any-platform "quotes" when required

SBOM make args can then be correctly processed including --configure-args using:
```
# and processed by:
args=( )
IFS= args=($(xargs --max-args=1 <<< "$makejdk_any_platform_args"))
for arg in "${args[@]}"
do
   echo "$arg"
done
```

