### PR TITLE
Exit from setupAntEnv is not propagated to its only usecase

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -871,10 +871,10 @@ generateSBoM() {
     return
   fi
 
-  # exit from $(setupAntEnv) is not propagated. We have to ensure, the exit propagates, and is fatal for the script
-  # co calling it one more time, rather sooner then later, without subshell.
-  setupAntEnv
-  local javaHome="$(setupAntEnv)"
+  # exit from local var=$(setupAntEnv) is not propagated. We have to ensure, the exit propagates, and is fatal for the script
+  # So the declaration is split. In that case the bug do not occur and thus the `exit 2` from setupAntEnv is correctly propagated
+  local javaHome
+  javaHome="$(setupAntEnv)"
 
   buildCyclonedxLib "${javaHome}"
   # classpath to run java app TemurinGenSBOM

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -871,7 +871,8 @@ generateSBoM() {
     return
   fi
 
-  # exit from $(setupAntEnv) is not propagated. We have to ensure it runs, so calling it one more time
+  # exit from $(setupAntEnv) is not propagated. We have to ensure, the exit propagates, and is fatal for the script
+  # co calling it one more time, rather sooner then later, without subshell.
   setupAntEnv
   local javaHome="$(setupAntEnv)"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -872,7 +872,7 @@ generateSBoM() {
   fi
 
   # exit from local var=$(setupAntEnv) is not propagated. We have to ensure that the exit propagates, and is fatal for the script
-  # So the declaration is split. In that case the bug do not occur and thus the `exit 2` from setupAntEnv is correctly propagated
+  # So the declaration is split. In that case the bug does not occur and thus the `exit 2` from setupAntEnv is correctly propagated
   local javaHome
   javaHome="$(setupAntEnv)"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -871,7 +871,7 @@ generateSBoM() {
     return
   fi
 
-  # exit from $(setupAntEnv) is not propagated. We ahve to ensure it is fatal, co calling it one more times
+  # exit from $(setupAntEnv) is not propagated. We have to ensure it runs, so calling it one more time
   setupAntEnv
   local javaHome="$(setupAntEnv)"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -52,8 +52,6 @@ export CONFIGURE_ARGS=""
 export ADDITIONAL_MAKE_TARGETS=""
 export GIT_CLONE_ARGUMENTS=()
 
-JAVA_HOME_MISSING_ERROR="Unable to find a suitable JAVA_HOME to build the cyclonedx-lib"
-
 # Parse the CL arguments, defers to the shared function in common-functions.sh
 function parseArguments() {
   parseConfigurationArguments "$@"
@@ -820,7 +818,7 @@ setupAntEnv() {
   # fall back to use JDK_BOOT_DIR which is set in make-adopt-build-farm.sh
     javaHome="${BUILD_CONFIG[JDK_BOOT_DIR]}"
   else
-    echo "$JAVA_HOME_MISSING_ERROR"
+    echo "Unable to find a suitable JAVA_HOME to build the cyclonedx-lib"
     exit 2
   fi
 
@@ -829,16 +827,6 @@ setupAntEnv() {
   fi
 
   echo "${javaHome}"
-}
-
-# if setupAntEnv is called in substitution subshel (eg.: `` ort $()), its exit
-# is not propagated so all consumers of it must check one more times
-checkJavaHome() {
-  local javaHome="${1}"
-  if [ ! -e "${javaHome}" ] ; then
-    echo "${JAVA_HOME_MISSING_ERROR}: $javaHome"
-    exit 2
-  fi
 }
 
 # Build the CycloneDX Java library and app used for SBoM generation
@@ -884,7 +872,6 @@ generateSBoM() {
   fi
 
   local javaHome="$(setupAntEnv)"
-  checkJavaHome "${javaHome}"
 
   buildCyclonedxLib "${javaHome}"
   # classpath to run java app TemurinGenSBOM

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -871,7 +871,7 @@ generateSBoM() {
     return
   fi
 
-  # exit from local var=$(setupAntEnv) is not propagated. We have to ensure, the exit propagates, and is fatal for the script
+  # exit from local var=$(setupAntEnv) is not propagated. We have to ensure that the exit propagates, and is fatal for the script
   # So the declaration is split. In that case the bug do not occur and thus the `exit 2` from setupAntEnv is correctly propagated
   local javaHome
   javaHome="$(setupAntEnv)"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -871,6 +871,8 @@ generateSBoM() {
     return
   fi
 
+  # exit from $(setupAntEnv) is not propagated. We ahve to ensure it is fatal, co calling it one more times
+  setupAntEnv
   local javaHome="$(setupAntEnv)"
 
   buildCyclonedxLib "${javaHome}"


### PR DESCRIPTION
I had hit this when I forget to run all the build chain with JAVA_HOME set.  It died, but without any trace. This PR is adding the trace of what went wrong.