### PR TITLE
Added support for zipped sources

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -78,7 +78,7 @@ unpackFromArchive() {
         echo "Source zip unpacked as if it contains exactly one directory"
         unzipGnuAbsPathWithStripComponents1 "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"
     else
-      local topLevelItems=$(tar --exclude='*/*' -tf  "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"  | grep "/$" -c) || local topLevelItems=1
+      local topLevelItems=$(tar --exclude='*/*' -tf  "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}" | grep "/$" -c) || local topLevelItems=1
       if [ "$topLevelItems" -eq "1" ] ; then
         echo "Source tarball contains exactly one directory"
         untarGnuAbsPathWithStripComponents1 "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -75,7 +75,7 @@ unpackFromArchive() {
   # If the tarball contains .git files, they should be ignored later
   pushd "./${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}"
     if [ "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]: -4}" == ".zip" ] ; then
-        echo "Source zip unpacked as if ti contains exactly one directory"
+        echo "Source zip unpacked as if it contains exactly one directory"
         unzipGnuAbsPathWithStripComponents1 "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"
     else
       local topLevelItems=$(tar --exclude='*/*' -tf  "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"  | grep "/$" -c) || local topLevelItems=1

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -51,7 +51,8 @@ copyFromDir() {
 # this is workarounding --strip-components 1 missing on gnu tar
 # it requires  absolute tar-filepath as it changes dir and is hardcoded to one
 # similar approach can be used also for zip in future
-unpackGnuAbsPathWithStripComponents1() {
+# warning! this method do not merge if (parts of!) destination exists.
+unpackGnuAbsPathWithStrip1Component() {
   local tmp=$(mktemp -d)
   pushd "$tmp" > /dev/null
     "$@"
@@ -62,12 +63,12 @@ unpackGnuAbsPathWithStripComponents1() {
   rmdir "$tmp"
 }
 
-untarGnuAbsPathWithStripComponents1() {
-  unpackGnuAbsPathWithStripComponents1 tar -xf "$@"
+untarGnuAbsPathWithStrip1Component() {
+  unpackGnuAbsPathWithStrip1Component tar -xf "$@"
 }
 
-unzipGnuAbsPathWithStripComponents1() {
-  unpackGnuAbsPathWithStripComponents1 unzip "$@"
+unzipGnuAbsPathWithStrip1Component() {
+  unpackGnuAbsPathWithStrip1Component unzip "$@"
 }
 
 unpackFromArchive() {
@@ -76,12 +77,12 @@ unpackFromArchive() {
   pushd "./${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}"
     if [ "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]: -4}" == ".zip" ] ; then
         echo "Source zip unpacked as if it contains exactly one directory"
-        unzipGnuAbsPathWithStripComponents1 "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"
+        unzipGnuAbsPathWithStrip1Component "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"
     else
       local topLevelItems=$(tar --exclude='*/*' -tf  "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}" | grep "/$" -c) || local topLevelItems=1
       if [ "$topLevelItems" -eq "1" ] ; then
         echo "Source tarball contains exactly one directory"
-        untarGnuAbsPathWithStripComponents1 "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"
+        untarGnuAbsPathWithStrip1Component "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"
       else
         echo "Source tarball does not contain a top level directory"
         tar -xf "${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]}"


### PR DESCRIPTION
Sources tarballs and binaries are available both in zip, tar.gz and tar.xz.  "my" `-l/--openjdk-source-location` was counting only tarballs and was unpacking them with `tar -xf` with workaround around `--strip-components 1`. Now, if the file ends with `.zip` it is unpacked by `unzip` with same workaround for `--strip-components 1` as tar.