### PR TITLE
Enable reproducible comparing tests on jdk21+ macos

### DIFF
--- a/test/system/reproducibleCompare/playlist.xml
+++ b/test/system/reproducibleCompare/playlist.xml
@@ -79,6 +79,6 @@
 		<versions>
 			<version>21+</version>
 		</versions>
-		<platformRequirements>os.osx,arch.aarch64</platformRequirements>
+		<platformRequirements>os.osx</platformRequirements>
 	</test>
 </playlist>


### PR DESCRIPTION
Depends https://github.com/adoptium/ci-jenkins-pipelines/pull/1136

https://github.com/adoptium/temurin-build/pull/4026