### PR TITLE
Update CUDA_VERSION to 9.1

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -136,7 +136,7 @@ then
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
     fi
 
-    CUDA_VERSION=9.0
+    CUDA_VERSION=9.1
     CUDA_HOME_FULL="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v$CUDA_VERSION"
     # use cygpath to map to 'short' names (without spaces)
     CUDA_HOME=$(cygpath -ms "$CUDA_HOME_FULL")


### PR DESCRIPTION
The cuda path (C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.0) to v9.1 in Adoptium playbook.
Therefore update the CUDA_VERSION variable.
reference link: https://github.com/adoptium/infrastructure/pull/3587