### PR TITLE
Update build-scripts to enable hotspot & temurin jdk(head) version branch builds

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -235,7 +235,7 @@ getOpenjdkGithubRepoName() {
   else
     local featureNumber=$(echo "${forest_name}" | tr -d "[:alpha:]")
 
-    # jdk-23+ stabilisation versions are with the jdk(head) repository
+    # jdk-23+ stabilisation versions are within the jdk(head) repository
     if [[ "${featureNumber}" -ge 23 ]]; then
       repoName="jdk"
     else

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC2155
 # ********************************************************************************
 # Copyright (c) 2018 Contributors to the Eclipse Foundation
 #

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -236,7 +236,7 @@ getOpenjdkGithubRepoName() {
     local featureNumber=$(echo "${forest_name}" | tr -d "[:alpha:]")
 
     # jdk-23+ stabilisation versions are with the jdk(head) repository
-    if [[ "${featureNumber]}" -ge 23 ]]; then
+    if [[ "${featureNumber}" -ge 23 ]]; then
       repoName="jdk"
     else
       repoName="${forest_name}"

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -170,6 +170,7 @@ setVariablesForConfigure() {
 setRepository() {
 
   local suffix
+  local githubRepoName=$(getOpenjdkGithubRepoName "${BUILD_CONFIG[OPENJDK_FOREST_NAME]}")
 
   # Location of Extensions for OpenJ9 project
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]]; then
@@ -200,12 +201,12 @@ setRepository() {
       || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_CORE_VERSION}" ]; then
       suffix="openjdk/riscv-port-${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
     else
-      suffix="openjdk/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
+      suffix="openjdk/${githubRepoName}"
     fi
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]]; then
-    suffix="adoptium/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
+    suffix="adoptium/${githubRepoName}"
   else
-    suffix="openjdk/${BUILD_CONFIG[OPENJDK_FOREST_NAME]}"
+    suffix="openjdk/${githubRepoName}"
   fi
 
   local repository
@@ -219,6 +220,30 @@ setRepository() {
   repository="$(echo "${repository}" | awk '{print tolower($0)}')"
 
   BUILD_CONFIG[REPOSITORY]="${BUILD_CONFIG[REPOSITORY]:-${repository}}"
+
+  echo "Using source repository ${BUILD_CONFIG[REPOSITORY]}"
+}
+
+# Given a forest_name (eg.jdk23), return the corresponding repository name
+getOpenjdkGithubRepoName() {
+  local forest_name="$1"
+  local repoName=""
+
+  # "Update" versions are currently in a repository with the name of the forest
+  if [[ ${forest_name} == *u ]]; then
+    repoName="${forest_name}"
+  else
+    local featureNumber=$(echo "${forest_name}" | tr -d "[:alpha:]")
+
+    # jdk-23+ stabilisation versions are with the jdk(head) repository
+    if [[ "${featureNumber]}" -ge 23 ]]; then
+      repoName="jdk"
+    else
+      repoName="${forest_name}"
+    fi
+  fi
+
+  echo "${repoName}"
 }
 
 # Specific architectures need to have special build settings

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -102,7 +102,7 @@ function setBranch() {
   local branch="master"
   local adoptium_mirror_branch="dev"
 
-  # non-u (and non-tip) jdk-23+ hotspot and adoptium version source is within a "version" branch
+  # non-u (and non-tip) jdk-23+ hotspot and adoptium version source is within a "version" branch in the "jdk" repository
   if [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != *u ]] && [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != "jdk" ]] && [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 23 ]]; then
     branch="jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
     adoptium_mirror_branch="dev_jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -102,8 +102,8 @@ function setBranch() {
   local branch="master"
   local adoptium_mirror_branch="dev"
 
-  # non-u jdk-23+ hotspot and adoptium version source is within a "version" branch
-  if [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != *u ]] && [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 23 ]]; then
+  # non-u (and non-tip) jdk-23+ hotspot and adoptium version source is within a "version" branch
+  if [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != *u ]] && [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != "jdk" ]] && [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 23 ]]; then
     branch="jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
     adoptium_mirror_branch="dev_jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
   fi

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -16,8 +16,12 @@
 # shellcheck disable=SC2153
 function setOpenJdkVersion() {
   # forest_name represents the JDK version with "u" suffix for an "update version"
-  # It no longer relates directly to the openjdk repository name
-  # jdkNN[u]
+  #
+  # It no longer relates directly to the openjdk repository name, as the jdk(head) repository
+  # now has version branches for jdk-23+
+  #
+  # Format: jdkNN[u]
+  #
   local forest_name=$1
 
   echo "Setting version based on forest_name=${forest_name}"

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -102,13 +102,10 @@ function setBranch() {
   local branch="master"
   local adoptium_mirror_branch="dev"
 
-  # Forest and feature number maybe not set yet if provided via command line argument
-  if [[ -n "${BUILD_CONFIG[OPENJDK_FOREST_NAME]}" ]] && [[ -n "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" ]]; then
-    # non-u jdk-23+ hotspot and adoptium is within a "version" branch
-    if [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != *u ]] && [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 23 ]]; then
-      branch="jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
-      adoptium_mirror_branch="dev_jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
-    fi
+  # non-u jdk-23+ hotspot and adoptium version source is within a "version" branch
+  if [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != *u ]] && [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 23 ]]; then
+    branch="jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
+    adoptium_mirror_branch="dev_jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
   fi
 
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]; then

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -20,6 +20,8 @@ function setOpenJdkVersion() {
   # jdkNN[u]
   local forest_name=$1
 
+  echo "Setting version based on forest_name=${forest_name}"
+
   # The argument passed here have actually very strict format of jdk8, jdk8u..., jdk
   # the build may fail later if this is not honoured.
   # If your repository has a different name, you can use --version or build from dir/snapshot
@@ -97,9 +99,9 @@ function setBranch() {
   local adoptium_mirror_branch="dev"
 
   # Forest and feature number maybe not set yet if provided via command line argument
-  if [[ -n "${BUILD_CONFIG[OPENJDK_FOREST_NAME]}" ]] && [[ -n "$BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]" ]]; then
+  if [[ -n "${BUILD_CONFIG[OPENJDK_FOREST_NAME]}" ]] && [[ -n "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" ]]; then
     # non-u jdk-23+ hotspot and adoptium is within a "version" branch
-    if [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != *u ]] && [[ "$BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]" -ge 23 ]]; then
+    if [[ ${BUILD_CONFIG[OPENJDK_FOREST_NAME]} != *u ]] && [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 23 ]]; then
       branch="jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
       adoptium_mirror_branch="dev_jdk${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
     fi

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -397,31 +397,6 @@ function parseConfigurationArguments() {
     setBranch
 }
 
-function setBranch() {
-
-  # Which repo branch to build, e.g. dev by default for temurin, "openj9" for openj9
-  local branch="master"
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]; then
-    branch="dev"
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]; then
-    branch="openj9";
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_DRAGONWELL}" ]; then
-    branch="master";
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_FAST_STARTUP}" ]; then
-    branch="master";
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
-    branch="develop";
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
-    if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] ; then
-      branch="risc-v"
-    else
-      branch="master"
-    fi
-  fi
-
-  BUILD_CONFIG[BRANCH]=${BUILD_CONFIG[BRANCH]:-$branch}
-}
-
 # Set the local dir if used
 function setOpenjdkSourceDir() {
   if [ ! -e "${1}" ] ; then

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -393,8 +393,6 @@ function parseConfigurationArguments() {
         *) echo >&2 "Invalid build.sh option: ${opt}"; exit 1;;
       esac
     done
-
-    setBranch
 }
 
 # Set the local dir if used


### PR DESCRIPTION
Fixes: https://github.com/adoptium/temurin-build/issues/3841

Provides support for building jdk-23+ for hotspot and temurin, from the jdk(head) version branches.

"hotspot" build tests:
- "jdk" (ie."tip" jdk-24) : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk/job/jdk-linux-x64-hotspot/658
- "jdk23" : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk/job/jdk-linux-x64-hotspot/657


