### PR TITLE
build.sh: Add time stamp for start of SBoM generation

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -875,6 +875,7 @@ generateSBoM() {
   local javaHome
   javaHome="$(setupAntEnv)"
 
+  echo "build.sh : $(date +%T) : Generating SBoM ..."
   buildCyclonedxLib "${javaHome}"
   # classpath to run java app TemurinGenSBOM
   local classpath="$(getCyclonedxClasspath)"


### PR DESCRIPTION
This add another entry to the timestamps added in https://github.com/adoptium/temurin-build/pull/2417 to make it easier to keep an eye on stage times during the build