### PR TITLE
Comparable builds need to patch SystemModule due to Vendor string differences

### DIFF
--- a/tooling/reproducible/comparable_patch.sh
+++ b/tooling/reproducible/comparable_patch.sh
@@ -414,10 +414,8 @@ if [[ "$OS" =~ CYGWIN* ]] && [[ "$PATCH_VS_VERSION_INFO" = true ]]; then
   neutraliseVsVersionInfo
 fi
 
-if [[ "$OS" =~ CYGWIN* ]] || [[ "$OS" =~ Darwin* ]]; then
-  # SystemModules$*.class's differ due to hash differences from Windows COMPANY_NAME and Signatures
-  removeSystemModulesHashBuilderParams
-fi
+# Remove SystemModule "hashes" caused by "Vendor String" and Windows/Mac Signature differences
+removeSystemModulesHashBuilderParams
 
 if [[ "$OS" =~ CYGWIN* ]]; then
   removeWindowsNonComparableData

--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -78,7 +78,10 @@ function expandJDK() {
   rm -rf "${JDK_ROOT}_CP"
 }
 
-# Process SystemModules classes to remove ModuleHashes$Builder differences due to Signatures
+# Process SystemModules classes to remove ModuleHashes$Builder differences
+# due to "hash" differences caused by:
+# - Windows&Mac Signatures for "Reproducible Builds"
+# - "Vendor String" differences for "Comparable Builds"
 #   1. javap
 #   2. search for line: // Method jdk/internal/module/ModuleHashes$Builder.hashForModule:(Ljava/lang/String;[B)Ljdk/internal/module/ModuleHashes$Builder;
 #   3. followed 3 lines later by: // String <module>


### PR DESCRIPTION
"Comparable Builds" patch script needs to patch SystemModules "hashes" for Linux as well, as hashes will differ due to the Vendor String causing hashes to differ.
