### PR TITLE
macos-11 github runner no longer available, remove jdk8u mac github action build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       matrix:
         os: [macOS]
         version: [
-          { name: jdk8u, distro: macos-11 },
+          { name: jdk8u, distro: macos-14 },
           { name: jdk11u, distro: macos-14 },
           { name: jdk17u, distro: macos-14 }
         ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,6 @@ jobs:
       matrix:
         os: [macOS]
         version: [
-          { name: jdk8u, distro: macos-14 },
           { name: jdk11u, distro: macos-14 },
           { name: jdk17u, distro: macos-14 }
         ]
@@ -165,26 +164,10 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        brew install automake bash binutils freetype gnu-sed nasm libtool harfbuzz
-
-    - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
-      id: setup-java
-      with:
-        java-version: 8
-        distribution: 'zulu'
-      if: matrix.version.name == 'jdk8u'
-
-    - name: Select correct Xcode (JDK8)
-      if: matrix.version.name == 'jdk8u'
-      run: |
-        rm -rf /Applications/Xcode.app
-        ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
-        # macos-14 runner does not have 11.7, use 15.2 instead when building on arm64 machine
-        rm -rf /Applications/Xcode-11.7.app
-        ln -s /Applications/Xcode_15.2.app /Applications/Xcode-11.7.app
+        brew install automake bash binutils freetype gnu-sed nasm
+        brew remove harfbuzz
 
     - name: Select correct Xcode (JDK11+)
-      if: matrix.version.name != 'jdk8u'
       run: |
         rm -rf /Applications/Xcode.app
         ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
@@ -193,22 +176,16 @@ jobs:
       run: |
         export JAVA_HOME=$JAVA_HOME_11_X64
         # jdk11u+ uses two part exploded & assemble build
-        if [ ${{ matrix.version.name }} != "jdk8u" ]; then
-          export BUILD_ARGS="--make-exploded-image --create-sbom"
-          ./build-farm/make-adopt-build-farm.sh
-          export BUILD_ARGS="--assemble-exploded-image --create-sbom"
-          ./build-farm/make-adopt-build-farm.sh
-        else
-          export BUILD_ARGS="--create-sbom"
-          ./build-farm/make-adopt-build-farm.sh
-        fi
+        export BUILD_ARGS="--make-exploded-image --create-sbom"
+        ./build-farm/make-adopt-build-farm.sh
+        export BUILD_ARGS="--assemble-exploded-image --create-sbom"
+        ./build-farm/make-adopt-build-farm.sh
       env:
         JAVA_TO_BUILD: ${{ matrix.version.name }}
         ARCHITECTURE: x64
         VARIANT: ${{ matrix.variant }}
         TARGET_OS: mac
         FILENAME: OpenJDK.tar.gz
-        JDK7_BOOT_DIR: ${{ steps.setup-java.outputs.path }}
 
     - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       name: Collect and Archive Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        brew install automake bash binutils freetype gnu-sed nasm libtool
+        brew install automake bash binutils freetype gnu-sed nasm libtool harfbuzz
 
     - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       id: setup-java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,10 @@ jobs:
       if: matrix.version.name == 'jdk8u'
       run: |
         rm -rf /Applications/Xcode.app
-        ln -s /Applications/Xcode_11.7.app /Applications/Xcode.app
+        ln -s /Applications/Xcode_15.2.app /Applications/Xcode.app
+        # macos-14 runner does not have 11.7, use 15.2 instead when building on arm64 machine
+        rm -rf /Applications/Xcode-11.7.app
+        ln -s /Applications/Xcode_15.2.app /Applications/Xcode-11.7.app
 
     - name: Select correct Xcode (JDK11+)
       if: matrix.version.name != 'jdk8u'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,6 @@ jobs:
     - name: Install Dependencies
       run: |
         brew install automake bash binutils freetype gnu-sed nasm
-        brew remove harfbuzz
 
     - name: Select correct Xcode (JDK11+)
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
     - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       id: setup-java
       with:
-        java-version: 7
+        java-version: 8
         distribution: 'zulu'
       if: matrix.version.name == 'jdk8u'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        brew install automake bash binutils freetype gnu-sed nasm
+        brew install automake bash binutils freetype gnu-sed nasm libtool
 
     - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       id: setup-java


### PR DESCRIPTION
github retired their macos-11 support: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

The current github macos runners do not install Xcode-11.7 required to build jdk8u, without trying to download and install Xcode-11.7, it's going to be hard to build jdk8u mac.
Removing seems the easiest option at the moment.

