### PR TITLE
Fixes, improvements, and jdk versions update for build triage script

### DIFF
--- a/.github/workflows/build-autotriage.yml
+++ b/.github/workflows/build-autotriage.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: "Run Build Auto Triage"
-        run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk22 jdk23head
+        run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk23 jdk24head
 
       - name: Create Issue From File
         env:


### PR DESCRIPTION
Includes:
- Removing jdk22
- Adding jdk23 (replacing jdk23head) and jdk24head
- Splits build and test failures into seperate sections
- Displays a short list of trss grid views for triaged pipelines
- Various bug fixes and improvements