### PR TITLE
Use VS 2022 by default for all JDK versions + skip freetype patching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
        fail-fast: false
        matrix:
          os: [windows-2022]
-         version: [jdk8u, jdk11u, jdk17u, jdk]
+         version: [jdk11u, jdk17u, jdk]
          variant: [temurin]
 
      env:

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -113,21 +113,17 @@ then
       export INCLUDE="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;$INCLUDE"
       export PATH="$PATH:/c/cygwin64/bin"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
-      TOOLCHAIN_VERSION="2017"
     elif [ "${JAVA_TO_BUILD}" == "${JDK9_VERSION}" ]
     then
-      TOOLCHAIN_VERSION="2013"
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
     elif [ "${JAVA_TO_BUILD}" == "${JDK10_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
     elif [ "$JAVA_FEATURE_VERSION" -lt 19 ]
     then
-      TOOLCHAIN_VERSION="2019"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
     elif [ "$JAVA_FEATURE_VERSION" -ge 19 ]
     then
-      TOOLCHAIN_VERSION="2022"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
     fi
 

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -24,7 +24,7 @@ export ALLOW_DOWNLOADS=true
 export LANG=C
 export OPENJ9_NASM_VERSION=2.13.03
 
-TOOLCHAIN_VERSION=""
+TOOLCHAIN_VERSION="2022"
 
 if [ "$ARCHITECTURE" == "aarch64" ]; then
   # Windows aarch64 cross compiles requires same version boot jdk
@@ -72,7 +72,6 @@ then
       # https://github.com/adoptium/temurin-build/issues/243
       export INCLUDE="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;$INCLUDE"
       export PATH="/c/cygwin64/bin:/usr/bin:$PATH"
-      TOOLCHAIN_VERSION="2017"
     elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
     then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar"
@@ -86,20 +85,16 @@ then
   else
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
-      TOOLCHAIN_VERSION="2013"
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
     elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
     then 
-      export TOOLCHAIN_VERSION="2017"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     elif [ "$JAVA_FEATURE_VERSION" -gt 11 ] && [ "$JAVA_FEATURE_VERSION" -lt 21 ]
     then
-      TOOLCHAIN_VERSION="2019"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     elif [ "$JAVA_FEATURE_VERSION" -ge 21 ]
     then
-      TOOLCHAIN_VERSION="2022"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     fi
   fi
@@ -159,18 +154,11 @@ then
     # NASM required for OpenSSL support as per #604
     export PATH="/cygdrive/c/Program Files/LLVM/bin:/usr/bin:/cygdrive/c/openjdk/nasm-$OPENJ9_NASM_VERSION:$PATH"
   else
-    TOOLCHAIN_VERSION="2017"
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 39ce3ac499d4cd7371031a062f410953c8ecce29" # 2.8.1
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
-    elif [ "$JAVA_FEATURE_VERSION" -ge 11 ] && [ "$JAVA_FEATURE_VERSION" -lt 21 ]
-    then
-      TOOLCHAIN_VERSION="2019"
-    elif [ "$JAVA_FEATURE_VERSION" -ge 21 ]
-    then
-      TOOLCHAIN_VERSION="2022"
     fi
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2421,7 +2421,10 @@ configureWorkspace
 echo "build.sh : $(date +%T) : Initiating build ..."
 getOpenJDKUpdateAndBuildVersion
 if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-  patchFreetypeWindows
+  # Not required for VS2022 and later which we are defaulting to
+  if [[ "${CONFIGURE_ARGS}" =~ "--with-toolchain-version=201" ]]; then
+    patchFreetypeWindows
+  fi
 fi
 configureCommandParameters
 buildTemplatedFile


### PR DESCRIPTION
Updating to use VS2022 for all Temurin builds. This change has been approved by the PMC today, but if it causes any unexpected issues it can be reverted.

freetype patching can (and should be, otherwise it tries to reference things that don't exist) be skipped when we're not building JDK8 with VS2017 otherwise [it tries to reference a file that isn't where it's expecting](https://github.com/adoptium/temurin-build/issues/2922#issuecomment-2273611105).

I'm currently testing with this branch on a machine which only has the VS2022 build tools installed and will report back once it's complete, but it's got to the middle of the build with jdk8u so I'm confident no other issues will show up, and standalone testing before creating this PR looked good.

Alternate solutions:
- I was tempted to just comment out the individual `TOOLCHAIN_VERSION` overrides instead of deleting them for now so that we knew where they all were.
- We could change all of the other versions explicitly to 2022 instead of providing a default at the start but this feels a lot cleaner given that we really do have a "standard" version that we're changing to.

This should leave OpenJ9 unaffected, but I'll tag in @AdamBrousseau too (LMK if you want this to apply to OpenJ9 as well)

Closes https://github.com/adoptium/temurin-build/issues/2922 