### PR TITLE
Use VS 2022 by default for all JDK versions + skip freetype patching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,6 +323,18 @@ jobs:
                  --add Microsoft.VisualStudio.Workload.NativeDesktop
                  --includeRecommended --includeOptional --quiet --norestart'
 
+     - name: DEBUG
+       shell: bash
+       run: ls -l '/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022'
+
+     - name: DEBUG2
+       shell: bash
+       run: ls -l '/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools'
+
+     - name: DEBUG3
+       shell: bash
+       run: ls -l '/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/../../BuildTools/vc/auxiliary/build/vcvarsx86_amd64.bat'
+
      - name: Install Git
        run: |
          Invoke-WebRequest 'https://github.com/git-for-windows/git/releases/download/v2.14.3.windows.1/Git-2.14.3-64-bit.exe' -OutFile 'C:\temp\git.exe'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -319,7 +319,8 @@ jobs:
      - name: Install Visual Studio 2022
        run: >
          Start-Process -FilePath "$HOME\vs2022.exe" -Wait -NoNewWindow -ArgumentList
-         '--wait --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+         '--wait --productId Microsoft.VisualStudio.Product.BuildTools --channelId VisualStudio.17.Release
+                 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
                  --add Microsoft.VisualStudio.Workload.NativeDesktop
                  --includeRecommended --includeOptional --quiet --norestart'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,6 +322,9 @@ jobs:
          '--wait --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
                  --add Microsoft.VisualStudio.Workload.NativeDesktop
                  --includeRecommended --includeOptional --quiet --norestart'
+     - name: DEBUG
+       run: >
+         ls -l $(cygpath "c:\Program Files (x86)\Microsoft Visual Studio\2022")
 
      - name: Install Git
        run: |
@@ -371,7 +374,7 @@ jobs:
          TARGET_OS: windows
          FILENAME: OpenJDK.zip
          BUILD_ARGS: --create-sbom
-         CONFIGURE_ARGS: --with-tools-dir='C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
+         CONFIGURE_ARGS: --with-tools-dir=$(cygpath "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools")
 
      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
        name: Collect and Archive Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,10 +322,6 @@ jobs:
          '--wait --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
                  --add Microsoft.VisualStudio.Workload.NativeDesktop
                  --includeRecommended --includeOptional --quiet --norestart'
-     - name: DEBUG
-       shell: bash
-       run: >
-         ls -l "$(cygpath "c:\Program Files (x86)\Microsoft Visual Studio\2022")"
 
      - name: Install Git
        run: |
@@ -375,7 +371,7 @@ jobs:
          TARGET_OS: windows
          FILENAME: OpenJDK.zip
          BUILD_ARGS: --create-sbom
-         CONFIGURE_ARGS: aaaaaa--with-tools-dir='/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools'
+         CONFIGURE_ARGS: --with-tools-dir='/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools'
 
      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
        name: Collect and Archive Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -325,7 +325,7 @@ jobs:
      - name: DEBUG
        shell: bash
        run: >
-         ls -l $(cygpath "c:\Program Files (x86)\Microsoft Visual Studio\2022")
+         ls -l "$(cygpath "c:\Program Files (x86)\Microsoft Visual Studio\2022")"
 
      - name: Install Git
        run: |
@@ -375,7 +375,7 @@ jobs:
          TARGET_OS: windows
          FILENAME: OpenJDK.zip
          BUILD_ARGS: --create-sbom
-         CONFIGURE_ARGS: --with-tools-dir=$(cygpath "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools")
+         CONFIGURE_ARGS: aaaaaa--with-tools-dir='/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools'
 
      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
        name: Collect and Archive Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,6 +323,7 @@ jobs:
                  --add Microsoft.VisualStudio.Workload.NativeDesktop
                  --includeRecommended --includeOptional --quiet --norestart'
      - name: DEBUG
+       shell: bash
        run: >
          ls -l $(cygpath "c:\Program Files (x86)\Microsoft Visual Studio\2022")
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,7 +295,7 @@ jobs:
 
      - name: Uninstall OS image VS2022
        run: >
-         Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -NoNewWindow -ArgumentList
+         Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
          'uninstall --quiet --wait --norestart'
 
      - name: Download Visual Studio 2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
          TARGET_OS: windows
          FILENAME: OpenJDK.zip
          BUILD_ARGS: --create-sbom
-         CONFIGURE_ARGS: --with-tools-dir='/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools'
+         CONFIGURE_ARGS: --with-tools-dir='/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build'
 
      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
        name: Collect and Archive Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,6 +293,11 @@ jobs:
          --remove Microsoft.VisualStudio.Component.Windows10SDK.22621
          --quiet'
 
+     - name: Uninstall OS image VS2022
+       run: >
+         Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -Wait -NoNewWindow -ArgumentList
+         'uninstall --quiet --wait --norestart'
+
      - name: Download Visual Studio 2022
        run: |
          curl -L "$env:VS2022_URL" -o "$HOME/vs2022.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,10 +293,10 @@ jobs:
          --remove Microsoft.VisualStudio.Component.Windows10SDK.22621
          --quiet'
 
-     - name: Uninstall OS image VS2022
+     - name: Uninstall github runner OS image VS2022 Enterprise
        run: >
          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
-         'uninstall --quiet --norestart --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise"'
+         'uninstall --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release'
 
      - name: Download Visual Studio 2022
        run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,8 +229,7 @@ jobs:
          variant: [temurin]
 
      env:
-      VS2017_URL: "https://download.visualstudio.microsoft.com/download/pr/c5c75dfa-1b29-4419-80f8-bd39aed6bcd9/7ed8fa27575648163e07548ff5667b55b95663a2323e2b2a5f87b16284e481e6/vs_Community.exe"
-      VS2019_URL: "https://download.visualstudio.microsoft.com/download/pr/6b655578-de8c-4862-ad77-65044ca714cf/f29399a618bd3a8d1dcc96d349453f686b6176590d904308402a6402543e310b/vs_Community.exe"
+      VS2022_URL: "https://download.visualstudio.microsoft.com/download/pr/1d66edfe-3c83-476b-bf05-e8901c62ba7f/bac71effb5a23d7cd1a81e5f628a0c8dcb7e8a07e0aa7077c853ed84a862dceb/vs_BuildTools.exe"
 
      steps:
      - name: Restore cygwin packages from cache
@@ -276,24 +275,14 @@ jobs:
          distribution: 'temurin'
          java-version: 11
 
-     - name: Restore Visual Studio 2017 from cache
-       id: vs2017
-       if: matrix.version == 'jdk8u'
+     - name: Restore Visual Studio 2022 from cache
+       id: vs2022
        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
        with:
-         path: ~/vs2017.exe
-         key: vs2017
-
-     - name: Restore Visual Studio 2019 from cache
-       id: vs2019
-       if: matrix.version == 'jdk11u' || matrix.version == 'jdk17u'
-       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-       with:
-         path: ~/vs2019.exe
-         key: vs2019
+         path: ~/vs2022.exe
+         key: vs2022
 
      - name: Uninstall WinSDKs
-       if: matrix.version == 'jdk8u' || matrix.version == 'jdk11u' || matrix.version == 'jdk17u'
        run: >
          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
          'modify --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise"
@@ -304,61 +293,30 @@ jobs:
          --remove Microsoft.VisualStudio.Component.Windows10SDK.22621
          --quiet'
 
-     - name: Download Visual Studio 2017
+     - name: Download Visual Studio 2022
        run: |
-         curl -L "$env:VS2017_URL" -o "$HOME/vs2017.exe"
-       if: steps.vs2017.outputs.cache-hit != 'true' && matrix.version == 'jdk8u'
+         curl -L "$env:VS2022_URL" -o "$HOME/vs2022.exe"
+       if: steps.vs2022.outputs.cache-hit != 'true'
 
-     - name: Verify Download Of Visual Studio 2017
+     - name: Verify Download Of Visual Studio 2022
        shell: powershell
        run: |
-         $expected_checksum="7ED8FA27575648163E07548FF5667B55B95663A2323E2B2A5F87B16284E481E6"
-         $actual_checksum=(Get-FileHash -Algorithm SHA256 -Path $HOME/vs2017.exe | Select-Object -ExpandProperty Hash)
+         $expected_checksum="bac71effb5a23d7cd1a81e5f628a0c8dcb7e8a07e0aa7077c853ed84a862dceb"
+         $actual_checksum=(Get-FileHash -Algorithm SHA256 -Path $HOME/vs2022.exe | Select-Object -ExpandProperty Hash)
          echo "Expect : $expected_checksum"
          echo "Actual : $actual_checksum"
          if ($expected_checksum -ne $actual_checksum) {
            Write-Output "Error - Checksum Verification Failed - Exiting"
            exit 1
          }
-       if: steps.vs2017.outputs.cache-hit != 'true' && matrix.version == 'jdk8u'
+       if: steps.vs2022.outputs.cache-hit != 'true'
 
-     - name: Install Visual Studio 2017
-       if: matrix.version == 'jdk8u'
+     - name: Install Visual Studio 2022
        run: >
-         Start-Process -FilePath "$HOME\vs2017.exe" -Wait -NoNewWindow -ArgumentList
-         'install --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.15.Release
-         --add Microsoft.VisualStudio.Workload.NativeDesktop
-         --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
-         --add Microsoft.VisualStudio.Component.Windows10SDK.17763
-         --quiet --wait'
-
-     - name: Download Visual Studio 2019
-       run: |
-         curl -L "$env:VS2019_URL" -o "$HOME/vs2019.exe"
-       if: steps.vs2019.outputs.cache-hit != 'true' && (matrix.version == 'jdk11u' || matrix.version == 'jdk17u')
-
-     - name: Verify Download Of Visual Studio 2019
-       shell: powershell
-       run: |
-         $expected_checksum="F29399A618BD3A8D1DCC96D349453F686B6176590D904308402A6402543E310B"
-         $actual_checksum=(Get-FileHash -Algorithm SHA256 -Path $HOME/vs2019.exe | Select-Object -ExpandProperty Hash)
-         echo "Expect : $expected_checksum"
-         echo "Actual : $actual_checksum"
-         if ($expected_checksum -ne $actual_checksum) {
-           Write-Output "Error - Checksum Verification Failed - Exiting"
-           exit 1
-         }
-       if: steps.vs2019.outputs.cache-hit != 'true' && (matrix.version == 'jdk11u' || matrix.version == 'jdk17u')
-
-     - name: Install Visual Studio 2019
-       if: matrix.version == 'jdk11u' || matrix.version == 'jdk17u'
-       run: >
-         Start-Process -FilePath "$HOME\vs2019.exe" -Wait -NoNewWindow -ArgumentList
-         'install --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.15.Release
-         --add Microsoft.VisualStudio.Workload.NativeDesktop
-         --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
-         --add Microsoft.VisualStudio.Component.Windows10SDK.22000
-         --quiet --wait'
+         Start-Process -FilePath "$HOME\vs2022.exe" -Wait -NoNewWindow -ArgumentList
+         '--wait --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+                 --add Microsoft.VisualStudio.Workload.NativeDesktop
+                 --includeRecommended --includeOptional --quiet --norestart'
 
      - name: Install Git
        run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
      - name: Uninstall OS image VS2022
        run: >
          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
-         'uninstall --quiet --wait --norestart'
+         'uninstall --quiet --norestart'
 
      - name: Download Visual Studio 2022
        run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
      - name: Uninstall OS image VS2022
        run: >
          Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
-         'uninstall --quiet --norestart'
+         'uninstall --quiet --norestart --installPath "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise"'
 
      - name: Download Visual Studio 2022
        run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,10 +293,10 @@ jobs:
          --remove Microsoft.VisualStudio.Component.Windows10SDK.22621
          --quiet'
 
-     #- name: Uninstall github runner OS image VS2022 Enterprise
-     #  run: >
-     #    Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
-     #    'uninstall --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release'
+     - name: Uninstall github runner OS image VS2022 Enterprise
+       run: >
+         Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
+         'uninstall --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release'
 
      - name: Download Visual Studio 2022
        run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
          TARGET_OS: windows
          FILENAME: OpenJDK.zip
          BUILD_ARGS: --create-sbom
-         CONFIGURE_ARGS: --with-tools-dir='/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Auxiliary/Build'
+         CONFIGURE_ARGS: --with-tools-dir='/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC'
 
      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
        name: Collect and Archive Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,10 +293,10 @@ jobs:
          --remove Microsoft.VisualStudio.Component.Windows10SDK.22621
          --quiet'
 
-     - name: Uninstall github runner OS image VS2022 Enterprise
-       run: >
-         Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
-         'uninstall --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release'
+     #- name: Uninstall github runner OS image VS2022 Enterprise
+     #  run: >
+     #    Start-Process -FilePath 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' -Wait -NoNewWindow -ArgumentList
+     #    'uninstall --quiet --norestart --productId Microsoft.VisualStudio.Product.Enterprise --channelId VisualStudio.17.Release'
 
      - name: Download Visual Studio 2022
        run: |
@@ -371,6 +371,7 @@ jobs:
          TARGET_OS: windows
          FILENAME: OpenJDK.zip
          BUILD_ARGS: --create-sbom
+         CONFIGURE_ARGS: --with-tools-dir='C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools'
 
      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
        name: Collect and Archive Artifacts

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -113,21 +113,17 @@ then
       export INCLUDE="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;$INCLUDE"
       export PATH="$PATH:/c/cygwin64/bin"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
-      TOOLCHAIN_VERSION="2017"
     elif [ "${JAVA_TO_BUILD}" == "${JDK9_VERSION}" ]
     then
-      TOOLCHAIN_VERSION="2013"
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
     elif [ "${JAVA_TO_BUILD}" == "${JDK10_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
     elif [ "$JAVA_FEATURE_VERSION" -lt 19 ]
     then
-      TOOLCHAIN_VERSION="2019"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
     elif [ "$JAVA_FEATURE_VERSION" -ge 19 ]
     then
-      TOOLCHAIN_VERSION="2022"
       export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
     fi
 

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -24,7 +24,7 @@ export ALLOW_DOWNLOADS=true
 export LANG=C
 export OPENJ9_NASM_VERSION=2.13.03
 
-TOOLCHAIN_VERSION=""
+TOOLCHAIN_VERSION="2022"
 
 if [ "$ARCHITECTURE" == "aarch64" ]; then
   # Windows aarch64 cross compiles requires same version boot jdk
@@ -72,7 +72,6 @@ then
       # https://github.com/adoptium/temurin-build/issues/243
       export INCLUDE="C:\Program Files\Debugging Tools for Windows (x64)\sdk\inc;$INCLUDE"
       export PATH="/c/cygwin64/bin:/usr/bin:$PATH"
-      TOOLCHAIN_VERSION="2017"
     elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
     then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar"
@@ -86,20 +85,16 @@ then
   else
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
-      TOOLCHAIN_VERSION="2013"
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 2.5.3"
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
     elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
     then 
-      export TOOLCHAIN_VERSION="2017"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     elif [ "$JAVA_FEATURE_VERSION" -gt 11 ] && [ "$JAVA_FEATURE_VERSION" -lt 21 ]
     then
-      TOOLCHAIN_VERSION="2019"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     elif [ "$JAVA_FEATURE_VERSION" -ge 21 ]
     then
-      TOOLCHAIN_VERSION="2022"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     fi
   fi
@@ -159,18 +154,11 @@ then
     # NASM required for OpenSSL support as per #604
     export PATH="/cygdrive/c/Program Files/LLVM/bin:/usr/bin:/cygdrive/c/openjdk/nasm-$OPENJ9_NASM_VERSION:$PATH"
   else
-    TOOLCHAIN_VERSION="2017"
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
     then
       export BUILD_ARGS="${BUILD_ARGS} --freetype-version 39ce3ac499d4cd7371031a062f410953c8ecce29" # 2.8.1
       export PATH="/cygdrive/c/openjdk/make-3.82/:$PATH"
-    elif [ "$JAVA_FEATURE_VERSION" -ge 11 ] && [ "$JAVA_FEATURE_VERSION" -lt 21 ]
-    then
-      TOOLCHAIN_VERSION="2019"
-    elif [ "$JAVA_FEATURE_VERSION" -ge 21 ]
-    then
-      TOOLCHAIN_VERSION="2022"
     fi
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2421,7 +2421,10 @@ configureWorkspace
 echo "build.sh : $(date +%T) : Initiating build ..."
 getOpenJDKUpdateAndBuildVersion
 if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-  patchFreetypeWindows
+  # Not required for VS2022 and later which we are defaulting to
+  if [[ "${CONFIGURE_ARGS}" =~ "--with-toolchain-version=201" ]]; then
+    patchFreetypeWindows
+  fi
 fi
 configureCommandParameters
 buildTemplatedFile


### PR DESCRIPTION
Update to https://github.com/adoptium/temurin-build/pull/3907 to change github build actions to use VS2022 BuildTools