### PR TITLE
Update various calls to mirrorlist.centos.org with vault.centos.org

### DIFF
--- a/test/system/reproducibleCompare/playlist.xml
+++ b/test/system/reproducibleCompare/playlist.xml
@@ -18,13 +18,13 @@
 	<include>reproducible.mk</include>
 	<test>
 		<testCaseName>Rebuild_Same_JDK_Reproducibility_Test</testCaseName>
-		<command>docker container rm reproducibleCompare; \
+		<command>docker container rm -f reproducibleCompare; \
 	docker run -v "$(TEST_RESROOT):/home/jenkins/test" -w "/home/jenkins/" -v "$(TEST_JDK_HOME):/home/jenkins/jdkbinary/" --name reproducibleCompare centos:7 /bin/bash /home/jenkins/test/linux_repro_build_compare.sh $(SBOM_FILE) /home/jenkins/jdkbinary; \
 	$(TEST_STATUS); \
 	docker cp reproducibleCompare:/home/jenkins/reprotest.diff ./; \
 	docker cp reproducibleCompare:/home/jenkins/reproJDK.tar.gz ./; \
 	docker cp reproducibleCompare:/home/jenkins/SBOM.json ./; \
-	docker container rm reproducibleCompare
+	docker container rm -f reproducibleCompare
 	</command>
 		<levels>
 			<level>special</level>

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -28,14 +28,9 @@ isJdkDir=false
 USING_DEVKIT="false"
 installPrereqs() {
   if test -r /etc/redhat-release; then
-    if [ "$(uname -m)" == "x86_64" ]; then
-      echo "Running on x64 architecture";
-      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
-    else
-      echo "Running on non-x64 architecture";
-      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
-    fi
-
+    #Replace mirrorlist to vault as centos7 reached EOL.
+    sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
+    sed -i 's|#baseurl=http://mirror.centos.org/|baseurl=http://vault.centos.org/|' /etc/yum.repos.d/CentOS-Base.repo
     yum install -y gcc gcc-c++ make autoconf unzip zip alsa-lib-devel cups-devel libXtst-devel libXt-devel libXrender-devel libXrandr-devel libXi-devel
     yum install -y file fontconfig fontconfig-devel systemtap-sdt-devel epel-release # Not included above ...
     yum install -y git bzip2 xz openssl pigz which jq # pigz/which not strictly needed but help in final compression

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -28,6 +28,14 @@ isJdkDir=false
 USING_DEVKIT="false"
 installPrereqs() {
   if test -r /etc/redhat-release; then
+    if [ "$(uname -m)" == "x86_64" ]; then
+      echo "Running on x64 architecture";
+      sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/7.9.2009/!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    else
+      echo "Running on non-x64 architecture";
+      sed -i 's|#baseurl=http://mirror.centos.org/altarch/\$releasever/|baseurl=http://vault.centos.org/altarch/7.9.2009/|' /etc/yum.repos.d/CentOS-Base.repo; \
+    fi
+
     yum install -y gcc gcc-c++ make autoconf unzip zip alsa-lib-devel cups-devel libXtst-devel libXt-devel libXrender-devel libXrandr-devel libXi-devel
     yum install -y file fontconfig fontconfig-devel systemtap-sdt-devel epel-release # Not included above ...
     yum install -y git bzip2 xz openssl pigz which jq # pigz/which not strictly needed but help in final compression

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -28,7 +28,7 @@ isJdkDir=false
 USING_DEVKIT="false"
 installPrereqs() {
   if test -r /etc/redhat-release; then
-    #Replace mirrorlist to vault as centos7 reached EOL.
+    # Replace mirrorlist to vault as centos7 reached EOL.
     sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
     sed -i 's|#baseurl=http://mirror.centos.org/|baseurl=http://vault.centos.org/|' /etc/yum.repos.d/CentOS-Base.repo
     yum install -y gcc gcc-c++ make autoconf unzip zip alsa-lib-devel cups-devel libXtst-devel libXt-devel libXrender-devel libXrandr-devel libXi-devel


### PR DESCRIPTION
Mirrorlist has been deprecated following the EOL of Centos 7

Fix #3905 