### PR TITLE
only specify --openjdk-target when cross compiling

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -70,7 +70,7 @@ else
     if [ "${ARCHITECTURE}" == "x64" ]; then
       # We can only target 10.9 on intel macs
       export cxx_flags_bucket="${cxx_flags_bucket} -mmacosx-version-min=10.9"
-    elif [ "${ARCHITECTURE}" == "aarch64" ]; then
+    elif [[ "${MACHINEARCHITECTURE}" == "x64" ]] && [[ "${ARCHITECTURE}" == "aarch64" ]]; then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=aarch64-apple-darwin"
     fi
   fi


### PR DESCRIPTION
This will partially fix https://github.com/adoptium/adoptium-support/issues/937 for macOS aarch64