### PR TITLE
Fix translation of package names in SBOM

### DIFF
--- a/tooling/strace_analysis.sh
+++ b/tooling/strace_analysis.sh
@@ -258,17 +258,17 @@ processFiles() {
             case "${os_type}" in
                 "alpine")
                     # Process alpine package query output: "FILE is owned by PACKAGE"
-                    pkg_name="$(echo "$pkg" | sed 's/is owned by//g' | tr -s ' ' | cut -d' ' -f2 | tr -d '\\n\\r')"
+                    pkg_name="$(echo "$pkg" | sed 's/is owned by//g' | tr -s ' ' | cut -d' ' -f2 | tr -d '\\\n\\\r')"
                     pkg_version="$pkg_name"
                     ;;
                 "debian")
                     # Process debian package query output: "PACKAGE: FILE"
-                    pkg_name="$(echo "$pkg" | cut -d":" -f1 | tr -d '\\n\\r')"
-                    pkg_version="$(apt show "$pkg_name" 2>/dev/null | grep Version | cut -d" " -f2 | tr -d '\\n\\r')"
+                    pkg_name="$(echo "$pkg" | cut -d":" -f1 | tr -d '\\\n\\\r')"
+                    pkg_version="$(apt show "$pkg_name" 2>/dev/null | grep Version | cut -d" " -f2 | tr -d '\\\n\\\r')"
                     ;;
                 "centos")
                     # Process centos package query output: "PACKAGE"
-                    pkg_name="$(echo "$pkg" | cut -d" " -f1 | tr -d '\\n\\r')"
+                    pkg_name="$(echo "$pkg" | cut -d" " -f1 | tr -d '\\\n\\\r')"
                     pkg_version="$pkg_name"
                     ;;
                 *)


### PR DESCRIPTION
Looks like it fixes https://github.com/adoptium/temurin-build/issues/3960

I built https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-aarch64-temurin/269/ off this branch, and the [SBOM](https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-aarch64-temurin/269/artifact/workspace/target/OpenJDK21U-sbom_aarch64_linux_hotspot_21.0.5_8-ea.json) has the correct package names
```
            {
              "name" : "openssl-libs-1.0.2k-26.el7_9.aarch64",
              "value" : "openssl-libs-1.0.2k-26.el7_9.aarch64"
            },
```
Instead of 
```
name	"opessl-libs-1.0.2k-26.el7_9.aach64"
value	"opessl-libs-1.0.2k-26.el7_9.aach64"
```
