### PR TITLE
Update Signature URL in BootJDK download, so Location field longer case sensitive.

### DIFF
--- a/sbin/common/downloaders.sh
+++ b/sbin/common/downloaders.sh
@@ -49,7 +49,7 @@ function downloadLinuxBootJDK() {
   # the fallback mechanism, as downloading of the GA binary might fail.
   set +e
   curl -L -o bootjdk.tar.gz "${apiURL}"
-  apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< Location:/{print $3 ".sig"}')
+  apiSigURL=$(curl -v "${apiURL}" 2>&1 | tr -d \\r | awk '/^< [Ll]ocation:/{print $3 ".sig"}')
   if ! grep "No releases match the request" bootjdk.tar.gz; then
     curl -L -o bootjdk.tar.gz.sig "${apiSigURL}"
     gpg --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B


### PR DESCRIPTION
Fixes #3978 

Amends the curl command used to validate the signature URL to check either Location or location.

Test build running here: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk23u/job/jdk23u-linux-riscv64-temurin/16/console 