### PR TITLE
Add support for Windows Redist DLL as Adoptium DevKit

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -83,11 +83,11 @@ configureDevKitConfigureParameter() {
       # ARCHITECTURE is set to the "target" architecture by caller, or defaults to build architecture if not set
       local dll_arch
       if [[ "${ARCHITECTURE}" == "x86-32" ]]; then
-        dll_arch = "x86"
+        dll_arch="x86"
       elif [[ "${ARCHITECTURE}" == "aarch64" ]]; then
-        dll_arch = "arm64"
+        dll_arch="arm64"
       else
-        dll_arch = "x64"
+        dll_arch="x64"
       fi
 
       # Add Windows Redist DLL paths

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -76,7 +76,28 @@ addConfigureArgIfValueIsNotEmpty() {
 # Configure the DevKit if required
 configureDevKitConfigureParameter() {
   if [[ -n "${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" ]]; then
-    addConfigureArg "--with-devkit=" "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}"
+    if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
+      # Windows DevKit, currently only Redist DLLs
+
+      # This is TARGET Architecture for the Redist DLLs to use
+      # ARCHITECTURE is set to the "target" architecture by caller, or defaults to build architecture if not set
+      local dll_arch
+      if [[ "${ARCHITECTURE}" == "x86-32" ]]; then
+        dll_arch = "x86"
+      elif [[ "${ARCHITECTURE}" == "aarch64" ]]; then
+        dll_arch = "arm64"
+      else
+        dll_arch = "x64"
+      fi
+
+      # Add Windows Redist DLL paths
+      addConfigureArg "--with-ucrt-dll-dir="    "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/ucrt/DLLs/${dll_arch}"
+      addConfigureArg "--with-msvcr-dll="       "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/vcruntime140.dll"
+      addConfigureArg "--with-vcruntime-1-dll=" "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/vcruntime140_1.dll"
+      addConfigureArg "--with-msvcp-dll="       "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/msvcp140.dll"
+    else
+      addConfigureArg "--with-devkit=" "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}"
+    fi
   fi
 } 
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -91,10 +91,10 @@ configureDevKitConfigureParameter() {
       fi
 
       # Add Windows Redist DLL paths
-      addConfigureArg "--with-ucrt-dll-dir="    "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/ucrt/DLLs/${dll_arch}"
-      addConfigureArg "--with-msvcr-dll="       "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/vcruntime140.dll"
-      addConfigureArg "--with-vcruntime-1-dll=" "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/vcruntime140_1.dll"
-      addConfigureArg "--with-msvcp-dll="       "{BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/msvcp140.dll"
+      addConfigureArg "--with-ucrt-dll-dir="    "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/ucrt/DLLs/${dll_arch}"
+      addConfigureArg "--with-msvcr-dll="       "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/vcruntime140.dll"
+      addConfigureArg "--with-vcruntime-1-dll=" "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/vcruntime140_1.dll"
+      addConfigureArg "--with-msvcp-dll="       "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}/${dll_arch}/msvcp140.dll"
     else
       addConfigureArg "--with-devkit=" "${BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]}"
     fi

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -731,21 +731,21 @@ downloadLinuxDevkit() {
     fi
 }
 
-# Download the required Windows DevKit if necessary and not available in /usr/local/devkit
+# Download the required Windows DevKit if necessary and not available in c:/openjdk/devkit
 #   For the moment this is just support for Windows Redist DLLs
 downloadWindowsDevkit() {
-    local USR_LOCAL_DEVKIT="/usr/local/devkit/${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
-    if [[ -d "${USR_LOCAL_DEVKIT}" ]]; then
-      local usrLocalDevkitInfo="${USR_LOCAL_DEVKIT}/devkit.info"
-       if ! grep "ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" "${usrLocalDevkitInfo}"; then
-        echo "WARNING: Devkit ${usrLocalDevkitInfo} does not match required release:"
+    local WIN_LOCAL_DEVKIT="/cygdrive/C/openjdk/devkit/${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
+    if [[ -d "${WIN_LOCAL_DEVKIT}" ]]; then
+      local winLocalDevkitInfo="${WIN_LOCAL_DEVKIT}/devkit.info"
+       if ! grep "ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}" "${winLocalDevkitInfo}"; then
+        echo "WARNING: Devkit ${winLocalDevkitInfo} does not match required release:"
         echo "       Required:   ADOPTIUM_DEVKIT_RELEASE=${BUILD_CONFIG[USE_ADOPTIUM_DEVKIT]}"
-        echo "       ${USR_LOCAL_DEVKIT}: $(grep ADOPTIUM_DEVKIT_RELEASE= "${usrLocalDevkitInfo}")"
+        echo "       ${WIN_LOCAL_DEVKIT}: $(grep ADOPTIUM_DEVKIT_RELEASE= "${winLocalDevkitInfo}")"
         echo "Attempting to download the required DevKit instead"
       else
         # Found a matching DevKit
-        echo "Using matching DevKit from location ${USR_LOCAL_DEVKIT}"
-        BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]="${USR_LOCAL_DEVKIT}"
+        echo "Using matching DevKit from location ${WIN_LOCAL_DEVKIT}"
+        BUILD_CONFIG[ADOPTIUM_DEVKIT_LOCATION]="${WIN_LOCAL_DEVKIT}"
       fi
     fi
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/3887

Adds partial support for an Adoptium Windows DevKit, that consists of purely the Redist DLLs from https://github.com/adoptium/devkit-binaries/releases/tag/vs2022_redist_14.40.33807_10.0.26100.0

eg.
```
--use-adoptium-devkit vs2022_redist_14.40.33807_10.0.26100.0
```

**Test builds:**
- jdk17u Windows x64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk17u/job/jdk17u-windows-x64-temurin/536/ - Success
- jdk17u Windows x86-32 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk17u/job/jdk17u-windows-x86-32-temurin/367/ - Success
- jdk21u Windows x64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/169/
- jdk21u Windows aarch64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-aarch64-temurin/7/ - Success

AQA Triage tests: https://github.com/adoptium/ci-jenkins-pipelines/issues/1104#issuecomment-2393086371