### PR TITLE
The removeSystemModulesHashBuilderParams also changed signature from JDK to jdk OS java_home

### DIFF
--- a/tooling/reproducible/comparable_patch.sh
+++ b/tooling/reproducible/comparable_patch.sh
@@ -349,7 +349,7 @@ fi
 
 if [[ "$OS" =~ CYGWIN* ]] || [[ "$OS" =~ Darwin* ]]; then
   # SystemModules$*.class's differ due to hash differences from Windows COMPANY_NAME and Signatures
-  removeSystemModulesHashBuilderParams "${JDK_DIR}"
+  removeSystemModulesHashBuilderParams "${JDK_DIR}" "${OS}" "$(dirname "$(dirname "$(readlink -f  "$(which java)")")")"
 fi
 
 if [[ "$OS" =~ CYGWIN* ]]; then


### PR DESCRIPTION
Hello! SSIA, Sorry I missed it befofre. I run it from fork, where I had fixed both but later commited only half (https://github.com/adoptium/temurin-build/commit/eb6b68e02579cb8ba113fc4beef77aa9db1f66a4)