### PR TITLE
Build build-sign-sbom ant target

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -119,7 +119,7 @@
                 <download-file-with-default-options destfile="github-package-url.jar"/>
         </target>
 
-	      <target name="build" depends="dep-checks, download-cyclonedx, download-jackson-core, download-jackson-dataformat-xml, download-jackson-databind, download-jackson-annotations, download-json-schema, download-commons-codec, download-commons-io, download-github-package-url, compile, jar">
+	      <target name="build" depends="dep-checks, download-cyclonedx, download-jackson-core, download-jackson-dataformat-xml, download-jackson-databind, download-jackson-annotations, download-json-schema, download-commons-codec, download-commons-io, download-github-package-url, compile, jar, build-sign-sbom">
                 <echo message="Building cyclonedx-lib"/>
         </target>
 


### PR DESCRIPTION
ref https://github.com/adoptium/temurin-build/issues/3946

Adding the `build-sign-sbom` target to the `build` target ensures that the `temurin-sign-sbom.jar` gets built during https://github.com/adoptium/temurin-build/blob/62ecfbaeb60cbe5f4072bd81b8d4a3546625dcb2/sbin/build.sh#L885 when the other cyclone dx libraries get built

