### PR TITLE
Add timestamps to  repro_compare.sh and friends

### DIFF
--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -387,8 +387,9 @@ function tempSign() {
     signToolPath="signtool"
     echo "Generating temp signatures with openssl and adding them to exe/dll files in ${JDK_DIR}"
     selfCert="test"
-    openssl req -x509 -quiet -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout $selfCert.key -out $selfCert.crt -subj "/CN=example.com" -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
-    openssl pkcs12 -export -passout pass:test -out $selfCert.pfx -inkey $selfCert.key -in $selfCert.crt
+
+    openssl req -x509 -quiet -newkey rsa:4096 -sha256 -days 3650 -passout pass:test -keyout $selfCert.key -out $selfCert.crt -subj "/CN=example.com" -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
+    openssl pkcs12 -export -passout pass:test -passin pass:test -out $selfCert.pfx -inkey $selfCert.key -in $selfCert.crt
     FILES=$(find "${JDK_DIR}" -type f -name '*.exe' -o -name '*.dll')
     for f in $FILES
      do

--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -388,7 +388,12 @@ function tempSign() {
     echo "Generating temp signatures with openssl and adding them to exe/dll files in ${JDK_DIR}"
     selfCert="test"
 
+    # semgrep needs to ignore this as it objects to the password, but that
+    # is only used for generating a temporary dummy signature required for
+    # the comparison and not used for validating anything
+    # nosemgrep
     openssl req -x509 -quiet -newkey rsa:4096 -sha256 -days 3650 -passout pass:test -keyout $selfCert.key -out $selfCert.crt -subj "/CN=example.com" -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
+    # nosemgrep
     openssl pkcs12 -export -passout pass:test -passin pass:test -out $selfCert.pfx -inkey $selfCert.key -in $selfCert.crt
     FILES=$(find "${JDK_DIR}" -type f -name '*.exe' -o -name '*.dll')
     for f in $FILES

--- a/tooling/reproducible/repro_compare.sh
+++ b/tooling/reproducible/repro_compare.sh
@@ -34,11 +34,11 @@ do
     exit 1
   fi
 
-  echo "Pre-processing ${JDK_DIR}"
+  echo "$(date +%T) : Pre-processing ${JDK_DIR}"
   rc=0
   source "$(dirname "$0")"/repro_process.sh "${JDK_DIR}" "${OS}" || rc=$?
   if [ $rc != 0 ]; then
-    echo "Pre-process of ${JDK_DIR} ${OS} failed"
+    echo "$(date +%T): Pre-processing of ${JDK_DIR} ${OS} failed"
     exit 1
   fi
 
@@ -59,8 +59,9 @@ files1=$(find "${JDK_DIR1}" -type f | wc -l)
 echo "Number of files: ${files1}"
 rc=0
 output="reprotest.diff"
-echo "Comparing ${JDK_DIR1} with ${JDK_DIR2} ... output to file: ${output}"
+echo "$(date +%T) : Comparing expanded JDKs from ${JDK_DIR1} with ${JDK_DIR2} ..."
 diff -r -q "${JDK_DIR1}" "${JDK_DIR2}" > "${output}" || rc=$?
+echo "$(date +%T) : diff complete - rc=$rc. Output written to file: ${output}"
 
 cat "${output}"
 

--- a/tooling/reproducible/repro_process.sh
+++ b/tooling/reproducible/repro_process.sh
@@ -38,7 +38,5 @@ fi
 
 patchManifests "${JDK_DIR}"
 
-echo "***********"
-echo " Preprocess ${JDK_DIR} SUCCESS :-)"
-echo "***********"
-
+echo "$(date +%T) : Pre-processing of ${JDK_DIR} SUCCESSFUL :-)"
+echo "" # blank line separator in log file


### PR DESCRIPTION
This adds time stamps to the steps in the reproducible comparison script just to be able to compare how long it takes when it's running (particularly on machines with different disks). 
It slightly changes the wording on some of the echo statements to to clarify what tools are being used for each step.
I've also enabled the use of `unzip -q` instead of `unzip ... > /dev/null` which looks nicer.
I have also added `-quiet` to the `openssl` commands which should mask the line with all the `.` and `+` characters but that doesn't seem to do the job on the windows/cygwin environment. I'm leaving it in anyway on the basis that it will hopefully make the output cleaner in some circumstances, including on windows if an update to openssl comes in that's happier with it.

Not tested on macos - it might be nice to verify that the `-q` and `quiet` options don't cause a problem there prior to merging.