### PR TITLE
Enable IPV6 at runtime

### DIFF
--- a/test/system/reproducibleCompare/playlist.xml
+++ b/test/system/reproducibleCompare/playlist.xml
@@ -19,7 +19,7 @@
 	<test>
 		<testCaseName>Rebuild_Same_JDK_Reproducibility_Test</testCaseName>
 		<command>docker container rm -f reproducibleCompare; \
-	docker run -v "$(TEST_RESROOT):/home/jenkins/test" -w "/home/jenkins/" -v "$(TEST_JDK_HOME):/home/jenkins/jdkbinary/" --name reproducibleCompare centos:7 /bin/bash /home/jenkins/test/linux_repro_build_compare.sh $(SBOM_FILE) /home/jenkins/jdkbinary; \
+	docker run --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 -v "$(TEST_RESROOT):/home/jenkins/test" -w "/home/jenkins/" -v "$(TEST_JDK_HOME):/home/jenkins/jdkbinary/" --name reproducibleCompare centos:7 /bin/bash /home/jenkins/test/linux_repro_build_compare.sh $(SBOM_FILE) /home/jenkins/jdkbinary; \
 	$(TEST_STATUS); \
 	docker cp reproducibleCompare:/home/jenkins/reprotest.diff ./; \
 	docker cp reproducibleCompare:/home/jenkins/reproJDK.tar.gz ./; \

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -89,6 +89,13 @@ setAntEnvironment() {
   export PATH="${LOCALGCCDIR}/bin:/usr/local/bin:/usr/bin:$PATH:/usr/local/apache-ant-${ANT_VERSION}/bin"
 }
 
+enableIPV6() {
+  sysctl -w net.ipv6.conf.all.disable_ipv6=0
+  sysctl -w net.ipv6.conf.default.disable_ipv6=0
+  sysctl -w net.ipv6.conf.tun0.disable_ipv6=0
+  sysctl -p
+}
+
 setTemurinBuildArgs() {
   local buildArgs="$1"
   local bootJdk="$2"
@@ -173,6 +180,7 @@ if [[ "${USING_DEVKIT}" == "false" ]]; then
   setNonDevkitGccEnvironment
 fi
 setAntEnvironment
+enableIPV6
 echo "original temurin build args is ${TEMURIN_BUILD_ARGS}"
 TEMURIN_BUILD_ARGS=$(setTemurinBuildArgs "$TEMURIN_BUILD_ARGS" "$BOOTJDK_VERSION" "$BUILDSTAMP")
 

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -89,13 +89,6 @@ setAntEnvironment() {
   export PATH="${LOCALGCCDIR}/bin:/usr/local/bin:/usr/bin:$PATH:/usr/local/apache-ant-${ANT_VERSION}/bin"
 }
 
-enableIPV6() {
-  sysctl -w net.ipv6.conf.all.disable_ipv6=0
-  sysctl -w net.ipv6.conf.default.disable_ipv6=0
-  sysctl -w net.ipv6.conf.tun0.disable_ipv6=0
-  sysctl -p
-}
-
 setTemurinBuildArgs() {
   local buildArgs="$1"
   local bootJdk="$2"
@@ -180,7 +173,6 @@ if [[ "${USING_DEVKIT}" == "false" ]]; then
   setNonDevkitGccEnvironment
 fi
 setAntEnvironment
-enableIPV6
 echo "original temurin build args is ${TEMURIN_BUILD_ARGS}"
 TEMURIN_BUILD_ARGS=$(setTemurinBuildArgs "$TEMURIN_BUILD_ARGS" "$BOOTJDK_VERSION" "$BUILDSTAMP")
 

--- a/tooling/reproducible/repro_compare.sh
+++ b/tooling/reproducible/repro_compare.sh
@@ -64,7 +64,7 @@ diff -r -q "${JDK_DIR1}" "${JDK_DIR2}" > "${output}" || rc=$?
 
 cat "${output}"
 
-grep "Files .*class" "${output}" | while read -r line; do
+grep "Files .*" "${output}" | while read -r line; do
   FILE1=$(echo "$line" | awk '{print $2}')
   FILE2=$(echo "$line" | awk '{print $4}')
   echo "diff -c on $FILE1 and $FILE2"

--- a/tooling/reproducible/repro_compare.sh
+++ b/tooling/reproducible/repro_compare.sh
@@ -64,6 +64,13 @@ diff -r -q "${JDK_DIR1}" "${JDK_DIR2}" > "${output}" || rc=$?
 
 cat "${output}"
 
+grep "Files .*class" "${output}" | while read -r line; do
+  FILE1=$(echo "$line" | awk '{print $2}')
+  FILE2=$(echo "$line" | awk '{print $4}')
+  echo "diff -c on $FILE1 and $FILE2"
+  diff -c "$FILE1" "$FILE2"
+done
+
 num_differences=$(wc -l < "${output}")
 echo "Number of differences: ${num_differences}"
 repro_pc100=$(( (files1-num_differences)*100*100/files1 ))


### PR DESCRIPTION
Enable IPV6  by configuring namespaced kernel parameters (sysctls) at runtime (--sysctl). 

Show verbose diff if there are files are different.

Close #3967 