### PR TITLE
Update windows_repro_build_compare.sh to allow for windows Redist devkit

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -79,9 +79,10 @@ configureDevKitConfigureParameter() {
     if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
       # Windows DevKit, currently only Redist DLLs
 
+
       # Default to build architecture unless target ARCHITECTURE variable is set
       def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-      if [[ -n "${ARCHITECTURE}" ]]; then
+      if [[ ! -z "${ARCHITECTURE+x}" ]]; then
         target_arch="${ARCHITECTURE}"
       fi
       echo "Target architecture for Windows devkit: ${target_arch}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -81,7 +81,7 @@ configureDevKitConfigureParameter() {
 
       # Default to build architecture unless target ARCHITECTURE variable is set
       local target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-      if [[ -n "${ARCHITECTURE+x}" ]]; then
+      if [ ${ARCHITECTURE+x} ] && [ -n "${ARCHITECTURE}" ]; then
         target_arch="${ARCHITECTURE}"
       fi
       echo "Target architecture for Windows devkit: ${target_arch}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -79,12 +79,18 @@ configureDevKitConfigureParameter() {
     if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
       # Windows DevKit, currently only Redist DLLs
 
+      # Default to build architecture unless target ARCHITECTURE variable is set
+      def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
+      if [ -n ${var+x} ]; then
+        target_arch="${ARCHITECTURE}"
+      fi
+      echo "Target architecture for Windows devkit: ${target_arch}"
+
       # This is TARGET Architecture for the Redist DLLs to use
-      # ARCHITECTURE is set to the "target" architecture by caller, or defaults to build architecture if not set
       local dll_arch
-      if [[ "${ARCHITECTURE}" == "x86-32" ]]; then
+      if [[ "${target_arch}" == "x86-32" ]]; then
         dll_arch="x86"
-      elif [[ "${ARCHITECTURE}" == "aarch64" ]]; then
+      elif [[ "${target_arch}" == "aarch64" ]]; then
         dll_arch="arm64"
       else
         dll_arch="x64"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -81,7 +81,7 @@ configureDevKitConfigureParameter() {
 
       # Default to build architecture unless target ARCHITECTURE variable is set
       def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-      if [ -n ${var+x} ]; then
+      if [ -n "${ARCHITECTURE+x}" ]; then
         target_arch="${ARCHITECTURE}"
       fi
       echo "Target architecture for Windows devkit: ${target_arch}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -79,6 +79,7 @@ configureDevKitConfigureParameter() {
     if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
       # Windows DevKit, currently only Redist DLLs
 
+      echo "HERE!"
 
       # Default to build architecture unless target ARCHITECTURE variable is set
       def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -82,8 +82,8 @@ configureDevKitConfigureParameter() {
       echo "HERE!"
 
       # Default to build architecture unless target ARCHITECTURE variable is set
-      def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-      if [[ ! -z "${ARCHITECTURE+x}" ]]; then
+      local target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
+      if [[ -n "${ARCHITECTURE+x}" ]]; then
         target_arch="${ARCHITECTURE}"
       fi
       echo "Target architecture for Windows devkit: ${target_arch}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -81,7 +81,7 @@ configureDevKitConfigureParameter() {
 
       # Default to build architecture unless target ARCHITECTURE variable is set
       def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-      if [ -n "${ARCHITECTURE+x}" ]; then
+      if [ ! -z "${ARCHITECTURE+x}" ]; then
         target_arch="${ARCHITECTURE}"
       fi
       echo "Target architecture for Windows devkit: ${target_arch}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -81,7 +81,7 @@ configureDevKitConfigureParameter() {
 
       # Default to build architecture unless target ARCHITECTURE variable is set
       def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-      if [ ! -z "${ARCHITECTURE+x}" ]; then
+      if [ -n "${ARCHITECTURE+x}" ]; then
         target_arch="${ARCHITECTURE}"
       fi
       echo "Target architecture for Windows devkit: ${target_arch}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -81,7 +81,7 @@ configureDevKitConfigureParameter() {
 
       # Default to build architecture unless target ARCHITECTURE variable is set
       def target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
-      if [ -n "${ARCHITECTURE+x}" ]; then
+      if [[ -n "${ARCHITECTURE}" ]]; then
         target_arch="${ARCHITECTURE}"
       fi
       echo "Target architecture for Windows devkit: ${target_arch}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -79,8 +79,6 @@ configureDevKitConfigureParameter() {
     if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
       # Windows DevKit, currently only Redist DLLs
 
-      echo "HERE!"
-
       # Default to build architecture unless target ARCHITECTURE variable is set
       local target_arch="${BUILD_CONFIG[OS_ARCHITECTURE]}"
       if [[ -n "${ARCHITECTURE+x}" ]]; then

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -684,10 +684,12 @@ Check_Architecture
 echo "---------------------------------------------"
 Check_VS_Versions
 echo "---------------------------------------------"
-Get_SRC_UCRT_Version
-echo "---------------------------------------------"
-Check_UCRT_Location
-echo "---------------------------------------------"
+if [[ "${buildArgs}" != *"--use-adoptium-devkit"* ]]; then
+  Get_SRC_UCRT_Version
+  echo "---------------------------------------------"
+  Check_UCRT_Location
+  echo "---------------------------------------------"
+fi
 echo "All Validation Checks Passed - Proceeding To Build"
 echo "---------------------------------------------"
 Check_And_Install_Ant

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -528,9 +528,9 @@ Clone_Build_Repo() {
   if [ ! -r "$WORK_DIR/temurin-build" ] ; then
     echo "Cloning Temurin Build Repository"
     echo ""
-    git clone -q https://github.com/adoptium/temurin-build "$WORK_DIR/temurin-build" || exit 1
-    echo "Switching To Build SHA From SBOM : $buildSHA"
-    (cd "$WORK_DIR/temurin-build" && git checkout -q "$buildSHA")
+    git clone -q https://github.com/andrew-m-leonard/openjdk-build "$WORK_DIR/temurin-build" || exit 1
+    echo "Switching To Build SHA From SBOM : win_repo"
+    (cd "$WORK_DIR/temurin-build" && git checkout -q "win_repo")
     echo "Completed"
   fi
 }

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -528,9 +528,9 @@ Clone_Build_Repo() {
   if [ ! -r "$WORK_DIR/temurin-build" ] ; then
     echo "Cloning Temurin Build Repository"
     echo ""
-    git clone -q https://github.com/andrew-m-leonard/openjdk-build "$WORK_DIR/temurin-build" || exit 1
+    git clone -q https://github.com/adoptium/temurin-build "$WORK_DIR/temurin-build" || exit 1
     echo "Switching To Build SHA From SBOM : $buildSHA"
-    (cd "$WORK_DIR/temurin-build" && git checkout -q "win_repro")
+    (cd "$WORK_DIR/temurin-build" && git checkout -q "$buildSHA")
     echo "Completed"
   fi
 }

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -529,8 +529,8 @@ Clone_Build_Repo() {
     echo "Cloning Temurin Build Repository"
     echo ""
     git clone -q https://github.com/andrew-m-leonard/openjdk-build "$WORK_DIR/temurin-build" || exit 1
-    echo "Switching To Build SHA From SBOM : win_repo"
-    (cd "$WORK_DIR/temurin-build" && git checkout -q "win_repo")
+    echo "Switching To Build SHA From SBOM : win_repro"
+    (cd "$WORK_DIR/temurin-build" && git checkout -q "win_repro")
     echo "Completed"
   fi
 }

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -528,9 +528,9 @@ Clone_Build_Repo() {
   if [ ! -r "$WORK_DIR/temurin-build" ] ; then
     echo "Cloning Temurin Build Repository"
     echo ""
-    git clone -q https://github.com/andrew-m-leonard/openjdk-build "$WORK_DIR/temurin-build" || exit 1
-    echo "Switching To Build SHA From SBOM : win_repro"
-    (cd "$WORK_DIR/temurin-build" && git checkout -q "win_repro")
+    git clone -q https://github.com/adoptium/temurin-build "$WORK_DIR/temurin-build" || exit 1
+    echo "Switching To Build SHA From SBOM : "
+    (cd "$WORK_DIR/temurin-build" && git checkout -q "$buildSHA")
     echo "Completed"
   fi
 }

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -529,7 +529,7 @@ Clone_Build_Repo() {
     echo "Cloning Temurin Build Repository"
     echo ""
     git clone -q https://github.com/adoptium/temurin-build "$WORK_DIR/temurin-build" || exit 1
-    echo "Switching To Build SHA From SBOM : "
+    echo "Switching To Build SHA From SBOM : $buildSHA"
     (cd "$WORK_DIR/temurin-build" && git checkout -q "$buildSHA")
     echo "Completed"
   fi

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -528,9 +528,9 @@ Clone_Build_Repo() {
   if [ ! -r "$WORK_DIR/temurin-build" ] ; then
     echo "Cloning Temurin Build Repository"
     echo ""
-    git clone -q https://github.com/adoptium/temurin-build "$WORK_DIR/temurin-build" || exit 1
+    git clone -q https://github.com/andrew-m-leonard/openjdk-build "$WORK_DIR/temurin-build" || exit 1
     echo "Switching To Build SHA From SBOM : $buildSHA"
-    (cd "$WORK_DIR/temurin-build" && git checkout -q "$buildSHA")
+    (cd "$WORK_DIR/temurin-build" && git checkout -q "win_repro")
     echo "Completed"
   fi
 }


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4021

Don't check local Windows system UCRT if --use-adoptium-devkit used, as the correct versions will be downloaded.

Grinder test: https://ci.adoptium.net/job/Grinder/11287/
