### PR TITLE
Fix incorrect jdkbinary JDK folder directory when run from Rebuild_Same_JDK_Reproducibility_Test

### DIFF
--- a/test/system/reproducibleCompare/playlist.xml
+++ b/test/system/reproducibleCompare/playlist.xml
@@ -19,6 +19,12 @@
 	<test>
 		<testCaseName>Rebuild_Same_JDK_Reproducibility_Test</testCaseName>
 		<command>docker container rm -f reproducibleCompare; \
+	echo "TEST_JDK_HOME = ${TEST_JDK_HOME}"; \
+	ls -l "$(TEST_JDK_HOME)"; \
+	echo "---"; \
+	ls -l "$(TEST_JDK_HOME)/jdk-21.0.6+2"; \
+	echo "---"; \
+	ls -l "$(TEST_JDK_HOME)/jdk-21.0.6+2/bin"; \
 	docker run --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.default.disable_ipv6=0 -v "$(TEST_RESROOT):/home/jenkins/test" -w "/home/jenkins/" -v "$(TEST_JDK_HOME):/home/jenkins/jdkbinary/" --name reproducibleCompare centos:7 /bin/bash /home/jenkins/test/linux_repro_build_compare.sh $(SBOM_FILE) /home/jenkins/jdkbinary; \
 	$(TEST_STATUS); \
 	docker cp reproducibleCompare:/home/jenkins/reprotest.diff ./; \

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -191,12 +191,21 @@ else
   cp -R "${JDK_PARAM}"/* "${sourceJDK}"
 fi
 
+echo "JDK_PARAM is ${JDK_PARAM}"
+ls -l "${JDK_PARAM}"
+echo "Current pwd:"
+pwd
+ls -l "$sourceJDK"
+
 echo "Rebuild args for makejdk_any_platform.sh are: $TEMURIN_BUILD_ARGS"
 echo " cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS 2>&1 | tee build.$$.log" | sh
 
 echo Comparing ...
 mkdir tarJDK
 tar xpfz temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz -C tarJDK
+
+ls -l tarJDK
+
 cp temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz reproJDK.tar.gz
 cp "$SBOM" SBOM.json
 

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -196,6 +196,8 @@ ls -l "${JDK_PARAM}"
 echo "Current pwd:"
 pwd
 ls -l "$sourceJDK"
+echo "bin:"
+ls -l "${sourceJDK}/bin"
 
 echo "Rebuild args for makejdk_any_platform.sh are: $TEMURIN_BUILD_ARGS"
 echo " cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS 2>&1 | tee build.$$.log" | sh

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -188,16 +188,10 @@ elif [[ $JDK_PARAM =~ tar.gz ]]; then
   tar xpfz "$JDK_PARAM" --strip-components=1 -C "$PWD/jdk-${TEMURIN_VERSION}"
 else
   # Local jdk dir
-  cp -R "${JDK_PARAM}"/* "${sourceJDK}"
+  cp -R "${JDK_PARAM}/jdk-${TEMURIN_VERSION}"/* "${sourceJDK}"
 fi
 
 echo "JDK_PARAM is ${JDK_PARAM}"
-ls -l "${JDK_PARAM}"
-echo "Current pwd:"
-pwd
-ls -l "$sourceJDK"
-echo "bin:"
-ls -l "${sourceJDK}/bin"
 
 echo "Rebuild args for makejdk_any_platform.sh are: $TEMURIN_BUILD_ARGS"
 echo " cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS 2>&1 | tee build.$$.log" | sh

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -14,6 +14,11 @@
 
 # This script examines the given SBOM metadata file, and then builds the exact same binary
 # and then compares with the supplied TARBALL_PARAM.
+#  SBOM_PARAM : Path to SBOM json file
+#  JDK_PARAM  : One of:
+#      URL of JDK tarball
+#      Path to JDK tarball file
+#      Local directory that contains the given expanded "jdk-V.0.M+B" JDK folder
 
 set -e
 

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -14,7 +14,9 @@
 
 # This script examines the given SBOM metadata file, and then builds the exact same binary
 # and then compares with the supplied TARBALL_PARAM.
-#  SBOM_PARAM : Path to SBOM json file
+#  SBOM_PARAM : One of:
+#      URL of SBOM metadata json file
+#      Path to SBOM metadata json file
 #  JDK_PARAM  : One of:
 #      URL of JDK tarball
 #      Path to JDK tarball file

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -200,8 +200,6 @@ echo Comparing ...
 mkdir tarJDK
 tar xpfz temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz -C tarJDK
 
-ls -l tarJDK
-
 cp temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz reproJDK.tar.gz
 cp "$SBOM" SBOM.json
 

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -191,15 +191,12 @@ else
   cp -R "${JDK_PARAM}/jdk-${TEMURIN_VERSION}"/* "${sourceJDK}"
 fi
 
-echo "JDK_PARAM is ${JDK_PARAM}"
-
 echo "Rebuild args for makejdk_any_platform.sh are: $TEMURIN_BUILD_ARGS"
 echo " cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS 2>&1 | tee build.$$.log" | sh
 
 echo Comparing ...
 mkdir tarJDK
 tar xpfz temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz -C tarJDK
-
 cp temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz reproJDK.tar.gz
 cp "$SBOM" SBOM.json
 

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -198,6 +198,14 @@ else
   cp -R "${JDK_PARAM}/jdk-${TEMURIN_VERSION}"/* "${sourceJDK}"
 fi
 
+echo "JDK_PARAM = ${JDK_PARAM}"
+ls -l "${JDK_PARAM}"
+echo "jdk folder:"
+ls -l "${JDK_PARAM}/jdk-${TEMURIN_VERSION}"
+echo "sourceJDK:"
+ls -l "${sourceJDK}"
+
+
 echo "Rebuild args for makejdk_any_platform.sh are: $TEMURIN_BUILD_ARGS"
 echo " cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS 2>&1 | tee build.$$.log" | sh
 


### PR DESCRIPTION
When linux_repro_build_compare.sh was called from aqa-tests passing the jdkbinary folder it was comparing the top-level jdkbinary folder containing all the artifacts (jdk,jre,static-libs,..) rather than the jdk-VERSION folder...

Slightly complicated by the fact that TKG calls using the expanded "all artifacts" top directory (jdkbinary), whereas a "user" might expect to call using a local reference to the jdk-V.0.M+B folder. I've updated the script to assume the when
a local directory is used it references the folder that contains the jdk-V.0.M+B folder specified in the SBOM.

Grinder test: https://ci.adoptium.net/job/Grinder/11309/
