### PR TITLE
Add smoke test for enabled JEP 493 for Eclipse Temurin builds

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
@@ -45,6 +45,9 @@ public class FeatureTests {
 
     private String testJdkHome = null;
 
+    /**
+     * Ensure TEST_JDK_HOME environment variable is set for every test in this class.
+     */
     @BeforeTest
     public final void ensureTestJDKSet() {
         String tmpJdkHome = System.getenv("TEST_JDK_HOME");

--- a/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptium/test/FeatureTests.java
@@ -46,16 +46,16 @@ public class FeatureTests {
     private String testJdkHome = null;
 
     @BeforeTest
-    public void ensureTestJDKSet() {
-        String testJdkHome = System.getenv("TEST_JDK_HOME");
-        if (testJdkHome == null) {
+    public final void ensureTestJDKSet() {
+        String tmpJdkHome = System.getenv("TEST_JDK_HOME");
+        if (tmpJdkHome == null) {
             throw new AssertionError("TEST_JDK_HOME is not set");
         }
-        this.testJdkHome = testJdkHome;
+        this.testJdkHome = tmpJdkHome;
     }
 
     /**
-     * Tests whether JEP 493 is enabled for Eclipse Temurin builds
+     * Tests whether JEP 493 is enabled for Eclipse Temurin builds.
      *
      * @see <a href="https://openjdk.java.net/jeps/493">JEP 493: Linking Run-Time Images without JMODs</a>
      */


### PR DESCRIPTION
This adds a smoke test for Eclipse Temurin builds which, after #4039, would expect the included `jlink` to have the capability enabled.

Grinder with this fix included is here:
https://ci.adoptium.net/job/Grinder/11381/console

Note in particular this output:

```
19:20:04  Nov 14, 2024 6:20:03 PM net.adoptium.test.FeatureTests testLinkableRuntimeJDK24Plus
19:20:04  INFO: Matched 'Capabilities:' line: Linking from run-time image enabled
```

and

```
19:20:04  PASSED: testLinkableRuntimeJDK24Plus
```

While at it I've reduced some code duplication which is now done via `@BeforeTest` once.

Thoughts?