### PR TITLE
Excuse the Otterdog blueprints

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -46,6 +46,7 @@ header:
     - 'security/certdata.txt'
     - 'sbin/*.template'
     - '.github/linters/*'
+    - '.github/workflows/dependabot-auto-merge.yml'
     - 'cyclonedx-lib/getDependencies'
     - 'cyclonedx-lib/dependency_data/**'
     - 'makejdk-any-platform.1'


### PR DESCRIPTION
Otterdog files are provided as templated text, that does not come with a specific license header.