### PR TITLE
Add potential boot location for jdk10 on orka mac

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -114,6 +114,11 @@ if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
     if [ -x "/Library/Java/JavaVirtualMachines/jdk${JDK_BOOT_VERSION}/Contents/Home/bin/javac" ]; then
       echo "Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/jdk${JDK_BOOT_VERSION}/Contents/Home"
       export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/jdk${JDK_BOOT_VERSION}/Contents/Home"
+    elif [ -x "/Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home/bin/javac" ]; then
+      # TODO: This temporary ELIF allows us to accomodate undesired dashes that may be present
+      # in boot directory names (e.g. jdk-10) on Orka node images (fix pending).
+      echo "Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home"
+      export "${BOOT_JDK_VARIABLE}"="/Library/Java/JavaVirtualMachines/jdk-${JDK_BOOT_VERSION}/Contents/Home"
     elif [ "$JDK_BOOT_VERSION" -ge 8 ]; then # Adoptium has no build pre-8
       mkdir -p "$bootDir"
       for releaseType in "ga" "ea"

--- a/tooling/build_autotriage/build_autotriage.sh
+++ b/tooling/build_autotriage/build_autotriage.sh
@@ -59,6 +59,7 @@ temurinPlatforms+=("mac-aarch64");          platformStart+=(11); platformEnd+=(9
 temurinPlatforms+=("mac-x64");              platformStart+=(8);  platformEnd+=(99)
 temurinPlatforms+=("solaris-sparcv9");      platformStart+=(8);  platformEnd+=(8)
 temurinPlatforms+=("solaris-x64");          platformStart+=(8);  platformEnd+=(8)
+temurinPlatforms+=("windows-aarch64");      platformStart+=(21); platformEnd+=(99)
 temurinPlatforms+=("windows-x64");          platformStart+=(8);  platformEnd+=(99)
 temurinPlatforms+=("windows-x86-32");       platformStart+=(8);  platformEnd+=(17)
 


### PR DESCRIPTION
This lets us accommodate the unexpected boot jdk location on Orka nodes until the template can be updated.