### PR TITLE
Fix various SBOM creation problems

### DIFF
--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -204,7 +204,7 @@
                 <property name="testCDXA_JSONFile" location="build/testCDXA.json"/>
                 <delete file="${testCDXA_XMLFile}"/>
                 <delete file="${testCDXA_JSONFile}"/>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenCDXA">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenCDXA" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--createNewCDXA"/>
                   <arg value="--attesting-org-name"/>
@@ -224,7 +224,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testCDXA_XMLFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenCDXA">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenCDXA" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--createNewCDXA"/>
                   <arg value="--attesting-org-name"/>
@@ -251,8 +251,8 @@
                 <property name="testSBOMFile_xml" location="build/testSBOM.xml"/>
                 <delete file="${testSBOMFile}"/>
                 <delete file="${testSBOMFile_xml}"/>
-
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+<echo message="${classpath}"/>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--createNewSBOM"/>
                   <arg value="--name"/>
@@ -263,7 +263,7 @@
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
 
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--createNewSBOM"/>
                   <arg value="--name"/>
@@ -275,7 +275,7 @@
                 </java>
 
                 <!-- JSON tests -->
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -283,7 +283,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -295,7 +295,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -307,7 +307,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -319,7 +319,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -331,7 +331,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-               <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+               <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -339,7 +339,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -351,7 +351,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -363,7 +363,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -373,7 +373,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -385,7 +385,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -397,7 +397,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -407,7 +407,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -419,7 +419,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -427,7 +427,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -439,7 +439,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -451,7 +451,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -461,7 +461,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -473,7 +473,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -481,7 +481,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -493,31 +493,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
-                  <arg value="--verbose"/>
-                  <arg value="--addExternalReference"/>
-                  <arg value="--url"/>
-                  <arg value="https://github.com/adoptium/jdk17/commit/a5afad28437"/>
-                  <arg value="--hashes"/>
-                  <arg value="1234567890123456789012345678901234567890123456789012345678901234"/>
-                  <arg value="--comment"/>
-                  <arg value="openjdk_source"/>
-                  <arg value="--jsonFile"/>
-                  <arg value="${testSBOMFile}"/>
-                </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
-                  <arg value="--verbose"/>
-                  <arg value="--addExternalReference"/>
-                  <arg value="--url"/>
-                  <arg value="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-1.1.6.tar.bz2"/>
-                  <arg value="--hashes"/>
-                  <arg value="1234567890123456789012345678901234567890123456789012345678901234"/>
-                  <arg value="--comment"/>
-                  <arg value="dependency_version_alsa"/>
-                  <arg value="--jsonFile"/>
-                  <arg value="${testSBOMFile}"/>
-                </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addMetadata"/>
                   <arg value="--metadataName"/>
@@ -525,7 +501,27 @@
                   <arg value="--jsonFile"/>
                  <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
+                  <arg value="--verbose"/>
+                  <arg value="--addMetadataTools"/>
+                  <arg value="--tool"/>
+                  <arg value="BOOTJDK"/>
+                  <arg value="--version"/>
+                  <arg value="20.0.2+9"/>
+                  <arg value="--jsonFile"/>
+                 <arg value="${testSBOMFile}"/>
+                </java>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
+                  <arg value="--verbose"/>
+                  <arg value="--addMetadataTools"/>
+                  <arg value="--tool"/>
+                  <arg value="GCC"/>
+                  <arg value="--version"/>
+                  <arg value="10.1"/>
+                  <arg value="--jsonFile"/>
+                 <arg value="${testSBOMFile}"/>
+                </java>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addFormulation"/>
                   <arg value="--formulaName"/>
@@ -533,7 +529,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addFormulationComp"/>
                   <arg value="--formulaName"/>
@@ -543,7 +539,7 @@
                   <arg value="--jsonFile"/>
                   <arg value="${testSBOMFile}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addFormulationCompProp"/>
                   <arg value="--formulaName"/>
@@ -559,7 +555,7 @@
                 </java>
 
                 <!-- XML tests -->
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -567,7 +563,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -579,7 +575,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -591,7 +587,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                  <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -603,7 +599,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -615,7 +611,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-               <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+               <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -623,7 +619,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -635,7 +631,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -647,7 +643,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -657,7 +653,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -669,7 +665,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -681,7 +677,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -691,7 +687,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -703,7 +699,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -711,7 +707,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -723,7 +719,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -735,7 +731,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -745,7 +741,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -757,7 +753,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponent"/>
                   <arg value="--compName"/>
@@ -765,7 +761,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addComponentProp"/>
                   <arg value="--compName"/>
@@ -777,31 +773,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
-                  <arg value="--verbose"/>
-                  <arg value="--addExternalReference"/>
-                  <arg value="--url"/>
-                  <arg value="https://github.com/adoptium/jdk17/commit/a5afad28437"/>
-                  <arg value="--hashes"/>
-                  <arg value="1234567890123456789012345678901234567890123456789012345678901234"/>
-                  <arg value="--comment"/>
-                  <arg value="openjdk_source"/>
-                  <arg value="--xmlFile"/>
-                  <arg value="${testSBOMFile_xml}"/>
-                </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
-                  <arg value="--verbose"/>
-                  <arg value="--addExternalReference"/>
-                  <arg value="--url"/>
-                  <arg value="https://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-1.1.6.tar.bz2"/>
-                  <arg value="--hashes"/>
-                  <arg value="1234567890123456789012345678901234567890123456789012345678901234"/>
-                  <arg value="--comment"/>
-                  <arg value="dependency_version_alsa"/>
-                  <arg value="--xmlFile"/>
-                  <arg value="${testSBOMFile_xml}"/>
-                </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addMetadata"/>
                   <arg value="--metadataName"/>
@@ -809,7 +781,29 @@
                   <arg value="--xmlFile"/>
                  <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+
+
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
+                  <arg value="--verbose"/>
+                  <arg value="--addMetadataTools"/>
+                  <arg value="--tool"/>
+                  <arg value="BOOTJDK"/>
+                  <arg value="--version"/>
+                  <arg value="20.0.2+9"/>
+                  <arg value="--xmlFile"/>
+                 <arg value="${testSBOMFile_xml}"/>
+                </java>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
+                  <arg value="--verbose"/>
+                  <arg value="--addMetadataTools"/>
+                  <arg value="--tool"/>
+                  <arg value="GCC"/>
+                  <arg value="--version"/>
+                  <arg value="10.1"/>
+                  <arg value="--xmlFile"/>
+                 <arg value="${testSBOMFile_xml}"/>
+                </java>
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addFormulation"/>
                   <arg value="--formulaName"/>
@@ -817,7 +811,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addFormulationComp"/>
                   <arg value="--formulaName"/>
@@ -827,7 +821,7 @@
                   <arg value="--xmlFile"/>
                   <arg value="${testSBOMFile_xml}"/>
                 </java>
-                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM">
+                <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addFormulationCompProp"/>
                   <arg value="--formulaName"/>

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -251,7 +251,6 @@
                 <property name="testSBOMFile_xml" location="build/testSBOM.xml"/>
                 <delete file="${testSBOMFile}"/>
                 <delete file="${testSBOMFile_xml}"/>
-<echo message="${classpath}"/>
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--createNewSBOM"/>

--- a/cyclonedx-lib/build.xml
+++ b/cyclonedx-lib/build.xml
@@ -793,16 +793,20 @@
                   <arg value="--xmlFile"/>
                  <arg value="${testSBOMFile_xml}"/>
                 </java>
+
+<!-- This fails for XML until upstream issue is fixed: https://github.com/CycloneDX/cyclonedx-core-java/issues/562
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
-                  <arg value="--verbose"/>
-                  <arg value="--addMetadataTools"/>
-                  <arg value="--tool"/>
+                  <arg value="verbose"/>
+                  <arg value="addMetadataTools"/>
+                  <arg value="tool"/>
                   <arg value="GCC"/>
-                  <arg value="--version"/>
+                  <arg value="version"/>
                   <arg value="10.1"/>
-                  <arg value="--xmlFile"/>
+                  <arg value="xmlFile"/>
                  <arg value="${testSBOMFile_xml}"/>
                 </java>
+-->
+
                 <java classpath="${classpath}" classname="temurin.sbom.TemurinGenSBOM" fork="yes" failonerror="yes">
                   <arg value="--verbose"/>
                   <arg value="--addFormulation"/>

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenCDXA.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenCDXA.java
@@ -102,7 +102,8 @@ public final class TemurinGenCDXA {
             }
         }
 
-        switch (cmd) {
+        try {
+          switch (cmd) {
             case "createCDXA":  // Create a new CDXA json file
                 Bom bom = createCdxa(fileName, attestingOrgName, predicate, targetName, targetUrl, targetHash, affirmationStmt, affirmationWebsite, thirdParty);
                 if (bom != null) {
@@ -113,8 +114,20 @@ public final class TemurinGenCDXA {
                 break;
 
             default:
-                System.out.println("Please enter a command.");
+                // Echo input command:
+                for (int i = 0; i < args.length; i++) {
+                    System.out.print(args[i] + " ");
+                }
+                System.out.println("\nPlease enter a valid command.");
                 System.exit(1);
+          }
+        } catch(Exception e) {
+            // Echo input command:
+            for (int i = 0; i < args.length; i++) {
+                System.out.print(args[i] + " ");
+            }
+            System.out.println("\nException: "+e);
+            System.exit(1);
         }
     }
 

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenCDXA.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenCDXA.java
@@ -121,12 +121,12 @@ public final class TemurinGenCDXA {
                 System.out.println("\nPlease enter a valid command.");
                 System.exit(1);
           }
-        } catch(Exception e) {
+        } catch (Exception e) {
             // Echo input command:
             for (int i = 0; i < args.length; i++) {
                 System.out.print(args[i] + " ");
             }
-            System.out.println("\nException: "+e);
+            System.out.println("\nException: " + e);
             System.exit(1);
         }
     }

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -23,6 +23,7 @@ import org.cyclonedx.model.Component;
 import org.cyclonedx.model.formulation.Formula;
 import org.cyclonedx.model.Hash;
 import org.cyclonedx.model.Metadata;
+import org.cyclonedx.model.metadata.ToolInformation;
 import org.cyclonedx.model.OrganizationalContact;
 import org.cyclonedx.model.OrganizationalEntity;
 import org.cyclonedx.model.Property;
@@ -110,10 +111,6 @@ public final class TemurinGenSBOM {
                 cmd = "addComponentHash";
             } else if (args[i].equals("--addComponentProp")) {       // Components --> Property: will add name-value.
                 cmd = "addComponentProp";
-            } else if (args[i].equals("--addExternalReference")) {
-                cmd = "addExternalReference";
-            } else if (args[i].equals("--addComponentExtRef")) {
-                cmd = "addComponentExternalReference";
             } else if (args[i].equals("--addMetadataTools")) {
                 cmd = "addMetadataTools";
             } else if (args[i].equals("--addFormulation")) {        // Formulation Component. We can set "name" for Formulation.
@@ -126,7 +123,8 @@ public final class TemurinGenSBOM {
                 verbose = true;
             }
         }
-        switch (cmd) {
+        try {
+          switch (cmd) {
             case "createNewSBOM":                                    // Creates new SBOM
                 Bom bom = createBom();
                 writeFile(bom, fileName);
@@ -182,7 +180,21 @@ public final class TemurinGenSBOM {
                 break;
 
             default:
-                System.out.println("Please enter a command.");
+                // Echo input command:
+                for (int i = 0; i < args.length; i++) {
+                    System.out.print(args[i] + " ");
+                }
+                System.out.println("\nPlease enter a valid command.");
+                System.exit(1);
+          }
+        } catch(Exception e) {
+            // Echo input command:
+            for (int i = 0; i < args.length; i++) {
+                System.out.print(args[i] + " ");
+            }
+            System.out.println("\nException: "+e);
+e.printStackTrace();
+            System.exit(1);
         }
     }
 
@@ -196,10 +208,19 @@ public final class TemurinGenSBOM {
         return bom;
     }
 
+    // Create Metadata if it doesn't exist
+    static Metadata getBomMetadata(Bom bom) {
+        Metadata metadata = bom.getMetadata();
+        if (metadata == null) {
+            metadata = new Metadata();
+        }
+        return metadata;
+    }
+
     // Method to store Metadata --> name.
     static Bom addMetadata(final String fileName) {
         Bom bom = readFile(fileName);
-        Metadata meta = new Metadata();
+        Metadata meta = getBomMetadata(bom);
         OrganizationalEntity org = new OrganizationalEntity();
         org.setName("Eclipse Foundation");
         org.setUrls(Collections.singletonList("https://www.eclipse.org/"));
@@ -213,7 +234,7 @@ public final class TemurinGenSBOM {
 
     static Bom addMetadataComponent(final String fileName, final String name, final String type, final String version, final String description) {
         Bom bom = readFile(fileName);
-        Metadata meta = new Metadata();
+        Metadata meta = getBomMetadata(bom);
         Component comp = new Component();
         Component.Type compType = Component.Type.FRAMEWORK;
         switch (type) {
@@ -235,9 +256,8 @@ public final class TemurinGenSBOM {
     // Method to store Metadata --> Properties List --> name-values.
     static Bom addMetadataProperty(final String fileName, final String name, final String value) {
         Bom bom = readFile(fileName);
-        Metadata meta = new Metadata();
+        Metadata meta = getBomMetadata(bom);
         Property prop1 = new Property();
-        meta = bom.getMetadata();
         prop1.setName(name);
         prop1.setValue(value);
         meta.addProperty(prop1);
@@ -247,12 +267,30 @@ public final class TemurinGenSBOM {
 
     static Bom addMetadataTools(final String fileName, final String toolName, final String version) {
         Bom bom = readFile(fileName);
-        Metadata meta = new Metadata();
-        Tool tool = new Tool();
-        meta = bom.getMetadata();
+        Metadata meta = getBomMetadata(bom);
+
+        // Create Tool Component
+        Component tool = new Component();
+        tool.setType(Component.Type.APPLICATION);
         tool.setName(toolName);
         tool.setVersion(version);
-        meta.addTool(tool);
+
+        // Create ToolInformation if not already
+        ToolInformation tools = meta.getToolChoice();
+        if (tools == null) {
+            tools = new ToolInformation();
+        }
+
+        // Create new components array, add existing to it
+        List<Component> components = tools.getComponents();
+        if (components == null) {
+            components = new LinkedList<Component>();
+        }
+
+        components.add(tool);
+        tools.setComponents(components);
+        meta.setToolChoice(tools);
+
         bom.setMetadata(meta);
         return bom;
     }

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -27,7 +27,6 @@ import org.cyclonedx.model.metadata.ToolInformation;
 import org.cyclonedx.model.OrganizationalContact;
 import org.cyclonedx.model.OrganizationalEntity;
 import org.cyclonedx.model.Property;
-import org.cyclonedx.model.Tool;
 import org.cyclonedx.parsers.JsonParser;
 import org.cyclonedx.parsers.XmlParser;
 import org.cyclonedx.Version;
@@ -187,12 +186,12 @@ public final class TemurinGenSBOM {
                 System.out.println("\nPlease enter a valid command.");
                 System.exit(1);
           }
-        } catch(Exception e) {
+        } catch (Exception e) {
             // Echo input command:
             for (int i = 0; i < args.length; i++) {
                 System.out.print(args[i] + " ");
             }
-            System.out.println("\nException: "+e);
+            System.out.println("\nException: " + e);
             System.exit(1);
         }
     }
@@ -208,7 +207,7 @@ public final class TemurinGenSBOM {
     }
 
     // Create Metadata if it doesn't exist
-    static Metadata getBomMetadata(Bom bom) {
+    static Metadata getBomMetadata(final Bom bom) {
         Metadata metadata = bom.getMetadata();
         if (metadata == null) {
             metadata = new Metadata();

--- a/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
+++ b/cyclonedx-lib/src/temurin/sbom/TemurinGenSBOM.java
@@ -193,7 +193,6 @@ public final class TemurinGenSBOM {
                 System.out.print(args[i] + " ");
             }
             System.out.println("\nException: "+e);
-e.printStackTrace();
             System.exit(1);
         }
     }

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -979,7 +979,7 @@ generateSBoM() {
   local fullVer=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersion.txt")
   local fullVerOutput=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersionOutput.txt")
 
-  # Create initial SBOMjson 
+  # Create initial SBOM json 
   createSBOMFile "${javaHome}" "${classpath}" "${sbomJson}"
   # Set default SBOM metadata
   addSBOMMetadata "${javaHome}" "${classpath}" "${sbomJson}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -979,7 +979,7 @@ generateSBoM() {
   local fullVer=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersion.txt")
   local fullVerOutput=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersionOutput.txt")
 
-  # Create initial SBOM json 
+  # Create initial SBOM json
   createSBOMFile "${javaHome}" "${classpath}" "${sbomJson}"
   # Set default SBOM metadata
   addSBOMMetadata "${javaHome}" "${classpath}" "${sbomJson}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1256,7 +1256,7 @@ addCycloneDXVersions() {
          JarVersionString=$(grep "${JarName}\.version=" "${JarDepsFile}" | cut -d'=' -f2)
          if [ -n "${JarVersionString}" ]; then
            addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar versions" "${JarName}.jar" "${JarVersionString}"
-         elif [ "${JarName}" != "temurin-gen-sbom" ]; then
+         elif [ "${JarName}" != "temurin-gen-sbom" ] && [ "${JarName}" != "temurin-gen-cdxa" ]; then
            echo "ERROR: Cannot determine jar version from ${JarDepsFile} for SBOM creation dependency ${JarName}.jar."
          fi
        done

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -928,14 +928,15 @@ getCyclonedxClasspath() {
 
   local CYCLONEDB_JAR_DIR="${CYCLONEDB_DIR}/build/jar"
 
-  local classpath="${CYCLONEDB_JAR_DIR}/temurin-gen-sbom.jar:${CYCLONEDB_JAR_DIR}/cyclonedx-core-java.jar:${CYCLONEDB_JAR_DIR}/jackson-core.jar:${CYCLONEDB_JAR_DIR}/jackson-dataformat-xml.jar:${CYCLONEDB_JAR_DIR}/jackson-databind.jar:${CYCLONEDB_JAR_DIR}/jackson-annotations.jar:${CYCLONEDB_JAR_DIR}/json-schema-validator.jar:${CYCLONEDB_JAR_DIR}/commons-codec.jar:${CYCLONEDB_JAR_DIR}/commons-io.jar:${CYCLONEDB_JAR_DIR}/github-package-url.jar:${CYCLONEDB_JAR_DIR}/commons-collections4.jar"
+  local classpath="${CYCLONEDB_JAR_DIR}/temurin-gen-sbom.jar:${CYCLONEDB_JAR_DIR}/cyclonedx-core-java.jar:${CYCLONEDB_JAR_DIR}/jackson-core.jar:${CYCLONEDB_JAR_DIR}/jackson-dataformat-xml.jar:${CYCLONEDB_JAR_DIR}/jackson-databind.jar:${CYCLONEDB_JAR_DIR}/jackson-annotations.jar:${CYCLONEDB_JAR_DIR}/json-schema-validator.jar:${CYCLONEDB_JAR_DIR}/commons-codec.jar:${CYCLONEDB_JAR_DIR}/commons-io.jar:${CYCLONEDB_JAR_DIR}/github-package-url.jar:${CYCLONEDB_JAR_DIR}/commons-collections4.jar:${CYCLONEDB_JAR_DIR}/stax2-api.jar:${CYCLONEDB_JAR_DIR}/woodstox-core.jar:${CYCLONEDB_JAR_DIR}/commons-lang3.jar"
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     classpath=""
     for jarfile in "${CYCLONEDB_JAR_DIR}/temurin-gen-sbom.jar" "${CYCLONEDB_JAR_DIR}/cyclonedx-core-java.jar" \
       "${CYCLONEDB_JAR_DIR}/jackson-core.jar" "${CYCLONEDB_JAR_DIR}/jackson-dataformat-xml.jar" \
       "${CYCLONEDB_JAR_DIR}/jackson-databind.jar" "${CYCLONEDB_JAR_DIR}/jackson-annotations.jar" \
       "${CYCLONEDB_JAR_DIR}/json-schema-validator.jar" "${CYCLONEDB_JAR_DIR}/commons-codec.jar" "${CYCLONEDB_JAR_DIR}/commons-io.jar" \
-      "${CYCLONEDB_JAR_DIR}/github-package-url.jar" "${CYCLONEDB_JAR_DIR}/commons-collections4.jar";
+      "${CYCLONEDB_JAR_DIR}/github-package-url.jar" "${CYCLONEDB_JAR_DIR}/commons-collections4.jar" \
+      "${CYCLONEDB_JAR_DIR}/stax2-api.jar" "${CYCLONEDB_JAR_DIR}/woodstox-core.jar" "${CYCLONEDB_JAR_DIR}/commons-lang3.jar";
     do
       classpath+=$(cygpath -w "${jarfile}")";"
     done
@@ -964,46 +965,46 @@ generateSBoM() {
   local sbomTargetName=$(getTargetFileNameForComponent "sbom")
   # Remove the tarball / zip extension from the name to be used for the SBOM
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    sbomTargetName=$(echo "${sbomTargetName}.json" | sed "s/\.zip//")
+    sbomTargetName=$(echo "${sbomTargetName}.xml" | sed "s/\.zip//")
   else
-    sbomTargetName=$(echo "${sbomTargetName}.json" | sed "s/\.tar\.gz//")
+    sbomTargetName=$(echo "${sbomTargetName}.xml" | sed "s/\.tar\.gz//")
   fi
 
-  local sbomJson="$(joinPathOS ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]} ${sbomTargetName})"
-  echo "OpenJDK SBOM will be ${sbomJson}."
+  local sbomXml="$(joinPathOS ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]} ${sbomTargetName})"
+  echo "OpenJDK SBOM will be ${sbomXml}."
 
-  # Clean any old json
-  rm -f "${sbomJson}"
+  # Clean any old xml
+  rm -f "${sbomXml}"
 
   local fullVer=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersion.txt")
   local fullVerOutput=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersionOutput.txt")
 
-  # Create initial SBOM json
-  createSBOMFile "${javaHome}" "${classpath}" "${sbomJson}"
+  # Create initial SBOM xml
+  createSBOMFile "${javaHome}" "${classpath}" "${sbomXml}"
   # Set default SBOM metadata
-  addSBOMMetadata "${javaHome}" "${classpath}" "${sbomJson}"
+  addSBOMMetadata "${javaHome}" "${classpath}" "${sbomXml}"
 
   # Create component to metadata in SBOM
-  addSBOMMetadataComponent "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "framework" "${fullVer}" "Eclipse Temurin components"
+  addSBOMMetadataComponent "${javaHome}" "${classpath}" "${sbomXml}" "Eclipse Temurin" "framework" "${fullVer}" "Eclipse Temurin components"
 
   # Below add property to metadata
   # Add OS full version (Kernel is covered in the first field)
-  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS version" "${BUILD_CONFIG[OS_FULL_VERSION]^}"
+  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS version" "${BUILD_CONFIG[OS_FULL_VERSION]^}"
   # TODO: Replace this "if" with its predecessor (commented out below) once
   # OS_ARCHITECTURE has been replaced by the new target architecture variable.
   # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
   # and that confuses things when cross-compiling an x64 mac build on arm mac.
-  #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
+  #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS architecture" "x86_64"
   else
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   fi
 
   # Set default SBOM formulation
-  addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX"
-  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar SHAs"
-  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar versions"
+  addSBOMFormulation "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX"
+  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar SHAs"
+  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar versions"
 
   # Below add build tools into metadata tools
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ]; then
@@ -1030,7 +1031,7 @@ generateSBoM() {
   # Add FreeMarker 3rd party (openj9)
   local freemarker_version="$(joinPathOS ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]} 'metadata/dependency_version_freemarker.txt')"
   if [ -f "${freemarker_version}" ]; then
-      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "FreeMarker" "$(cat ${freemarker_version})"
+      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "FreeMarker" "$(cat ${freemarker_version})"
   fi
   # Add CycloneDX versions
   addCycloneDXVersions
@@ -1039,10 +1040,10 @@ generateSBoM() {
   local buildimagesha=$(cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/docker.txt)
   # ${BUILD_CONFIG[CONTAINER_COMMAND]^} always set to false cannot rely on it.
   if [ -n "${buildimagesha}" ] && [ "${buildimagesha}" != "N.A" ]; then
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "Use Docker for build" "true"
-    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "Docker image SHA1" "${buildimagesha}"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "Use Docker for build" "true"
+    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "Docker image SHA1" "${buildimagesha}"
   else
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "Use Docker for build" "false"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "Use Docker for build" "false"
   fi
 
   checkingToolSummary
@@ -1079,41 +1080,41 @@ generateSBoM() {
     local sha=$(sha256File "${archiveFile}")
 
     # Create JDK Component
-    addSBOMComponent "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "${fullVer}" "${BUILD_CONFIG[BUILD_VARIANT]^} ${component} Component"
+    addSBOMComponent "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "${fullVer}" "${BUILD_CONFIG[BUILD_VARIANT]^} ${component} Component"
 
     # Add SHA256 hash for the component
-    addSBOMComponentHash "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "${sha}"
+    addSBOMComponentHash "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "${sha}"
 
     # Below add different properties to JDK component
     # Add target archive name as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Filename" "${archiveName}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Filename" "${archiveName}"
     # Add variant as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "JDK Variant" "${BUILD_CONFIG[BUILD_VARIANT]^}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "JDK Variant" "${BUILD_CONFIG[BUILD_VARIANT]^}"
     # Add scmRef as JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "SCM Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "SCM Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
     # Add OpenJDK source ref commit as JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "OpenJDK Source Commit" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "OpenJDK Source Commit" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"
     # Add buildRef as JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Temurin Build Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Temurin Build Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
     # Add jenkins job ID as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Builder Job Reference" "${BUILD_URL:-N.A}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Builder Job Reference" "${BUILD_URL:-N.A}"
     # Add jenkins builder (agent/machine name) as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Builder Name" "${NODE_NAME:-N.A}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Builder Name" "${NODE_NAME:-N.A}"
 
     # Add build timestamp
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Build Timestamp" "${BUILD_CONFIG[BUILD_TIMESTAMP]}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Build Timestamp" "${BUILD_CONFIG[BUILD_TIMESTAMP]}"
 
     # Add Tool Summary section from configure.txt
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Build Tools Summary" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_tool_sum.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Build Tools Summary" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_tool_sum.txt"
     # Add builtConfig JDK Component Property, load as Json string
     built_config=$(createConfigToJsonString)
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Build Config" "${built_config}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Build Config" "${built_config}"
     # Add full_version_output JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "full_version_output" "${fullVerOutput}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "full_version_output" "${fullVerOutput}"
     # Add makejdk_any_platform_args JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "makejdk_any_platform_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/config/makejdk-any-platform.args"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "makejdk_any_platform_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/config/makejdk-any-platform.args"
     # Add make_command_args JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
   done
 
 
@@ -1158,11 +1159,11 @@ generateSBoM() {
     devkit_path=$(echo ${devkit_path} | sed 's,\./,,' | sed 's,//,/,')
     bootjdk_path=$(echo ${bootjdk_path} | sed 's,\./,,' | sed 's,//,/,')
 
-    bash "$SCRIPT_DIR/../tooling/strace_analysis.sh" "${straceOutputDir}" "${temurinBuildDir}" "${bootjdk_path}" "${classpath}" "${sbomJson}" "${buildOutputDir}" "${openjdkSrcDir}" "${javaHome}" "${toolchain_path}"
+    bash "$SCRIPT_DIR/../tooling/strace_analysis.sh" "${straceOutputDir}" "${temurinBuildDir}" "${bootjdk_path}" "${classpath}" "${sbomXml}" "${buildOutputDir}" "${openjdkSrcDir}" "${javaHome}" "${toolchain_path}"
   fi
 
   # Print SBOM location
-  echo "CycloneDX SBOM has been created in ${sbomJson}"
+  echo "CycloneDX SBOM has been created in ${sbomXml}"
 }
 
 # Generate build tools info into dependency file
@@ -1233,7 +1234,7 @@ addFreeTypeVersionInfo() {
       version="${ver_major}.${ver_minor}.${ver_patch}"
    fi
 
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "FreeType" "${version}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "FreeType" "${version}"
 }
 
 # Determine and store CycloneDX SHAs that have been used to provide the SBOMs
@@ -1249,12 +1250,12 @@ addCycloneDXVersions() {
          else
             JarSha=$(sha256sum "$JAR" | cut -d' ' -f1)
          fi
-         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar SHAs" "${JarName}.jar" "${JarSha}"
+         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar SHAs" "${JarName}.jar" "${JarSha}"
          # Now the jar's SHA has been added, we add the version string.
          JarDepsFile="$(joinPath ${CYCLONEDB_DIR} dependency_data/dependency_data.properties)"
          JarVersionString=$(grep "${JarName}\.version=" "${JarDepsFile}" | cut -d'=' -f2)
          if [ -n "${JarVersionString}" ]; then
-           addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar versions" "${JarName}.jar" "${JarVersionString}"
+           addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar versions" "${JarName}.jar" "${JarVersionString}"
          elif [ "${JarName}" != "temurin-gen-sbom" ]; then
            echo "ERROR: Cannot determine jar version from ${JarDepsFile} for SBOM creation dependency ${JarName}.jar."
          fi
@@ -1295,7 +1296,7 @@ addALSAVersion() {
        fi
 
        echo "Adding ALSA version to SBOM: ${ALSA_VERSION}"
-       addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "ALSA" "${ALSA_VERSION}"
+       addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "ALSA" "${ALSA_VERSION}"
      fi
 }
 
@@ -1354,7 +1355,7 @@ addGLIBCforLinux() {
      # Get musl build ldd version
      local MUSL_VERSION="$(ldd --version 2>&1 | grep "Version" | tr -s " " | cut -d" " -f2)"
      echo "Adding MUSL version to SBOM: ${MUSL_VERSION}"
-     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"
+     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MUSL" "${MUSL_VERSION}"
    else
      # Get GLIBC from configured build spec.gmk sysroot and features.h definitions
      local GLIBC_MAJOR=$(getHeaderPropertyUsingCompiler "features.h" "#define[ ]+__GLIBC__")
@@ -1362,7 +1363,7 @@ addGLIBCforLinux() {
      local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"
 
      echo "Adding GLIBC version to SBOM: ${GLIBC_VERSION}"
-     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GLIBC" "${GLIBC_VERSION}"
+     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "GLIBC" "${GLIBC_VERSION}"
    fi
 }
 
@@ -1372,7 +1373,7 @@ addGCC() {
    local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | tr -s " " | grep "C Compiler: Version" | cut -d" " -f5)"
 
    echo "Adding GCC version to SBOM: ${gcc_version}"
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GCC" "${gcc_version}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "GCC" "${gcc_version}"
 }
 
 addCompilerWindows() {
@@ -1392,13 +1393,13 @@ addCompilerWindows() {
   local msvs_cpp_version="$(grep -o -P '\* C\+\+ Compiler:\s+\K[^"]+' "${inputConfigFile}" | awk '{print $2}')"
 
   echo "Adding Windows Compiler versions to SBOM: ${msvs_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MSVS Windows Compiler Version" "${msvs_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MSVS Windows Compiler Version" "${msvs_version}"
   echo "Adding Windows C Compiler version to SBOM: ${msvs_c_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MSVS C Compiler Version" "${msvs_c_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MSVS C Compiler Version" "${msvs_c_version}"
   echo "Adding Windows C++ Compiler version to SBOM: ${msvs_cpp_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MSVS C++ Compiler Version" "${msvs_cpp_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MSVS C++ Compiler Version" "${msvs_cpp_version}"
   echo "Adding Windows SDK version to SBOM: ${ucrt_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MS Windows SDK Version" "${ucrt_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MS Windows SDK Version" "${ucrt_version}"
 }
 
 addCompilerMacOS() {
@@ -1408,7 +1409,7 @@ addCompilerMacOS() {
   local macx_version="$(grep ".* Toolchain:" "${inputConfigFile}" | awk -F ':' '{print $2}' | sed -e 's/^[ \t]*//')"
 
   echo "Adding MacOS compiler version to SBOM: ${macx_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MacOS Compiler" "${macx_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MacOS Compiler" "${macx_version}"
 }
 
 addBootJDK() {
@@ -1423,7 +1424,7 @@ addBootJDK() {
    local bootjdk="$("${bootjava}" -XshowSettings 2>&1 | grep "java\.runtime\.version" | tr -s " " | cut -d" " -f4 | sed "s/\"//g")"
 
    echo "Adding BOOTJDK to SBOM: ${bootjdk}"
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "BOOTJDK" "${bootjdk}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "BOOTJDK" "${bootjdk}"
 }
 
 getGradleJavaHome() {

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -965,46 +965,46 @@ generateSBoM() {
   local sbomTargetName=$(getTargetFileNameForComponent "sbom")
   # Remove the tarball / zip extension from the name to be used for the SBOM
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    sbomTargetName=$(echo "${sbomTargetName}.xml" | sed "s/\.zip//")
+    sbomTargetName=$(echo "${sbomTargetName}.json" | sed "s/\.zip//")
   else
-    sbomTargetName=$(echo "${sbomTargetName}.xml" | sed "s/\.tar\.gz//")
+    sbomTargetName=$(echo "${sbomTargetName}.json" | sed "s/\.tar\.gz//")
   fi
 
-  local sbomXml="$(joinPathOS ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]} ${sbomTargetName})"
-  echo "OpenJDK SBOM will be ${sbomXml}."
+  local sbomJson="$(joinPathOS ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]} ${sbomTargetName})"
+  echo "OpenJDK SBOM will be ${sbomJson}."
 
-  # Clean any old xml
-  rm -f "${sbomXml}"
+  # Clean any old json
+  rm -f "${sbomJson}"
 
   local fullVer=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersion.txt")
   local fullVerOutput=$(cat "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/productVersionOutput.txt")
 
-  # Create initial SBOM xml
-  createSBOMFile "${javaHome}" "${classpath}" "${sbomXml}"
+  # Create initial SBOMjson 
+  createSBOMFile "${javaHome}" "${classpath}" "${sbomJson}"
   # Set default SBOM metadata
-  addSBOMMetadata "${javaHome}" "${classpath}" "${sbomXml}"
+  addSBOMMetadata "${javaHome}" "${classpath}" "${sbomJson}"
 
   # Create component to metadata in SBOM
-  addSBOMMetadataComponent "${javaHome}" "${classpath}" "${sbomXml}" "Eclipse Temurin" "framework" "${fullVer}" "Eclipse Temurin components"
+  addSBOMMetadataComponent "${javaHome}" "${classpath}" "${sbomJson}" "Eclipse Temurin" "framework" "${fullVer}" "Eclipse Temurin components"
 
   # Below add property to metadata
   # Add OS full version (Kernel is covered in the first field)
-  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS version" "${BUILD_CONFIG[OS_FULL_VERSION]^}"
+  addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS version" "${BUILD_CONFIG[OS_FULL_VERSION]^}"
   # TODO: Replace this "if" with its predecessor (commented out below) once
   # OS_ARCHITECTURE has been replaced by the new target architecture variable.
   # This is because OS_ARCHITECTURE is currently the build arch, not the target arch,
   # and that confuses things when cross-compiling an x64 mac build on arm mac.
-  #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
+  #   addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   if [[ "${BUILD_CONFIG[TARGET_FILE_NAME]}" =~ .*_x64_.* ]]; then
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS architecture" "x86_64"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "x86_64"
   else
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "OS architecture" "${BUILD_CONFIG[OS_ARCHITECTURE]^}"
   fi
 
   # Set default SBOM formulation
-  addSBOMFormulation "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX"
-  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar SHAs"
-  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar versions"
+  addSBOMFormulation "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX"
+  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar SHAs"
+  addSBOMFormulationComp "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar versions"
 
   # Below add build tools into metadata tools
   if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ]; then
@@ -1031,7 +1031,7 @@ generateSBoM() {
   # Add FreeMarker 3rd party (openj9)
   local freemarker_version="$(joinPathOS ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]} 'metadata/dependency_version_freemarker.txt')"
   if [ -f "${freemarker_version}" ]; then
-      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "FreeMarker" "$(cat ${freemarker_version})"
+      addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "FreeMarker" "$(cat ${freemarker_version})"
   fi
   # Add CycloneDX versions
   addCycloneDXVersions
@@ -1040,10 +1040,10 @@ generateSBoM() {
   local buildimagesha=$(cat ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/docker.txt)
   # ${BUILD_CONFIG[CONTAINER_COMMAND]^} always set to false cannot rely on it.
   if [ -n "${buildimagesha}" ] && [ "${buildimagesha}" != "N.A" ]; then
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "Use Docker for build" "true"
-    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "Docker image SHA1" "${buildimagesha}"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "Use Docker for build" "true"
+    addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "Docker image SHA1" "${buildimagesha}"
   else
-    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomXml}" "Use Docker for build" "false"
+    addSBOMMetadataProperty "${javaHome}" "${classpath}" "${sbomJson}" "Use Docker for build" "false"
   fi
 
   checkingToolSummary
@@ -1080,41 +1080,41 @@ generateSBoM() {
     local sha=$(sha256File "${archiveFile}")
 
     # Create JDK Component
-    addSBOMComponent "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "${fullVer}" "${BUILD_CONFIG[BUILD_VARIANT]^} ${component} Component"
+    addSBOMComponent "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "${fullVer}" "${BUILD_CONFIG[BUILD_VARIANT]^} ${component} Component"
 
     # Add SHA256 hash for the component
-    addSBOMComponentHash "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "${sha}"
+    addSBOMComponentHash "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "${sha}"
 
     # Below add different properties to JDK component
     # Add target archive name as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Filename" "${archiveName}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Filename" "${archiveName}"
     # Add variant as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "JDK Variant" "${BUILD_CONFIG[BUILD_VARIANT]^}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "JDK Variant" "${BUILD_CONFIG[BUILD_VARIANT]^}"
     # Add scmRef as JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "SCM Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "SCM Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/scmref.txt"
     # Add OpenJDK source ref commit as JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "OpenJDK Source Commit" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "OpenJDK Source Commit" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/openjdkSource.txt"
     # Add buildRef as JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Temurin Build Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Temurin Build Ref" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/buildSource.txt"
     # Add jenkins job ID as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Builder Job Reference" "${BUILD_URL:-N.A}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Builder Job Reference" "${BUILD_URL:-N.A}"
     # Add jenkins builder (agent/machine name) as JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Builder Name" "${NODE_NAME:-N.A}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Builder Name" "${NODE_NAME:-N.A}"
 
     # Add build timestamp
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Build Timestamp" "${BUILD_CONFIG[BUILD_TIMESTAMP]}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Build Timestamp" "${BUILD_CONFIG[BUILD_TIMESTAMP]}"
 
     # Add Tool Summary section from configure.txt
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Build Tools Summary" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_tool_sum.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Build Tools Summary" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/dependency_tool_sum.txt"
     # Add builtConfig JDK Component Property, load as Json string
     built_config=$(createConfigToJsonString)
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "Build Config" "${built_config}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "Build Config" "${built_config}"
     # Add full_version_output JDK Component Property
-    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "full_version_output" "${fullVerOutput}"
+    addSBOMComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "full_version_output" "${fullVerOutput}"
     # Add makejdk_any_platform_args JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "makejdk_any_platform_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/config/makejdk-any-platform.args"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "makejdk_any_platform_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/config/makejdk-any-platform.args"
     # Add make_command_args JDK Component Property
-    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomXml}" "${componentName}" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
+    addSBOMComponentPropertyFromFile "${javaHome}" "${classpath}" "${sbomJson}" "${componentName}" "make_command_args" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/makeCommandArg.txt"
   done
 
 
@@ -1159,11 +1159,11 @@ generateSBoM() {
     devkit_path=$(echo ${devkit_path} | sed 's,\./,,' | sed 's,//,/,')
     bootjdk_path=$(echo ${bootjdk_path} | sed 's,\./,,' | sed 's,//,/,')
 
-    bash "$SCRIPT_DIR/../tooling/strace_analysis.sh" "${straceOutputDir}" "${temurinBuildDir}" "${bootjdk_path}" "${classpath}" "${sbomXml}" "${buildOutputDir}" "${openjdkSrcDir}" "${javaHome}" "${toolchain_path}"
+    bash "$SCRIPT_DIR/../tooling/strace_analysis.sh" "${straceOutputDir}" "${temurinBuildDir}" "${bootjdk_path}" "${classpath}" "${sbomJson}" "${buildOutputDir}" "${openjdkSrcDir}" "${javaHome}" "${toolchain_path}"
   fi
 
   # Print SBOM location
-  echo "CycloneDX SBOM has been created in ${sbomXml}"
+  echo "CycloneDX SBOM has been created in ${sbomJson}"
 }
 
 # Generate build tools info into dependency file
@@ -1234,7 +1234,7 @@ addFreeTypeVersionInfo() {
       version="${ver_major}.${ver_minor}.${ver_patch}"
    fi
 
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "FreeType" "${version}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "FreeType" "${version}"
 }
 
 # Determine and store CycloneDX SHAs that have been used to provide the SBOMs
@@ -1250,12 +1250,12 @@ addCycloneDXVersions() {
          else
             JarSha=$(sha256sum "$JAR" | cut -d' ' -f1)
          fi
-         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar SHAs" "${JarName}.jar" "${JarSha}"
+         addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar SHAs" "${JarName}.jar" "${JarSha}"
          # Now the jar's SHA has been added, we add the version string.
          JarDepsFile="$(joinPath ${CYCLONEDB_DIR} dependency_data/dependency_data.properties)"
          JarVersionString=$(grep "${JarName}\.version=" "${JarDepsFile}" | cut -d'=' -f2)
          if [ -n "${JarVersionString}" ]; then
-           addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomXml}" "CycloneDX" "CycloneDX jar versions" "${JarName}.jar" "${JarVersionString}"
+           addSBOMFormulationComponentProperty "${javaHome}" "${classpath}" "${sbomJson}" "CycloneDX" "CycloneDX jar versions" "${JarName}.jar" "${JarVersionString}"
          elif [ "${JarName}" != "temurin-gen-sbom" ] && [ "${JarName}" != "temurin-gen-cdxa" ]; then
            echo "ERROR: Cannot determine jar version from ${JarDepsFile} for SBOM creation dependency ${JarName}.jar."
          fi
@@ -1296,7 +1296,7 @@ addALSAVersion() {
        fi
 
        echo "Adding ALSA version to SBOM: ${ALSA_VERSION}"
-       addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "ALSA" "${ALSA_VERSION}"
+       addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "ALSA" "${ALSA_VERSION}"
      fi
 }
 
@@ -1355,7 +1355,7 @@ addGLIBCforLinux() {
      # Get musl build ldd version
      local MUSL_VERSION="$(ldd --version 2>&1 | grep "Version" | tr -s " " | cut -d" " -f2)"
      echo "Adding MUSL version to SBOM: ${MUSL_VERSION}"
-     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MUSL" "${MUSL_VERSION}"
+     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MUSL" "${MUSL_VERSION}"
    else
      # Get GLIBC from configured build spec.gmk sysroot and features.h definitions
      local GLIBC_MAJOR=$(getHeaderPropertyUsingCompiler "features.h" "#define[ ]+__GLIBC__")
@@ -1363,7 +1363,7 @@ addGLIBCforLinux() {
      local GLIBC_VERSION="${GLIBC_MAJOR}.${GLIBC_MINOR}"
 
      echo "Adding GLIBC version to SBOM: ${GLIBC_VERSION}"
-     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "GLIBC" "${GLIBC_VERSION}"
+     addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GLIBC" "${GLIBC_VERSION}"
    fi
 }
 
@@ -1373,7 +1373,7 @@ addGCC() {
    local gcc_version="$(sed -n '/^Tools summary:$/,$p' "${inputConfigFile}" | tr -s " " | grep "C Compiler: Version" | cut -d" " -f5)"
 
    echo "Adding GCC version to SBOM: ${gcc_version}"
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "GCC" "${gcc_version}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "GCC" "${gcc_version}"
 }
 
 addCompilerWindows() {
@@ -1393,13 +1393,13 @@ addCompilerWindows() {
   local msvs_cpp_version="$(grep -o -P '\* C\+\+ Compiler:\s+\K[^"]+' "${inputConfigFile}" | awk '{print $2}')"
 
   echo "Adding Windows Compiler versions to SBOM: ${msvs_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MSVS Windows Compiler Version" "${msvs_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MSVS Windows Compiler Version" "${msvs_version}"
   echo "Adding Windows C Compiler version to SBOM: ${msvs_c_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MSVS C Compiler Version" "${msvs_c_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MSVS C Compiler Version" "${msvs_c_version}"
   echo "Adding Windows C++ Compiler version to SBOM: ${msvs_cpp_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MSVS C++ Compiler Version" "${msvs_cpp_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MSVS C++ Compiler Version" "${msvs_cpp_version}"
   echo "Adding Windows SDK version to SBOM: ${ucrt_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MS Windows SDK Version" "${ucrt_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MS Windows SDK Version" "${ucrt_version}"
 }
 
 addCompilerMacOS() {
@@ -1409,7 +1409,7 @@ addCompilerMacOS() {
   local macx_version="$(grep ".* Toolchain:" "${inputConfigFile}" | awk -F ':' '{print $2}' | sed -e 's/^[ \t]*//')"
 
   echo "Adding MacOS compiler version to SBOM: ${macx_version}"
-  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "MacOS Compiler" "${macx_version}"
+  addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "MacOS Compiler" "${macx_version}"
 }
 
 addBootJDK() {
@@ -1424,7 +1424,7 @@ addBootJDK() {
    local bootjdk="$("${bootjava}" -XshowSettings 2>&1 | grep "java\.runtime\.version" | tr -s " " | cut -d" " -f4 | sed "s/\"//g")"
 
    echo "Adding BOOTJDK to SBOM: ${bootjdk}"
-   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomXml}" "BOOTJDK" "${bootjdk}"
+   addSBOMMetadataTools "${javaHome}" "${classpath}" "${sbomJson}" "BOOTJDK" "${bootjdk}"
 }
 
 getGradleJavaHome() {

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -22,11 +22,11 @@ SBOMFILE="$1"
 MAJORVERSION="$2"
 #FULLVERSION="$3"
 
-GLIBC=$(jq '.metadata.tools[] | select(.name|test("GLIBC")) | .version'           "$1" | tr -d \")
-GCC=$(jq '.metadata.tools[] | select(.name|test("GCC")) | .version'               "$1" | tr -d \")
-BOOTJDK=$(jq '.metadata.tools[] | select(.name|test("BOOTJDK")) | .version'       "$1"  | tr -d \")
-ALSA=$(jq '.metadata.tools[] | select(.name|test("ALSA")) | .version'             "$1" | tr -d \" | sed -e 's/^.*alsa-lib-//' -e 's/\.tar.bz2//')
-FREETYPE=$(jq '.metadata.tools[] | select(.name|test("FreeType")) | .version'     "$1"  | tr -d \")
+GLIBC=$(jq '.metadata.tools.components[] | select(.name|test("GLIBC")) | .version'           "$1" | tr -d \")
+GCC=$(jq '.metadata.tools.components[] | select(.name|test("GCC")) | .version'               "$1" | tr -d \")
+BOOTJDK=$(jq '.metadata.tools.components[] | select(.name|test("BOOTJDK")) | .version'       "$1"  | tr -d \")
+ALSA=$(jq '.metadata.tools.components[] | select(.name|test("ALSA")) | .version'             "$1" | tr -d \" | sed -e 's/^.*alsa-lib-//' -e 's/\.tar.bz2//')
+FREETYPE=$(jq '.metadata.tools.components[] | select(.name|test("FreeType")) | .version'     "$1"  | tr -d \")
 COMPILER=$(jq '.components[0].properties[] | select(.name|test("Build Tools Summary")).value' "$SBOMFILE" | sed -e 's/^.*Toolchain: //g' -e 's/\ *\*.*//g')
 
 EXPECTED_COMPILER="gcc (GNU Compiler Collection)"


### PR DESCRIPTION
- Fix benign build ERROR with createSBOM jar SHA list
```
11:37:51  ERROR: Cannot determine jar version from /home/jenkins/workspace/build-scripts/jobs/jdk21u/jdk21u-linux-x64-temurin/sbin/../cyclonedx-lib/dependency_data/dependency_data.properties for SBOM creation dependency temurin-gen-cdxa.jar.
```
- Bom.metadata not being created correctly for addComponentProp, luckily it is the first method called, so didn't cause a problem!
- Rededundent addExternalReference and addComponentExtRef were not removed and unittests were actually failing, but they were no being tested with fail on error! so passed!
- Metadata.tools has been deprecated in CycloneDX 1.0.6 spec and will be removed at some point, replaced by ToolInformation.Component
- Add the 3 new extra CycloneDX 1.0.6 dependency jars to the SBOM classpath

