### PR TITLE
Enhance SBOM and JDK file check

### DIFF
--- a/test/system/reproducibleCompare/reproducible.mk
+++ b/test/system/reproducibleCompare/reproducible.mk
@@ -12,25 +12,25 @@
 # ********************************************************************************
 
 ifndef SBOM_FILE
-SBOM_FILE := $(shell ls $(TEST_ROOT)/../jdkbinary/ | grep "sbom" | grep -v "metadata")
-ifeq ($(strip $(SBOM_FILE)),)
-$(error ERROR! NO SBOM_FILE AVAILABLE)
-endif
-SBOM_FILE := $(TEST_ROOT)/../jdkbinary/$(SBOM_FILE)
+    SBOM_FILE := $(shell ls $(TEST_ROOT)/../jdkbinary/ | grep "sbom" | grep -v "metadata")
+    ifeq ($(strip $(SBOM_FILE)),)
+        $(error ERROR! NO SBOM_FILE AVAILABLE)
+    endif
+    SBOM_FILE := $(TEST_ROOT)/../jdkbinary/$(SBOM_FILE)
 endif
 
 ifndef JDK_FILE
-JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.tar.gz')
-ifneq (,$(findstring win,$(SPEC)))
-JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.zip')
-endif
-ifeq ($(strip $(JDK_FILE)),)
-$(error ERROR! NO JDK_FILE AVAILABLE)
-endif
+    JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.tar.gz')
+    ifneq (,$(findstring win,$(SPEC)))
+        JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.zip')
+    endif
+    ifeq ($(strip $(JDK_FILE)),)
+        $(error ERROR! NO JDK_FILE AVAILABLE)
+    endif
 endif
 
 ifneq (,$(findstring linux,$(SPEC)))
-SBOM_FILE := $(subst $(TEST_ROOT)/../jdkbinary,/home/jenkins/test,$(SBOM_FILE))
+    SBOM_FILE := $(subst $(TEST_ROOT)/../jdkbinary,/home/jenkins/test,$(SBOM_FILE))
 endif
 
 RM_DEBUGINFO := $(shell find $(TEST_JDK_HOME) -type f -name "*.debuginfo" -delete)

--- a/test/system/reproducibleCompare/reproducible.mk
+++ b/test/system/reproducibleCompare/reproducible.mk
@@ -12,24 +12,25 @@
 # ********************************************************************************
 
 ifndef SBOM_FILE
-	SBOM_FILE := $(shell ls $(TEST_ROOT)/../jdkbinary/ | grep "sbom" | grep -v "metadata")
-	ifeq ($(strip $(SBOM_FILE)),)
-    $(error no SBOM_FILE available)
-	endif
-	SBOM_FILE := $(TEST_ROOT)/../jdkbinary/$(SBOM_FILE)
+SBOM_FILE := $(shell ls $(TEST_ROOT)/../jdkbinary/ | grep "sbom" | grep -v "metadata")
+ifeq ($(strip $(SBOM_FILE)),)
+$(error ERROR! NO SBOM_FILE AVAILABLE)
 endif
+SBOM_FILE := $(TEST_ROOT)/../jdkbinary/$(SBOM_FILE)
+endif
+
 ifndef JDK_FILE
-	JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.tar.gz')
-	ifneq (,$(findstring win,$(SPEC)))
-		JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.zip')
-	endif
-	ifeq ($(strip $(JDK_FILE)),)
-    $(error no JDK_FILE available)
-	endif
+JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.tar.gz')
+ifneq (,$(findstring win,$(SPEC)))
+JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.zip')
+endif
+ifeq ($(strip $(JDK_FILE)),)
+$(error ERROR! NO JDK_FILE AVAILABLE)
+endif
 endif
 
 ifneq (,$(findstring linux,$(SPEC)))
-	SBOM_FILE := $(subst $(TEST_ROOT)/../jdkbinary,/home/jenkins/test,$(SBOM_FILE))
+SBOM_FILE := $(subst $(TEST_ROOT)/../jdkbinary,/home/jenkins/test,$(SBOM_FILE))
 endif
 
 RM_DEBUGINFO := $(shell find $(TEST_JDK_HOME) -type f -name "*.debuginfo" -delete)

--- a/test/system/reproducibleCompare/reproducible.mk
+++ b/test/system/reproducibleCompare/reproducible.mk
@@ -14,9 +14,11 @@
 ifndef SBOM_FILE
     SBOM_FILE := $(shell ls $(TEST_ROOT)/../jdkbinary/ | grep "sbom" | grep -v "metadata")
     ifeq ($(strip $(SBOM_FILE)),)
-        $(error ERROR! NO SBOM_FILE AVAILABLE)
+        $(info ERROR! NO SBOM_FILE AVAILABLE)
+        SBOM_FILE :=
+    else
+        SBOM_FILE := $(TEST_ROOT)/../jdkbinary/$(SBOM_FILE)
     endif
-    SBOM_FILE := $(TEST_ROOT)/../jdkbinary/$(SBOM_FILE)
 endif
 
 ifndef JDK_FILE
@@ -25,12 +27,14 @@ ifndef JDK_FILE
         JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.zip')
     endif
     ifeq ($(strip $(JDK_FILE)),)
-        $(error ERROR! NO JDK_FILE AVAILABLE)
+        $(info ERROR! NO JDK_FILE AVAILABLE)
     endif
 endif
 
 ifneq (,$(findstring linux,$(SPEC)))
-    SBOM_FILE := $(subst $(TEST_ROOT)/../jdkbinary,/home/jenkins/test,$(SBOM_FILE))
+    ifneq ($(strip $(SBOM_FILE)),)
+        SBOM_FILE := $(subst $(TEST_ROOT)/../jdkbinary,/home/jenkins/test,$(SBOM_FILE))
+    endif
 endif
 
 RM_DEBUGINFO := $(shell find $(TEST_JDK_HOME) -type f -name "*.debuginfo" -delete)

--- a/test/system/reproducibleCompare/reproducible.mk
+++ b/test/system/reproducibleCompare/reproducible.mk
@@ -13,12 +13,18 @@
 
 ifndef SBOM_FILE
 	SBOM_FILE := $(shell ls $(TEST_ROOT)/../jdkbinary/ | grep "sbom" | grep -v "metadata")
+	ifeq ($(strip $(SBOM_FILE)),)
+    $(error no SBOM_FILE available)
+	endif
 	SBOM_FILE := $(TEST_ROOT)/../jdkbinary/$(SBOM_FILE)
 endif
 ifndef JDK_FILE
 	JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.tar.gz')
 	ifneq (,$(findstring win,$(SPEC)))
 		JDK_FILE := $(shell find $(TEST_ROOT)/../jdkbinary/ -type f -name '*-jdk_*.zip')
+	endif
+	ifeq ($(strip $(JDK_FILE)),)
+    $(error no JDK_FILE available)
 	endif
 endif
 

--- a/tooling/reproducible/macos_repro_build_compare.sh
+++ b/tooling/reproducible/macos_repro_build_compare.sh
@@ -23,7 +23,7 @@ set -e
 
 # Check All 3 Params Are Supplied
 if [ "$#" -lt 3 ]; then
-  echo "Usage: $0 SBOM_URL/SBOM_PATH JDKZIP_URL/JDKZIP_PATH"
+  echo "Usage: $0 SBOM_URL/SBOM_PATH JDKZIP_URL/JDKZIP_PATH REPORT_DIR"
   echo ""
   echo "1. SBOM_URL/SBOM_PATH - should be the FULL path OR a URL to a Temurin JDK SBOM JSON file in CycloneDX Format"
   echo "    eg. https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-sbom_x64_mac_hotspot_21.0.3_9.json"

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -19,7 +19,7 @@
 set -e
 
 # Check All 3 Params Are Supplied
-if [ "$#" -lt 2 ]; then
+if [ "$#" -lt 3 ]; then
   echo "Usage: $0 SBOM_URL/SBOM_PATH JDKZIP_URL/JDKZIP_PATH"
   echo ""
   echo "1. SBOM_URL/SBOM_PATH - should be the FULL path OR a URL to a Temurin JDK SBOM JSON file in CycloneDX Format"
@@ -27,6 +27,8 @@ if [ "$#" -lt 2 ]; then
   echo ""
   echo "2. JDKZIP_URL/JDKZIP_PATH - should be the FULL path OR a URL to a Temurin Windows JDK Zip file"
   echo "    eg. https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_x64_windows_hotspot_21.0.2_13.zip"
+  echo ""
+  echo "3. REPORT_DIR - should be the FULL path OR a URL to the output directory for the comparison report"
   echo ""
   exit 1
 fi

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -20,7 +20,7 @@ set -e
 
 # Check All 3 Params Are Supplied
 if [ "$#" -lt 3 ]; then
-  echo "Usage: $0 SBOM_URL/SBOM_PATH JDKZIP_URL/JDKZIP_PATH"
+  echo "Usage: $0 SBOM_URL/SBOM_PATH JDKZIP_URL/JDKZIP_PATH REPORT_DIR"
   echo ""
   echo "1. SBOM_URL/SBOM_PATH - should be the FULL path OR a URL to a Temurin JDK SBOM JSON file in CycloneDX Format"
   echo "    eg. https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-sbom_x64_windows_hotspot_21.0.2_13.json"


### PR DESCRIPTION
Fixes #4079

If no SBOM and JDK file available fail the job.

Related https://github.com/adoptium/temurin-build/issues/4079