### PR TITLE
Adding JDK25 to autotriage

### DIFF
--- a/.github/workflows/build-autotriage.yml
+++ b/.github/workflows/build-autotriage.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: "Run Build Auto Triage"
-        run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk23u jdk24head
+        run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk23u jdk24 jdk25head
 
       - name: Create Issue From File
         env:


### PR DESCRIPTION
Adds JDK25 to the autotriage tool, identifies it as the new head stream, and re-identifies jdk24 as its own version.