### PR TITLE
warn on false negatives if repro_compare.sh is run after  comparable_patch.sh in  ReproducibleBuilds.md

### DIFF
--- a/tooling/reproducible/ReproducibleBuilds.md
+++ b/tooling/reproducible/ReproducibleBuilds.md
@@ -50,7 +50,7 @@ The patching process involves:
 - Remove any non-deterministic build process artifact strings, like Manifest Created-By stamps.
 - Zero out CRC in .gnu_debuglink ELF sections to eliminate .debuginfo-induced differences.
 
-**warning:** If you run `comparable_patch.sh`, do not use `repro_compare.sh` for final comparison. You would get false negatives. Run plain `diff jdk1 jdk2` with any switches you need. 
+**warning:** If you run `comparable_patch.sh`, do not use `repro_compare.sh` for final comparison. You would get false negatives. Run plain `diff jdk1 jdk2` with any switches you need.
 
 ### How to setup and run comparable_patch.sh on Windows
 

--- a/tooling/reproducible/ReproducibleBuilds.md
+++ b/tooling/reproducible/ReproducibleBuilds.md
@@ -50,6 +50,8 @@ The patching process involves:
 - Remove any non-deterministic build process artifact strings, like Manifest Created-By stamps.
 - Zero out CRC in .gnu_debuglink ELF sections to eliminate .debuginfo-induced differences.
 
+**warning:** If you run `comparable_patch.sh`, do not use `repro_compare.sh` for final comparison. You would get false negatives. Run plain `diff jdk1 jdk2` with any switches you need. 
+
 ### How to setup and run comparable_patch.sh on Windows
 
 #### Tooling setup:


### PR DESCRIPTION
I may be misunderstanding, but it seems, that if you run `comparable_patch.sh` you can not use `repro_compare.sh` for final comparison. You would get false negatives. Run plain `diff jdk1 jdk2` Should be the only  thing to call. 
I would like to add this as warning to the readme.