### PR TITLE
Same results for similar and identical

### DIFF
--- a/tooling/reproducible/ReproducibleBuilds.md
+++ b/tooling/reproducible/ReproducibleBuilds.md
@@ -50,7 +50,7 @@ The patching process involves:
 - Remove any non-deterministic build process artifact strings, like Manifest Created-By stamps.
 - Zero out CRC in .gnu_debuglink ELF sections to eliminate .debuginfo-induced differences.
 
-**warning:** If you run `comparable_patch.sh`, do not use `repro_compare.sh` for final comparison. You would get false negatives. Run plain `diff jdk1 jdk2` with any switches you need.
+**warning:** If you run `comparable_patch.sh`, do not use `repro_compare.sh` for final comparison. You would get false negatives. Run plain `diff jdk1 jdk2` with any switches you need, or use `PREPROCESS=no repro_compare.sh` with the flag `PREPROCESS=no`. Any other value then `no` would lead again to preprocessing, and thus false negatives.
 
 ### How to setup and run comparable_patch.sh on Windows
 

--- a/tooling/reproducible/repro_compare.sh
+++ b/tooling/reproducible/repro_compare.sh
@@ -21,11 +21,20 @@ BLD_TYPE2="$3"
 JDK_DIR2="$4"
 OS="$5"
 
+# if PREPROCESS flag is set to 'no', then preprocessing is not run
+# this is usefull, if yo want to compare two identical copies of JDK
+#  or if you want to run repro_compare.sh only as result generator after you
+#  run comparable_patch.sh. This helps to keep diff in unified output
+if [ -z "${PREPROCESS:-}" ] ; then
+  PREPROCESS="yes"
+fi
+
 mkdir "${JDK_DIR}_BK"
 cp -R "${JDK_DIR1}"/* "${JDK_DIR}"_BK
 BK_JDK_DIR=$(realpath "${JDK_DIR}"_BK/)
 
 JDK_DIR_Arr=("${JDK_DIR1}" "${JDK_DIR2}")
+if [ "$PREPROCESS" != "no" ] ; then
 for  JDK_DIR in "${JDK_DIR_Arr[@]}"
 do
   if [[ ! -d "${JDK_DIR}" ]] || [[ ! -d "${JDK_DIR}/bin"  ]]; then
@@ -54,6 +63,9 @@ do
     processModuleInfo "${JDK_DIR}" "${OS}" "${BK_JDK_DIR}"
   fi
 done
+else
+  echo "Preprocessing skipped on user request. Generating just diff."
+fi
 
 files1=$(find "${JDK_DIR1}" -type f | wc -l)
 echo "Number of files: ${files1}"

--- a/tooling/reproducible/repro_compare.sh
+++ b/tooling/reproducible/repro_compare.sh
@@ -21,6 +21,18 @@ BLD_TYPE2="$3"
 JDK_DIR2="$4"
 OS="$5"
 
+checkJdkDir() {
+  JDK_DIR="${1}"
+  if [[ ! -d "${JDK_DIR}" ]] || [[ ! -d "${JDK_DIR}/bin"  ]]; then
+    echo "$JDK_DIR does not exist or does not point at a JDK"
+    echo "repro_compare.sh (temurin|openjdk) JDK_DIR1 (temurin|openjdk) JDK_DIR2 OS"
+    exit 1
+  fi
+}
+
+checkJdkDir "${JDK_DIR1}"
+checkJdkDir "${JDK_DIR2}"
+
 # if PREPROCESS flag is set to 'no', then preprocessing is not run
 # this is usefull, if yo want to compare two identical copies of JDK
 #  or if you want to run repro_compare.sh only as result generator after you
@@ -37,12 +49,6 @@ JDK_DIR_Arr=("${JDK_DIR1}" "${JDK_DIR2}")
 if [ "$PREPROCESS" != "no" ] ; then
 for  JDK_DIR in "${JDK_DIR_Arr[@]}"
 do
-  if [[ ! -d "${JDK_DIR}" ]] || [[ ! -d "${JDK_DIR}/bin"  ]]; then
-    echo "$JDK_DIR does not exist or does not point at a JDK"
-    echo "repro_compare.sh (temurin|openjdk) JDK_DIR1 (temurin|openjdk) JDK_DIR2 OS"
-    exit 1
-  fi
-
   echo "$(date +%T) : Pre-processing ${JDK_DIR}"
   rc=0
   source "$(dirname "$0")"/repro_process.sh "${JDK_DIR}" "${OS}" || rc=$?


### PR DESCRIPTION
Hello!

When I was following the:  https://github.com/adoptium/temurin-build/commit/d1c15a677275e44c3fed8c287159743794e88f6a, I realised that after the `diff jdk1 jdk2` I'm moreover replicating what repro_compare.sh is doing.  Thus I thought it would be better to leave it all on repro_compare.sh
, and just allow it to skip the whole preprocessing. WDYT?
