### PR TITLE
Add gtest support on jdk15+

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -580,6 +580,12 @@ configureZlibLocation() {
   fi
 }
 
+configureGtestLocation() {
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 15 ]; then
+      addConfigureArg "--with-gtest=" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedgtest"
+  fi
+}
+
 # Configure the command parameters
 configureCommandParameters() {
   configureVersionStringParameter
@@ -624,6 +630,7 @@ configureCommandParameters() {
 
   configureFreetypeLocation
   configureZlibLocation
+  configureGtestLocation
 
   echo "Completed configuring the version string parameter, config args are now: ${CONFIGURE_ARGS}"
 }

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -40,6 +40,9 @@ FREETYPE_FONT_SHARED_OBJECT_FILENAME="libfreetype.so*"
 # sha256 of https://github.com/adoptium/devkit-binaries/releases/tag/vs2022_redist_14.40.33807_10.0.26100.1742
 WINDOWS_REDIST_CHECKSUM="ac6060f5f8a952f59faef20e53d124c2c267264109f3f6fabeb2b7aefb3e3c62"
 
+GTEST_VERSION=1.16.0
+GTEST_CHECKSUM="78c676fc63881529bf97bf9d45948d905a66833fbfa5318ea2cd7478cb98f399"
+
 copyFromDir() {
   echo "Copying OpenJDK source from  ${BUILD_CONFIG[OPENJDK_LOCAL_SOURCE_ARCHIVE_ABSPATH]} to $(pwd)/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]} to be built"
   # We really do not want to use .git for dirs, as we expect user have them set up, ignoring them
@@ -817,6 +820,18 @@ downloadBootJdkIfNeeded () {
   fi
 }
 
+downloadGtest() {
+  local gtestUnpacked="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedgtest"
+  if [ -e "${gtestUnpacked}" ]; then
+    echo "Reusing $gtestUnpacked"
+  else
+    local gtestArchive="${BUILD_CONFIG[WORKSPACE_DIR]}/libs/googletest-${GTEST_VERSION}.tar.gz"
+    downloadFile "${gtestArchive}" "https://github.com/google/googletest/releases/download/v${GTEST_VERSION}/googletest-${GTEST_VERSION}.tar.gz" "${GTEST_CHECKSUM}"
+    mkdir -p "${gtestUnpacked}"
+    tar -xzf "${gtestArchive}" --strip-components=1  -C "${gtestUnpacked}"
+  fi
+}
+
 # Download all of the dependencies for OpenJDK (Alsa, FreeType, boot-jdk etc.)
 downloadingRequiredDependencies() {
   if [[ "${BUILD_CONFIG[CLEAN_LIBS]}" == "true" ]]; then
@@ -860,6 +875,10 @@ downloadingRequiredDependencies() {
     esac
   else
     echo "Skipping Freetype"
+  fi
+
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 15 ]; then
+      downloadGtest
   fi
 }
 


### PR DESCRIPTION
Adds gtest support for testimage on jdk15+. ([in-tree gtest was removed in jdk15](https://bugs.openjdk.org/browse/JDK-8245610)) This is needed for some hotspot tests.

Fixes https://github.com/adoptium/temurin-build/issues/3956

**Testing:**
Tested locally on rhel-8 using command:
`./makejdk-any-platform.sh -J /usr/lib/jvm/java-11-openjdk --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b03  --build-variant temurin jdk17u`
( fixed the issue, gtest files appeared in test-image in `hotspot/gtest` )