### PR TITLE
Redirect output to build.log and add all related info to testoutput

### DIFF
--- a/test/system/reproducibleCompare/playlist.xml
+++ b/test/system/reproducibleCompare/playlist.xml
@@ -24,6 +24,7 @@
 	docker cp reproducibleCompare:/home/jenkins/reprotest.diff ./; \
 	docker cp reproducibleCompare:/home/jenkins/reproJDK.tar.gz ./; \
 	docker cp reproducibleCompare:/home/jenkins/SBOM.json ./; \
+	docker cp reproducibleCompare:/home/jenkins/build.log ./; \
 	docker container rm -f reproducibleCompare
 	</command>
 		<levels>

--- a/tooling/reproducible/linux_repro_build_compare.sh
+++ b/tooling/reproducible/linux_repro_build_compare.sh
@@ -192,13 +192,14 @@ else
 fi
 
 echo "Rebuild args for makejdk_any_platform.sh are: $TEMURIN_BUILD_ARGS"
-echo " cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS 2>&1 | tee build.$$.log" | sh
+echo " cd temurin-build && ./makejdk-any-platform.sh $TEMURIN_BUILD_ARGS > build.log 2>&1" | sh
 
 echo Comparing ...
 mkdir tarJDK
 tar xpfz temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz -C tarJDK
 cp temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz reproJDK.tar.gz
 cp "$SBOM" SBOM.json
+cp temurin-build/build.log build.log
 
 cp "$ScriptPath"/repro_*.sh "$PWD"
 chmod +x "$PWD"/repro_*.sh

--- a/tooling/reproducible/macos_repro_build_compare.sh
+++ b/tooling/reproducible/macos_repro_build_compare.sh
@@ -452,9 +452,10 @@ Build_JDK() {
 
   # Trigger Build
   cd "$WORK_DIR"
-  echo "cd temurin-build && ./makejdk-any-platform.sh $buildArgs 2>&1 | tee build.$$.log" | sh
+  echo "cd temurin-build && ./makejdk-any-platform.sh $buildArgs > build.log 2>&1" | sh
   # Copy The Built JDK To The Working Directory
   cp "$WORK_DIR"/temurin-build/workspace/target/OpenJDK*-jdk_*tar.gz "$WORK_DIR"/reproJDK.tar.gz
+  cp "$WORK_DIR"/temurin-build/build.log "$WORK_DIR"/build.log
 }
 
 Compare_JDK() {
@@ -498,6 +499,8 @@ Compare_JDK() {
     echo "Copying Output To $REPORT_DIR"
     cp "$WORK_DIR"/compare/reprotest.diff "$REPORT_DIR"
     cp "$WORK_DIR"/reproJDK.tar.gz "$REPORT_DIR"
+    cp "$WORK_DIR"/build.log "$REPORT_DIR"
+    cp "$WORK_DIR"/src_sbom.json "$REPORT_DIR"
   fi
   Clean_Up_Everything
   exit $rc 

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -577,9 +577,10 @@ Build_JDK() {
 
   # Trigger Build
   cd "$WORK_DIR"
-  echo "cd temurin-build && ./makejdk-any-platform.sh $buildArgs 2>&1 | tee build.$$.log" | sh
+  echo "cd temurin-build && ./makejdk-any-platform.sh $buildArgs > build.log 2>&1" | sh
   # Copy The Built JDK To The Working Directory
   cp "${WORK_DIR}"/temurin-build/workspace/target/OpenJDK*-jdk_*.zip "$WORK_DIR/reproJDK.zip"
+  cp "${WORK_DIR}"/temurin-build/build.log "$WORK_DIR/build.log"
 }
 
 Compare_JDK() {
@@ -656,6 +657,8 @@ Compare_JDK() {
     echo "Copying Output To $REPORT_DIR"
     cp "$ScriptPath/reprotest.diff" "$REPORT_DIR"
     cp "$WORK_DIR/reproJDK.zip" "$REPORT_DIR"
+    cp "$WORK_DIR/src_sbom.json" "$REPORT_DIR"
+    cp "$WORK_DIR/build.log" "$REPORT_DIR"
   fi
 }
 


### PR DESCRIPTION
Reduce reproducible tests output to console. Redirect all output to build.log, which will be archived as part of testoutput.

Also add sbom.json to testoutput for mac and win. (linux already enabled.)

Related https://github.com/adoptium/ci-jenkins-pipelines/issues/1188