### PR TITLE
Correct SBOM ALSA version check

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1287,12 +1287,14 @@ addALSAVersion() {
 
      # Get ALSA include dir from the built build spec.gmk for ALSA_CFLAGS.
      local ALSA_INCLUDE="$(grep "^ALSA_CFLAGS[ ]*:=" ${specFile} | sed "s/^ALSA_CFLAGS[ ]*:=[ ]*//" | sed "s/^-I//")"
-     if [ -z "${ALSA_INCLUDE}" ]; then
-       echo "No ALSA_CFLAGS, ALSA not used"
+     # Get ALSA lib from the built build spec.gmk for ALSA_LIBS.
+     local ALSA_LIBS="$(grep "^ALSA_LIBS[ ]*:=" ${specFile} | sed "s/^ALSA_LIBS[ ]*:=[ ]*//")"
+     if [ -z "${ALSA_INCLUDE}" ] && [ -z "${ALSA_LIBS}" ]; then
+       echo "No ALSA_CFLAGS or ALSA_LIBS, ALSA not used"
      else
        local ALSA_VERSION
-       if [ "${ALSA_INCLUDE}" == "ignoreme" ]; then
-         # Value will be "ignoreme" if default/sysroot/devkit include path ALSA is being used, ask compiler for version
+       if [ "${ALSA_INCLUDE}" == "ignoreme" ] || [ -z "${ALSA_INCLUDE}" ]; then
+         # Value will be "ignoreme" or empty if system/sysroot/devkit ALSA is being used, ask compiler for version
          ALSA_VERSION=$(getHeaderPropertyUsingCompiler "alsa/version.h" "#define[ ]+SND_LIB_VERSION_STR")
        else
          local ALSA_VERSION_H="${ALSA_INCLUDE}/version.h"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4152

With ALSA from system or devkit, the ALSA_CFLAGS is not set, only ALSA_LIBS is set, the SBOM ALSA check needs to check both, then get for system/devkit if not ALSA_CFLAGS is specified

Test build: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-aarch64-temurin/291/ - SBOM ALSA correct (1.1.6)

jdk8u test: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-linux-x64-temurin/522/ - Good