### PR TITLE
Fix documentation `AdoptOpenJDK_Build_Script_Relationships.png` image location

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ repository.
 
 I wrote this diagram partially for my own benefit in [issue 957](https://github.com/adoptium/temurin-build/issues/957) that lists the shell scripts (`S`) and environment scripts (`E`). I think it would be useful to incorporate this into the documentation (potentially annotated with a bit more info) so people can find their way around the myriad of script levels that we now have.
 Note that the "end user" scripts start at `makejdk-any-platform.sh` and a
-diagram of those relationships can be seen [here](https://github.com/adoptium/temurin-build/blob/master/docs/images/AdoptOpenJDK_Build_Script_Relationships.png)
+diagram of those relationships can be seen [here](https://github.com/adoptium/ci-jenkins-pipelines/blob/master/docs/images/AdoptOpenJDK_Build_Script_Relationships.png)
 
 *See the [ci-jenkins-pipelines FAQ.md](https://github.com/adoptium/ci-jenkins-pipelines/blob/master/FAQ.md#how-do-i-find-my-way-around-adoptopenjdks-build-automation-scripts) for the Jenkins side of the pipeline*
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Example usage:
 
 ### Script Relationships
 
-![Build Variant Workflow](docs/images/AdoptOpenJDK_Build_Script_Relationships.png)
+![Build Variant Workflow](https://github.com/adoptium/ci-jenkins-pipelines/blob/master/docs/images/AdoptOpenJDK_Build_Script_Relationships.png)
 
 The main script to build OpenJDK is `makejdk-any-platform.sh`, which itself uses
 and/or calls `configureBuild.sh`, `docker-build.sh` and/or `native-build.sh`.


### PR DESCRIPTION
The image link in the documentation is broken as the file has been moved to another repo.