### PR TITLE
cacerts: follow redirects in http requests

### DIFF
--- a/security/mk-ca-bundle.pl
+++ b/security/mk-ca-bundle.pl
@@ -310,7 +310,8 @@ if(!$opt_n) {
         report "Get certdata with curl!";
         my $proto = !$opt_k ? "--proto =https" : "";
         my $quiet = $opt_q ? "-s" : "";
-        my @out = `curl -w %{response_code} $proto $quiet -o "$txt" "$url"`;
+        my $follow = "-L";
+        my @out = `curl -w %{response_code} $proto $quiet $follow -o "$txt" "$url"`;
         if(!$? && @out && $out[0] == 200) {
           $fetched = 1;
           report "Downloaded $txt";


### PR DESCRIPTION
The CACert updater job has been failing for some time: https://github.com/adoptium/temurin-build/actions/runs/14481848049/job/40620227207

It looks like Mozilla changed the http endpoints to redirect to an edge server which was breaking our code as we weren't following redirects