### PR TITLE
Add GitHub Workflow to Fetch and Upload Temurin SBOMs to DependencyTrack

### DIFF
--- a/.github/workflows/fetch_upload_sboms.yml
+++ b/.github/workflows/fetch_upload_sboms.yml
@@ -33,7 +33,7 @@ jobs:
         run: pip install requests
 
       - name: Run SBOM fetcher script
-        run: python fetch_sboms.py
+        run: python scripts/fetch_sboms.py
 
       - name: Upload SBOMs and metadata
         uses: actions/upload-artifact@v4
@@ -70,4 +70,4 @@ jobs:
           projectVersion: ${{ matrix.projectVersion }}
           bomArtifact: sboms
           bomFilename: workspace/${{ matrix.path }}
-          parentProject: '<parentProject_ID>' # must replace with real UUID
+          parentProject: '<parentProject_ID>' # must be replaced with real UUID

--- a/.github/workflows/fetch_upload_sboms.yml
+++ b/.github/workflows/fetch_upload_sboms.yml
@@ -1,0 +1,220 @@
+# name: Fetch and Upload Temurin SBOMs to DependencyTrack
+
+# on:
+#   workflow_dispatch: # manual trigger
+
+# env:
+#   API_URL_BASE: https://api.adoptium.net/v3/assets/feature_releases/21/ga
+#   IMAGE_TYPE: sbom
+#   VENDOR: eclipse
+#   HEAP_SIZE: normal
+#   PAGE_SIZE: 20 # number of results per page
+#   DEPENDENCY_TRACK_URL: https://sbom.eclipse.org
+#   PROJECT_ROOT: Temurin # Root project name for DependencyTrack
+#   JAVA_VERSION: JDK 21
+
+# jobs:
+#   fetch-upload:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#       - name: Install jq
+#         run: sudo apt-get install -y jq # install jq for JSON parsing 
+
+#       - name: generate-sbom
+#         # env:
+#         #   API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }} # uses API key from Github secrets 
+#         run: | # we loop through paginated results 
+#           before=""
+#           page=1
+
+#           while true; do
+#             echo "Fetching page $page..."
+#             URL="${API_URL_BASE}?image_type=${IMAGE_TYPE}&vendor=${VENDOR}&heap_size=${HEAP_SIZE}&page_size=${PAGE_SIZE}"
+#             if [ -n "$before" ]; then
+#               URL="${URL}&before=${before}"
+#             fi
+
+#             curl -s "$URL" -o page.json       # fetch current page of results
+#             count=$(jq 'length' page.json)    # count number of results in the page
+
+#             if [ "$count" -eq 0 ]; then
+#               echo "No more results. Done."
+#               break
+#             fi
+
+#             # iterate over each asset in the page
+#             for i in $(seq 0 $((count - 1))); do
+#               version=$(jq -r ".[$i].version_data.semver" page.json)
+#               release_date=$(jq -r ".[$i].timestamp" page.json | cut -d'T' -f1)
+            
+#               # get number of binaries for this asset
+#               bin_count=$(jq ".[$i].binaries | length" page.json)
+            
+#               # iterate over each binary for this asset
+#               for j in $(seq 0 $((bin_count - 1))); do
+#                 os=$(jq -r ".[$i].binaries[$j].os" page.json)
+#                 arch=$(jq -r ".[$i].binaries[$j].architecture" page.json)
+#                 sbomUrl=$(jq -r ".[$i].binaries[$j].package.link" page.json)
+            
+#                 if [ "$sbomUrl" = "null" ]; then
+#                   echo "No SBOM for $version ($os $arch). Skipping."
+#                   continue
+#                 fi
+            
+#                 # project name for DependencyTrack
+#                 projectName="${PROJECT_ROOT} / ${JAVA_VERSION} / ${os} ${arch} / jdk-${version}"
+
+#                 echo "Downloading SBOM for ${projectName}"
+#                 curl -s -o sbom.json "$sbomUrl"
+            
+#                 # store the SBOM as an artifact to upload to DependencyTrack
+#                 mkdir -p "sboms/${os}_${arch}_${version}"
+#                 mv sbom.json "sboms/${os}_${arch}_${version}/sbom.json"
+#                 echo "Stored SBOM for ${projectName}"
+            
+#               done
+#             done            
+            
+#             before=$(jq -r '.[-1].release_date' page.json)
+#             page=$((page + 1)) 
+#             sleep 1 # to avoid rate limits
+#           done
+#       - name: Upload SBOM artifacts
+#         uses: actions/upload-artifact@v4
+#         with:
+#           name: all-sboms
+#           path: sboms/
+
+# store-sbom-data: 
+#     needs: ['generate-sbom']
+#     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+#     with:
+#       projectName: '<product_name>' # display name
+#       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+#       bomArtifact: '<artifact_name>' # name from upload in generate-sbom job
+#       bomFilename: 'bom.json'
+#       parentProject: '<parentProject_ID>' # provisioned by us
+
+
+name: Fetch and Upload Temurin SBOMs to DependencyTrack
+
+on:
+  workflow_dispatch:
+
+env:
+  API_URL_BASE: https://api.adoptium.net/v3/assets/feature_releases/21/ga
+  IMAGE_TYPE: sbom
+  VENDOR: eclipse
+  HEAP_SIZE: normal
+  PAGE_SIZE: 20
+  DEPENDENCY_TRACK_URL: https://sbom.eclipse.org
+  PROJECT_ROOT: Temurin
+  JAVA_VERSION: JDK 21
+
+jobs:
+  fetch-sboms:
+    runs-on: ubuntu-latest
+
+    outputs:
+      sbom-metadata: ${{ steps.export.outputs.matrix }}
+
+    steps:
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Fetch and store SBOMs
+        run: |
+          mkdir -p sboms/
+          echo "[" > metadata.json
+          before=""
+          page=1
+          first=true
+
+          while true; do
+            echo "Fetching page $page..."
+            URL="${API_URL_BASE}?image_type=${IMAGE_TYPE}&vendor=${VENDOR}&heap_size=${HEAP_SIZE}&page_size=${PAGE_SIZE}"
+            if [ -n "$before" ]; then
+              URL="${URL}&before=${before}"
+            fi
+
+            curl -s "$URL" -o page.json
+            count=$(jq 'length' page.json)
+
+            if [ "$count" -eq 0 ]; then
+              echo "No more results."
+              break
+            fi
+
+            for i in $(seq 0 $((count - 1))); do
+              version=$(jq -r ".[$i].version_data.semver" page.json)
+              bin_count=$(jq ".[$i].binaries | length" page.json)
+
+              for j in $(seq 0 $((bin_count - 1))); do
+                os=$(jq -r ".[$i].binaries[$j].os" page.json)
+                arch=$(jq -r ".[$i].binaries[$j].architecture" page.json)
+                sbomUrl=$(jq -r ".[$i].binaries[$j].package.link" page.json)
+
+                if [ "$sbomUrl" = "null" ]; then
+                  continue
+                fi
+
+                dir="sboms/${os}_${arch}_${version}"
+                mkdir -p "$dir"
+                curl -s -o "$dir/sbom.json" "$sbomUrl"
+
+                projectName="${PROJECT_ROOT} / ${JAVA_VERSION} / ${os} ${arch} / jdk-${version}"
+
+                if [ "$first" = true ]; then
+                  first=false
+                else
+                  echo "," >> metadata.json
+                fi
+
+                echo "  {\"path\": \"$dir/sbom.json\", \"projectName\": \"$projectName\", \"projectVersion\": \"$version\"}" >> metadata.json
+              done
+            done
+
+            before=$(jq -r '.[-1].release_date' page.json)
+            page=$((page + 1))
+            sleep 1
+          done
+
+          echo "]" >> metadata.json
+
+      - name: Upload SBOMs and metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: sboms
+          path: |
+            sboms/
+            metadata.json
+
+      - id: export
+        run: |
+          matrix=$(jq -c '.' metadata.json)
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  store-each-sbom:
+    needs: fetch-sboms
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.fetch-sboms.outputs.sbom-metadata) }}
+
+    steps:
+      - name: Download SBOMs
+        uses: actions/download-artifact@v4
+        with:
+          name: sboms
+          path: ./workspace
+
+      - name: Call store-sbom reusable workflow
+        uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+        with:
+          projectName: ${{ matrix.projectName }}
+          projectVersion: ${{ matrix.projectVersion }}
+          bomArtifact: sboms
+          bomFilename: ${{ matrix.path }}
+          parentProject: '<parentProject_ID>'

--- a/.github/workflows/fetch_upload_sboms.yml
+++ b/.github/workflows/fetch_upload_sboms.yml
@@ -17,7 +17,7 @@ jobs:
   fetch-sboms:
     runs-on: ubuntu-latest
 
-    outputs:
+    outputs:  # Expose matrix output for next job
       sbom-metadata: ${{ steps.export.outputs.matrix }}
 
     steps:
@@ -30,7 +30,13 @@ jobs:
           python-version: 3.11
 
       - name: Install Python dependencies
-        run: pip install requests
+        run: |
+          pip install requests
+          pip install os
+          pip install json
+          pip install time
+          pip install pathlib
+          pip install datetime
 
       - name: Run SBOM fetcher script
         run: python scripts/fetch_sboms.py
@@ -40,12 +46,12 @@ jobs:
         with:
           name: sboms
           path: |
-            sboms/
-            metadata.json
+            sboms/         # Folder with downloaded SBOMs
+            metadata.json  # JSON metadata for the next matrix job
 
-      - id: export
+      - id: export         # Step to read metadata.json and output a JSON matrix
         run: |
-          matrix=$(jq -c '.' metadata.json)
+          matrix=$(jq -c '.' metadata.json)   # Read the JSON file as a single-line JSON array
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   store-each-sbom:
@@ -55,6 +61,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJson(needs.fetch-sboms.outputs.sbom-metadata) }}
+        # This creates one matrix job per object in the metadata.json list
 
     steps:
       - name: Download SBOMs
@@ -63,7 +70,7 @@ jobs:
           name: sboms
           path: workspace
 
-      - name: Store SBOM in DependencyTrack
+      - name: Store SBOM in DependencyTrack   # Reusable workflow that uploads to DependencyTrack
         uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
         with:
           projectName: ${{ matrix.projectName }}

--- a/.github/workflows/fetch_upload_sboms.yml
+++ b/.github/workflows/fetch_upload_sboms.yml
@@ -1,102 +1,3 @@
-# name: Fetch and Upload Temurin SBOMs to DependencyTrack
-
-# on:
-#   workflow_dispatch: # manual trigger
-
-# env:
-#   API_URL_BASE: https://api.adoptium.net/v3/assets/feature_releases/21/ga
-#   IMAGE_TYPE: sbom
-#   VENDOR: eclipse
-#   HEAP_SIZE: normal
-#   PAGE_SIZE: 20 # number of results per page
-#   DEPENDENCY_TRACK_URL: https://sbom.eclipse.org
-#   PROJECT_ROOT: Temurin # Root project name for DependencyTrack
-#   JAVA_VERSION: JDK 21
-
-# jobs:
-#   fetch-upload:
-#     runs-on: ubuntu-latest
-
-#     steps:
-#       - name: Install jq
-#         run: sudo apt-get install -y jq # install jq for JSON parsing 
-
-#       - name: generate-sbom
-#         # env:
-#         #   API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }} # uses API key from Github secrets 
-#         run: | # we loop through paginated results 
-#           before=""
-#           page=1
-
-#           while true; do
-#             echo "Fetching page $page..."
-#             URL="${API_URL_BASE}?image_type=${IMAGE_TYPE}&vendor=${VENDOR}&heap_size=${HEAP_SIZE}&page_size=${PAGE_SIZE}"
-#             if [ -n "$before" ]; then
-#               URL="${URL}&before=${before}"
-#             fi
-
-#             curl -s "$URL" -o page.json       # fetch current page of results
-#             count=$(jq 'length' page.json)    # count number of results in the page
-
-#             if [ "$count" -eq 0 ]; then
-#               echo "No more results. Done."
-#               break
-#             fi
-
-#             # iterate over each asset in the page
-#             for i in $(seq 0 $((count - 1))); do
-#               version=$(jq -r ".[$i].version_data.semver" page.json)
-#               release_date=$(jq -r ".[$i].timestamp" page.json | cut -d'T' -f1)
-            
-#               # get number of binaries for this asset
-#               bin_count=$(jq ".[$i].binaries | length" page.json)
-            
-#               # iterate over each binary for this asset
-#               for j in $(seq 0 $((bin_count - 1))); do
-#                 os=$(jq -r ".[$i].binaries[$j].os" page.json)
-#                 arch=$(jq -r ".[$i].binaries[$j].architecture" page.json)
-#                 sbomUrl=$(jq -r ".[$i].binaries[$j].package.link" page.json)
-            
-#                 if [ "$sbomUrl" = "null" ]; then
-#                   echo "No SBOM for $version ($os $arch). Skipping."
-#                   continue
-#                 fi
-            
-#                 # project name for DependencyTrack
-#                 projectName="${PROJECT_ROOT} / ${JAVA_VERSION} / ${os} ${arch} / jdk-${version}"
-
-#                 echo "Downloading SBOM for ${projectName}"
-#                 curl -s -o sbom.json "$sbomUrl"
-            
-#                 # store the SBOM as an artifact to upload to DependencyTrack
-#                 mkdir -p "sboms/${os}_${arch}_${version}"
-#                 mv sbom.json "sboms/${os}_${arch}_${version}/sbom.json"
-#                 echo "Stored SBOM for ${projectName}"
-            
-#               done
-#             done            
-            
-#             before=$(jq -r '.[-1].release_date' page.json)
-#             page=$((page + 1)) 
-#             sleep 1 # to avoid rate limits
-#           done
-#       - name: Upload SBOM artifacts
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: all-sboms
-#           path: sboms/
-
-# store-sbom-data: 
-#     needs: ['generate-sbom']
-#     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
-#     with:
-#       projectName: '<product_name>' # display name
-#       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
-#       bomArtifact: '<artifact_name>' # name from upload in generate-sbom job
-#       bomFilename: 'bom.json'
-#       parentProject: '<parentProject_ID>' # provisioned by us
-
-
 name: Fetch and Upload Temurin SBOMs to DependencyTrack
 
 on:
@@ -120,67 +21,19 @@ jobs:
       sbom-metadata: ${{ steps.export.outputs.matrix }}
 
     steps:
-      - name: Install jq
-        run: sudo apt-get install -y jq
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Fetch and store SBOMs
-        run: |
-          mkdir -p sboms/
-          echo "[" > metadata.json
-          before=""
-          page=1
-          first=true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
-          while true; do
-            echo "Fetching page $page..."
-            URL="${API_URL_BASE}?image_type=${IMAGE_TYPE}&vendor=${VENDOR}&heap_size=${HEAP_SIZE}&page_size=${PAGE_SIZE}"
-            if [ -n "$before" ]; then
-              URL="${URL}&before=${before}"
-            fi
+      - name: Install Python dependencies
+        run: pip install requests
 
-            curl -s "$URL" -o page.json
-            count=$(jq 'length' page.json)
-
-            if [ "$count" -eq 0 ]; then
-              echo "No more results."
-              break
-            fi
-
-            for i in $(seq 0 $((count - 1))); do
-              version=$(jq -r ".[$i].version_data.semver" page.json)
-              bin_count=$(jq ".[$i].binaries | length" page.json)
-
-              for j in $(seq 0 $((bin_count - 1))); do
-                os=$(jq -r ".[$i].binaries[$j].os" page.json)
-                arch=$(jq -r ".[$i].binaries[$j].architecture" page.json)
-                sbomUrl=$(jq -r ".[$i].binaries[$j].package.link" page.json)
-
-                if [ "$sbomUrl" = "null" ]; then
-                  continue
-                fi
-
-                dir="sboms/${os}_${arch}_${version}"
-                mkdir -p "$dir"
-                curl -s -o "$dir/sbom.json" "$sbomUrl"
-
-                projectName="${PROJECT_ROOT} / ${JAVA_VERSION} / ${os} ${arch} / jdk-${version}"
-
-                if [ "$first" = true ]; then
-                  first=false
-                else
-                  echo "," >> metadata.json
-                fi
-
-                echo "  {\"path\": \"$dir/sbom.json\", \"projectName\": \"$projectName\", \"projectVersion\": \"$version\"}" >> metadata.json
-              done
-            done
-
-            before=$(jq -r '.[-1].release_date' page.json)
-            page=$((page + 1))
-            sleep 1
-          done
-
-          echo "]" >> metadata.json
+      - name: Run SBOM fetcher script
+        run: python fetch_sboms.py
 
       - name: Upload SBOMs and metadata
         uses: actions/upload-artifact@v4
@@ -208,13 +61,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: sboms
-          path: ./workspace
+          path: workspace
 
-      - name: Call store-sbom reusable workflow
+      - name: Store SBOM in DependencyTrack
         uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
         with:
           projectName: ${{ matrix.projectName }}
           projectVersion: ${{ matrix.projectVersion }}
           bomArtifact: sboms
-          bomFilename: ${{ matrix.path }}
-          parentProject: '<parentProject_ID>'
+          bomFilename: workspace/${{ matrix.path }}
+          parentProject: '<parentProject_ID>' # must replace with real UUID

--- a/scripts/fetch_sboms.py
+++ b/scripts/fetch_sboms.py
@@ -39,7 +39,17 @@ def fetch_sboms():
             print("No more results.")
             break
 
+        stop = False 
+
         for asset in data:
+            # we stop if the last asset is before the cutoff date
+            release_date_str = asset["timestamp"]
+            release_date = datetime.fromisoformat(release_date_str.replace("Z", "")).date()
+
+            if release_date < cutoff_date:
+                stop = True
+                break   
+
             version = asset["version_data"]["semver"]
             for binary in asset.get("binaries", []):
                 os_name = binary["os"]
@@ -63,8 +73,12 @@ def fetch_sboms():
                     "projectName": project_name,
                     "projectVersion": version
                 })
+            
+            if stop: 
+                print(f"Stopping fetch as the last asset is before the cutoff date: {cutoff_date}")
+                break
 
-        before = data[-1]["release_date"]
+        before = data[-1]["timestamp"].split("T")[0]
         page += 1
         time.sleep(1)
 

--- a/scripts/fetch_sboms.py
+++ b/scripts/fetch_sboms.py
@@ -1,0 +1,76 @@
+import os
+import requests
+import json
+import time
+from pathlib import Path
+
+API_URL_BASE = os.environ.get("API_URL_BASE", "https://api.adoptium.net/v3/assets/feature_releases/21/ga")
+IMAGE_TYPE = os.environ.get("IMAGE_TYPE", "sbom")
+VENDOR = os.environ.get("VENDOR", "eclipse")
+HEAP_SIZE = os.environ.get("HEAP_SIZE", "normal")
+PAGE_SIZE = int(os.environ.get("PAGE_SIZE", "20"))
+PROJECT_ROOT = os.environ.get("PROJECT_ROOT", "Temurin")
+JAVA_VERSION = os.environ.get("JAVA_VERSION", "JDK 21")
+
+def fetch_sboms():
+    sbom_dir = Path("sboms")
+    sbom_dir.mkdir(exist_ok=True)
+    metadata = []
+
+    page = 1
+    before = None
+
+    while True:
+        print(f"Fetching page {page}...")
+        params = {
+            "image_type": IMAGE_TYPE,
+            "vendor": VENDOR,
+            "heap_size": HEAP_SIZE,
+            "page_size": PAGE_SIZE
+        }
+        if before:
+            params["before"] = before
+
+        response = requests.get(API_URL_BASE, params=params)
+        response.raise_for_status()
+        data = response.json()
+
+        if not data:
+            print("No more results.")
+            break
+
+        for asset in data:
+            version = asset["version_data"]["semver"]
+            for binary in asset.get("binaries", []):
+                os_name = binary["os"]
+                arch = binary["architecture"]
+                sbom_url = binary.get("package", {}).get("link")
+
+                if not sbom_url:
+                    print(f"Skipping {version} ({os_name} {arch}) - no SBOM")
+                    continue
+
+                path = sbom_dir / f"{os_name}_{arch}_{version}" / "sbom.json"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                print(f"Downloading SBOM for {os_name} {arch} {version}")
+                sbom_resp = requests.get(sbom_url)
+                sbom_resp.raise_for_status()
+                path.write_text(sbom_resp.text)
+
+                project_name = f"{PROJECT_ROOT} / {JAVA_VERSION} / {os_name} {arch} / jdk-{version}"
+                metadata.append({
+                    "path": str(path),
+                    "projectName": project_name,
+                    "projectVersion": version
+                })
+
+        before = data[-1]["release_date"]
+        page += 1
+        time.sleep(1)
+
+    with open("metadata.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+    print("Done. Wrote SBOMs and metadata.json.")
+
+if __name__ == "__main__":
+    fetch_sboms()

--- a/scripts/fetch_sboms.py
+++ b/scripts/fetch_sboms.py
@@ -3,6 +3,8 @@ import requests
 import json
 import time
 from pathlib import Path
+from datetime import datetime
+
 
 API_URL_BASE = os.environ.get("API_URL_BASE", "https://api.adoptium.net/v3/assets/feature_releases/21/ga")
 IMAGE_TYPE = os.environ.get("IMAGE_TYPE", "sbom")


### PR DESCRIPTION
This adds a GitHub workflow that fetches SBOMs for Temurin JDK 21 from the Adoptium API and uploads them to Eclipse DependencyTrack. It limits releases to those up to the end of 2022, and uses a python script in scripts/fetch_sbom.py to fetch sboms from API and handle metadata generation. 

Currently, the script:
- Fetches SBOMs from the Adoptium API, saves them into structured folders by OS, architecture, version (According to project hierarchy described in #4182 
- Generates a metadata.json file with projectName, projectVersion and file path to each SBOM
- Uploads SBOMs and metadata as artifacts
- Uses a matrix job to loop over each SBOM and call the reusable workflow eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main

To do: 
- We are still waiting on parentProject UUIDs for proper DependencyTrack hierarchy
- Need to test with the UUIDs after we get them

fixes #4182  