### PR TITLE
Fix jdk-25+ Mac & Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
        fail-fast: false
        matrix:
          os: [windows-2022]
-         version: [jdk11u, jdk17u, jdk21u, jdk]
+         version: [jdk17u, jdk21u, jdk]
          variant: [temurin]
 
      env:
@@ -253,10 +253,10 @@ jobs:
        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
        with:
         path: C:\cygwin64
-        key: cygwin-packages-${{ runner.os }}-v2
+        key: cygwin-packages-${{ runner.os }}-v1
 
      - name: Install Cygwin and packages
-       uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d
+       uses: cygwin/cygwin-install-action@006ad0b0946ca6d0a3ea2d4437677fa767392401
        with:
          install-dir: C:\cygwin64
          packages: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
         key: cygwin-packages-${{ runner.os }}-v1
 
      - name: Install Cygwin and packages
-       uses: cygwin/cygwin-install-action@49f298a7ebb00d4b3ddf58000c3e78eff5fbd6b9 # Use cygwin v2 until https://bugs.openjdk.org/browse/JDK-8357657 resolved to fix jdk11u build
+       uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d
        with:
          install-dir: C:\cygwin64
          packages: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
         key: cygwin-packages-${{ runner.os }}-v1
 
      - name: Install Cygwin and packages
-       uses: cygwin/cygwin-install-action@006ad0b0946ca6d0a3ea2d4437677fa767392401
+       uses: cygwin/cygwin-install-action@f5e0f048310c425e84bc789f493a828c6dc80a25 # Use cygwin v3 until https://bugs.openjdk.org/browse/JDK-8357657 resolved to fix jdk11u build
        with:
          install-dir: C:\cygwin64
          packages: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
         key: cygwin-packages-${{ runner.os }}-v1
 
      - name: Install Cygwin and packages
-       uses: cygwin/cygwin-install-action@f5e0f048310c425e84bc789f493a828c6dc80a25 # Use cygwin v3 until https://bugs.openjdk.org/browse/JDK-8357657 resolved to fix jdk11u build
+       uses: cygwin/cygwin-install-action@49f298a7ebb00d4b3ddf58000c3e78eff5fbd6b9 # Use cygwin v2 until https://bugs.openjdk.org/browse/JDK-8357657 resolved to fix jdk11u build
        with:
          install-dir: C:\cygwin64
          packages: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
        with:
         path: C:\cygwin64
-        key: cygwin-packages-${{ runner.os }}-v1
+        key: cygwin-packages-${{ runner.os }}-v2
 
      - name: Install Cygwin and packages
        uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -724,7 +724,7 @@ buildTemplatedFile() {
     # To work around jdk-25+ bug https://bugs.openjdk.org/browse/JDK-8363942,
     # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
     # to force target regeneration.
-    FULL_MAKE_COMMAND="which make \&\& make --version \&\& make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
+    FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -722,6 +722,7 @@ buildTemplatedFile() {
   #  # This is required so that make will only touch the jmods and not re-compile them after signing
   #  FULL_MAKE_COMMAND="make -t \&\& ${FULL_MAKE_COMMAND}"
   #fi
+  echo "NOT using make -t !!"
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
     # Check if strace is available

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -718,10 +718,10 @@ buildTemplatedFile() {
 
   FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
 
-  if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
-    # This is required so that make will only touch the jmods and not re-compile them after signing
-    FULL_MAKE_COMMAND="make -t \&\& ${FULL_MAKE_COMMAND}"
-  fi
+  #if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
+  #  # This is required so that make will only touch the jmods and not re-compile them after signing
+  #  FULL_MAKE_COMMAND="make -t \&\& ${FULL_MAKE_COMMAND}"
+  #fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
     # Check if strace is available

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -726,7 +726,6 @@ buildTemplatedFile() {
     # to force target regeneration.
     FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
   fi
-  echo "using make -t !!"
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
     # Check if strace is available

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -724,7 +724,7 @@ buildTemplatedFile() {
     # To work around jdk-25+ bug https://bugs.openjdk.org/browse/JDK-8363942,
     # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
     # to force target regeneration.
-    FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
+    FULL_MAKE_COMMAND="which make \&\& make --version \&\& make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -720,7 +720,7 @@ buildTemplatedFile() {
 
   if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     # This is required so that make will only touch the jmods and not re-compile them after signing
-    FULL_MAKE_COMMAND="PATH=/opt/homebrew/opt/make/libexec/gnubin:\$PATH make -t  \&\& ${FULL_MAKE_COMMAND}"
+    FULL_MAKE_COMMAND="which make \&\& make --version \&\& make -t  \&\& ${FULL_MAKE_COMMAND}"
   fi
   echo "using make -t !!"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -720,7 +720,7 @@ buildTemplatedFile() {
 
   if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     # This is required so that make will only touch the jmods and not re-compile them after signing
-    FULL_MAKE_COMMAND="(make -t \|\| rm -f create-main-targets-include) \&\& ${FULL_MAKE_COMMAND}"
+    FULL_MAKE_COMMAND="PATH=/opt/homebrew/opt/make/libexec/gnubin:\$PATH make -t  \&\& ${FULL_MAKE_COMMAND}"
   fi
   echo "using make -t !!"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -720,7 +720,7 @@ buildTemplatedFile() {
 
   if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     # This is required so that make will only touch the jmods and not re-compile them after signing
-    FULL_MAKE_COMMAND="which make \&\& make --version \&\& make -t  \&\& ${FULL_MAKE_COMMAND}"
+    FULL_MAKE_COMMAND="which make \&\& make --version \&\& make -t \&\& rm create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
   fi
   echo "using make -t !!"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -720,7 +720,11 @@ buildTemplatedFile() {
 
   if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     # This is required so that make will only touch the jmods and not re-compile them after signing
-    FULL_MAKE_COMMAND="PATH=/opt/homebrew/opt/make/libexec/gnubin:\$PATH \&\& which make \&\& make --version \&\& make -t \&\& rm create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
+
+    # To work around jdk-25+ bug https://bugs.openjdk.org/browse/JDK-8363942,
+    # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
+    # to force target regeneration.
+    FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
   fi
   echo "using make -t !!"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -718,11 +718,11 @@ buildTemplatedFile() {
 
   FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
 
-  #if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
-  #  # This is required so that make will only touch the jmods and not re-compile them after signing
-  #  FULL_MAKE_COMMAND="make -t \&\& ${FULL_MAKE_COMMAND}"
-  #fi
-  echo "NOT using make -t !!"
+  if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
+    # This is required so that make will only touch the jmods and not re-compile them after signing
+    FULL_MAKE_COMMAND="(make -t || rm -f create-main-targets-include) \&\& ${FULL_MAKE_COMMAND}"
+  fi
+  echo "using make -t !!"
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
     # Check if strace is available

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -720,7 +720,7 @@ buildTemplatedFile() {
 
   if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     # This is required so that make will only touch the jmods and not re-compile them after signing
-    FULL_MAKE_COMMAND="which make \&\& make --version \&\& make -t \&\& rm create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
+    FULL_MAKE_COMMAND="PATH=/opt/homebrew/opt/make/libexec/gnubin:\$PATH \&\& which make \&\& make --version \&\& make -t \&\& rm create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
   fi
   echo "using make -t !!"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -720,7 +720,7 @@ buildTemplatedFile() {
 
   if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     # This is required so that make will only touch the jmods and not re-compile them after signing
-    FULL_MAKE_COMMAND="(make -t || rm -f create-main-targets-include) \&\& ${FULL_MAKE_COMMAND}"
+    FULL_MAKE_COMMAND="(make -t \|\| rm -f create-main-targets-include) \&\& ${FULL_MAKE_COMMAND}"
   fi
   echo "using make -t !!"
 


### PR DESCRIPTION
Due to upstream make changes the "internal Eclipse signing" procedure involving "make -t" fails.
bug: https://bugs.openjdk.org/browse/JDK-8363942

- make -t fails with GNU make 3.81, causing: make[1]: *** wait: No child processes.  Stop.
- After a successful "make -t" the image targets are not regenerated, the workaround for this is to remove the make generated artifact "create-main-targets-include" if it exists

Mac Orka images need updating to use GNU make 4.4+
Windows images already using GNU make 4.4.1

Note: Removed Windows jdk11u runner build failure in jdk.crypto.ec due to bug https://bugs.openjdk.org/browse/JDK-8357657

**Test builds:**
- jdk25 Windows x64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25/job/jdk25-windows-x64-temurin/18/ - SUCCESS
- jdk11u Mac x64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-mac-x64-temurin/425/ - SUCCESS
- jdk11u Windows x64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-windows-x64-temurin/431/ - SUCCESS
- jdk8u Mac x64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-mac-x64-temurin/558/ - SUCCESS
- jdk8u Windows x64 : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-windows-x64-temurin/565/ - SUCCESS

