### PR TITLE
Correctly set build tag based on SCM_REF|BRANCH|TAG

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2038,9 +2038,9 @@ createDefaultTag() {
 
 # Get the build "tag" being built, either specified via TAG or BRANCH, otherwise get latest from the git repo
 getOpenJDKTag() {
-  if [ -n "BUILD_CONFIG[TAG]" ]; then
+  if [ -n "${BUILD_CONFIG[TAG]}" ]; then
     # Checked out TAG specified
-    echo "BUILD_CONFIG[TAG]"
+    echo "${BUILD_CONFIG[TAG]}"
   elif cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" && git show-ref -q --verify "refs/tags/${BUILD_CONFIG[BRANCH]}"; then
     # Checked out BRANCH is a tag
     echo "${BUILD_CONFIG[BRANCH]}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2079,7 +2079,7 @@ getFirstTagFromOpenJDKGitRepo() {
     firstMatchingNameFromRepo=$(grep OPENJDK_TAG ${openj9_openjdk_tag_file} | awk 'BEGIN {FS = "[ :=]+"} {print $2}')
   else
     git fetch --tags "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}"
-    firstMatchingNameFromRepo=$(git tag --list "$TAG_SEARCH" | "$get_tag_cmd")
+    firstMatchingNameFromRepo=$(git tag --merged HEAD "$TAG_SEARCH" | "$get_tag_cmd")
   fi
 
   if [ -z "$firstMatchingNameFromRepo" ]; then


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4203
Fixes https://github.com/adoptium/temurin-build/issues/4189

The above issues are occuring on Mac and Windows due to the two pass build make_exploded & assemble_image, the 2nd phase does not setup the build tag correctly in this scenario and defaults to getting the latest "tag" from the remote repo, which will not be always correct, eg.when building an old tag.

Note: The actual code being built was correct, it is just the jdk home folder naming that ended up incorrect.

This PR adds the logic that is already done in the 1st phase ([here](https://github.com/adoptium/temurin-build/blob/43cabe30d73b951bfa9c0324ca407a3d651a9ea2/sbin/prepareWorkspace.sh#L228)) to the 2nd phase getOpenJDK tag.

Test builds of old EA tag jdk-21.0.8+6 : 
- x64 linux : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-x64-temurin/348/ - SUCCESS
- x64 mac : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-x64-temurin/220/ - SUCCESS
- x64 windows : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/303/ - SUCCESS
- 
