### PR TITLE
Set configureArgs for temurin on Mac to use GNU make 3.8.1 for jdk8->24

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -32,6 +32,12 @@ if [[ "${MACHINEARCHITECTURE}" == "arm64" ]] && [[ "${ARCHITECTURE}" == "x64" ]]
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=x86_64-apple-darwin"
 fi
 
+# For Temurin jdk8u->jdk24u the OSX system default GNU make 3.8.1 must be used to correctly make_exploded/sign/assemble
+if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]] && [[ "$JAVA_FEATURE_VERSION" -lt 25 ]] && [[ -f "/usr/bin/make" ]]; then
+  # Use OSX default GNU make 3.81
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} MAKE=/usr/bin/make"
+fi
+
 if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-toolchain-type=clang"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4205

With the updated jdk25 openjdk make files, the make -t build/sign/assemble Mac procedure requires GNU make 3.81, however jdk8-24 requires GNU make 3.81 (OSX system default make) for successful "make -t".

ci.adoptium.net Orka nodes now have GNU make 4.4.1 install, which openjdk will find by default, to override its selection for jdk8-24, the openjdk configureArg "MAKE=/usr/bin/make" can be used.

Test builds:
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-mac-x64-temurin/561/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-mac-aarch64-temurin/380/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-mac-x64-temurin/426/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk17u/job/jdk17u-mac-x64-temurin/579/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk17u/job/jdk17u-mac-aarch64-temurin/523/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-x64-temurin/216/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-aarch64-temurin/221/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk24u/job/jdk24u-mac-aarch64-temurin/23/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk24u/job/jdk24u-mac-x64-temurin/17/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25/job/jdk25-mac-x64-temurin/11/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25/job/jdk25-mac-aarch64-temurin/24/ - SUCCESS
