### PR TITLE
simple-build.sh: Fix quoting of sha256, fix and quote params to `createMetadata` to protect against empty variables

### DIFF
--- a/sbin/solaris/build-simple.sh
+++ b/sbin/solaris/build-simple.sh
@@ -13,6 +13,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************
 
+# Note that this script expects SCM_REF and TARGET_ARCH variables to be provided
+# by the calling jenkins job
+
 createMetadataFile() {
     metadata_file="$1"
     arch="$2"
@@ -87,7 +90,7 @@ createMetadataFile() {
     echo '",'>> $metadata_file 
     echo '"version_data": "jdk8u",' >> $metadata_file
     echo '"binary_type": "'$bin_type'",' >> $metadata_file
-    echo '"sha256": "'$sha256',' >> $metadata_file
+    echo '"sha256": "'$sha256'",' >> $metadata_file
     echo '"full_version_output": "'$ver_txt'",' >> $metadata_file
     echo '"makejdk_any_platform_args": "",' >> $metadata_file 
     echo '"configure_arguments": "",' >> $metadata_file
@@ -154,7 +157,7 @@ for FILE in OpenJDK*; do
     else
         metadata_file=$FILE.json
     fi
-    createMetadataFile $metadata_file ${TARGET_ARCH} $SCM_REF metadata/buildSource.txt metadata/version.txt $bin_type $sha256
+    createMetadataFile "$metadata_file" "${TARGET_ARCH}" "$SCM_REF" metadata/buildSource.txt metadata/version.txt "$sha256"
 done
 # Simple test job uses filenames.txt to determine the correct filenames to pull down
 ls -1 > filenames.txt


### PR DESCRIPTION
Fixes a few things in the files:
```
$ grep sha256 *json
OpenJDK8U-debugimage_sparcv9_solaris_hotspot_8u462b08.tar.gz.json:"sha256": "62213208862bcf29c2ad565b945f37d60af0e5e2f3efddcaaf2423d03c4540ec,
OpenJDK8U-jdk_sparcv9_solaris_hotspot_8u462b08.tar.gz.json:"sha256": "debugimage,
OpenJDK8U-jre_sparcv9_solaris_hotspot_8u462b08.tar.gz.json:"sha256": "jdk,
OpenJDK8U-sbom_sparcv9_solaris_hotspot_8u462b08-metadata.json:"sha256": "jre,
```
- The sha256 fields in the metadata files were missing a quote at the end of the strings and so the API code couldn't parse them
- The `$bin_type` parameter shouldn't be used in the call to `createMetaData` (it's blank on the first run through so works correctly for the debugimage, then is set to non-blank for the others and so the previous `bin_type` takes the place of the sha256, hence the odd looking entries in the list above even ignoring the missing trailing quotes)
- I've stuck quotes around the parameters to `createMetaData` which is generally good practice and would should also mean that there is less of an issue if any variables are blank (e.g. if you try run the script standalone from the command line)