### PR TITLE
Remove the need to use "make -t" after Mac & Windows signing

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -33,10 +33,10 @@ if [[ "${MACHINEARCHITECTURE}" == "arm64" ]] && [[ "${ARCHITECTURE}" == "x64" ]]
 fi
 
 # For Temurin jdk8u->jdk24u the OSX system default GNU make 3.8.1 must be used to correctly make_exploded/sign/assemble
-if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]] && [[ "$JAVA_FEATURE_VERSION" -lt 25 ]] && [[ -f "/usr/bin/make" ]]; then
-  # Use OSX default GNU make 3.81
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} MAKE=/usr/bin/make"
-fi
+#if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]] && [[ "$JAVA_FEATURE_VERSION" -lt 25 ]] && [[ -f "/usr/bin/make" ]]; then
+#  # Use OSX default GNU make 3.81
+#  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} MAKE=/usr/bin/make"
+#fi
 
 if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
 then

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -32,12 +32,6 @@ if [[ "${MACHINEARCHITECTURE}" == "arm64" ]] && [[ "${ARCHITECTURE}" == "x64" ]]
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=x86_64-apple-darwin"
 fi
 
-# For Temurin jdk8u->jdk24u the OSX system default GNU make 3.8.1 must be used to correctly make_exploded/sign/assemble
-#if [[ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ]] && [[ "$JAVA_FEATURE_VERSION" -lt 25 ]] && [[ -f "/usr/bin/make" ]]; then
-#  # Use OSX default GNU make 3.81
-#  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} MAKE=/usr/bin/make"
-#fi
-
 if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-toolchain-type=clang"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -725,7 +725,8 @@ buildTemplatedFile() {
     # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
     # to force target regeneration.
     #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
-    echo "NO MAKE -t !!"
+    FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=trace ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
+    echo "NO MAKE -t with LOG=trace!!"
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -726,6 +726,8 @@ buildTemplatedFile() {
     # to force target regeneration.
     #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
     echo "NO MAKE -t !!"
+echo "JCMD 1"
+codesign -dv --verbose=4 workspace/build/src/build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
@@ -803,9 +805,15 @@ executeTemplatedFile() {
   # We need the exitcode from the configure-and-build.sh script
   set +eu
 
+echo "JCMD 2"
+codesign -dv --verbose=4 workspace/build/src/build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
+
   # Execute the build passing the workspace dir and target dir as params for configure.txt
   bash "${BUILD_CONFIG[WORKSPACE_DIR]}/config/configure-and-build.sh" ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]}
   exitCode=$?
+
+echo "JCMD 3"
+codesign -dv --verbose=4 workspace/build/src/build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
 
   if [ "${exitCode}" -eq 3 ]; then
     createOpenJDKFailureLogsArchive

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -725,7 +725,7 @@ buildTemplatedFile() {
     # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
     # to force target regeneration.
     #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
-    FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=debug ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
+    FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=trace ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
     echo "NO MAKE -t Windows!!"
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -725,7 +725,7 @@ buildTemplatedFile() {
     # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
     # to force target regeneration.
     #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
-    #FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=trace ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
+    FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=debug ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
     echo "NO MAKE -t Windows!!"
   fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -720,13 +720,7 @@ buildTemplatedFile() {
 
   if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
     # This is required so that make will only touch the jmods and not re-compile them after signing
-
-    # To work around jdk-25+ bug https://bugs.openjdk.org/browse/JDK-8363942,
-    # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
-    # to force target regeneration.
-    #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
-    FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=trace ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
-    echo "NO MAKE -t Windows!!"
+    touchSignedBuildOutputFolders
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
@@ -748,6 +742,30 @@ buildTemplatedFile() {
   cat "$SCRIPT_DIR/build.template" |
     sed -e "s|{configureArg}|${FULL_CONFIGURE}|" \
       -e "s|{makeCommandArg}|${FULL_MAKE_COMMAND}|" >"${BUILD_CONFIG[WORKSPACE_DIR]}/config/configure-and-build.sh"
+}
+
+# Touch the exploded build image output folders so that the executables do not get re-built
+# by make when assembling the images
+touchSignedBuildOutputFolders() {
+  local buildOutputFolder="."
+  if [ -z "${BUILD_CONFIG[USER_OPENJDK_BUILD_ROOT_DIRECTORY]}" ] ; then
+    buildOutputFolder="build/*/."
+  fi
+
+  local buildOutputFolderName=$(ls -d ${PWD}/${buildOutputFolder})
+
+  local signedFolderTimestamp=$(date -u +"%Y%m%d%H%M.%S")
+  echo "Touching signed build folders within build output directory: ${buildOutputFolderName} using timestamp: ${signedFolderTimestamp}"
+
+  # The following build exploded image output folders contain the signed executables
+  local signedFolders=("hotspot/variant-server" "jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources" "support")
+  for signedFolder in "${signedFolders[@]}"
+  do
+    if [[ -d "${buildOutputFolderName}/${signedFolder}" ]]; then
+      echo "Touching signed build output folder: ${buildOutputFolderName}/${signedFolder}"
+      find ${buildOutputFolderName}/${signedFolder} -exec touch -t ${signedFolderTimestamp} {} +
+    fi
+  done
 }
 
 createSourceArchive() {

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -725,8 +725,8 @@ buildTemplatedFile() {
     # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
     # to force target regeneration.
     #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
-    FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=trace ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
-    echo "NO MAKE -t with LOG=trace!!"
+    #FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} LOG=trace ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${ADDITIONAL_MAKE_TARGETS}"
+    echo "NO MAKE -t Windows!!"
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -727,7 +727,7 @@ buildTemplatedFile() {
     #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
     echo "NO MAKE -t !!"
 echo "JCMD 1"
-codesign -dv --verbose=4 workspace/build/src/build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
+codesign -dv --verbose=4 build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
@@ -806,14 +806,14 @@ executeTemplatedFile() {
   set +eu
 
 echo "JCMD 2"
-codesign -dv --verbose=4 workspace/build/src/build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
+codesign -dv --verbose=4 build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
 
   # Execute the build passing the workspace dir and target dir as params for configure.txt
   bash "${BUILD_CONFIG[WORKSPACE_DIR]}/config/configure-and-build.sh" ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]}
   exitCode=$?
 
 echo "JCMD 3"
-codesign -dv --verbose=4 workspace/build/src/build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
+codesign -dv --verbose=4 build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
 
   if [ "${exitCode}" -eq 3 ]; then
     createOpenJDKFailureLogsArchive

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -726,8 +726,6 @@ buildTemplatedFile() {
     # to force target regeneration.
     #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
     echo "NO MAKE -t !!"
-echo "JCMD 1"
-codesign -dv --verbose=4 build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then
@@ -805,15 +803,9 @@ executeTemplatedFile() {
   # We need the exitcode from the configure-and-build.sh script
   set +eu
 
-echo "JCMD 2"
-codesign -dv --verbose=4 build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
-
   # Execute the build passing the workspace dir and target dir as params for configure.txt
   bash "${BUILD_CONFIG[WORKSPACE_DIR]}/config/configure-and-build.sh" ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]}
   exitCode=$?
-
-echo "JCMD 3"
-codesign -dv --verbose=4 build/macosx-aarch64-server-release/support/modules_cmds/jdk.jcmd/jcmd
 
   if [ "${exitCode}" -eq 3 ]; then
     createOpenJDKFailureLogsArchive

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -724,7 +724,8 @@ buildTemplatedFile() {
     # To work around jdk-25+ bug https://bugs.openjdk.org/browse/JDK-8363942,
     # GNU make version 4.4+ is required, along with removal of make artifact create-main-targets-include,
     # to force target regeneration.
-    FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
+    #FULL_MAKE_COMMAND="make -t \&\& rm -f create-main-targets-include \&\& ${FULL_MAKE_COMMAND}"
+    echo "NO MAKE -t !!"
   fi
 
   if [[ "${BUILD_CONFIG[ENABLE_SBOM_STRACE]}" == "true" ]]; then


### PR DESCRIPTION
Fixes https://github.com/adoptium/ci-jenkins-pipelines/issues/1251

Currently we use "make -t" to touch the signed executables after Eclipse signing, however this method does not behave reliably with OpenJDK make files, especially since changes and new features in jdk-25+.

This PR removes the use of "make -t", and instead simply touches the exploded (default) image build support output with an identical "timestamp" (all the same), thus negating the issues of differing timestamps causing make problems.
