### PR TITLE
Update validateSBOMcontent.sh's EXPECTED_FREETYPE

### DIFF
--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -44,7 +44,7 @@ elif echo "$SBOMFILE" | grep _aix_; then
   if [ "$MAJORVERSION" -lt 17 ]; then
     EXPECTED_FREETYPE=2.8.0
   else
-    EXPECTED_FREETYPE=2.13.2 # Bundled version
+    EXPECTED_FREETYPE=2.13.3 # Bundled version
   fi
 elif echo "$SBOMFILE" | grep _alpine-linux_ > /dev/null; then
   EXPECTED_FREETYPE=2.11.1
@@ -78,17 +78,17 @@ elif echo "$SBOMFILE" | grep 64_windows_; then
   EXPECTED_FREETYPE=2.8.1
   EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2022)"
   if [ "${MAJORVERSION}" = "11" ] || [ "${MAJORVERSION}" = "17" ]; then
-    EXPECTED_FREETYPE=2.13.2 # Bundled version
+    EXPECTED_FREETYPE=2.13.3 # Bundled version
   fi
 elif echo "$SBOMFILE" | grep _x86-32_windows_; then
-  EXPECTED_FREETYPE=2.13.2 # Bundled version
+  EXPECTED_FREETYPE=2.13.3 # Bundled version
   EXPECTED_COMPILER="microsoft (Microsoft Visual Studio 2022)"
   if [ "${MAJORVERSION}" = "8"  ]; then
     EXPECTED_FREETYPE=2.5.3
   fi
 elif echo "$SBOMFILE" | grep _mac_; then
   # NOTE: mac/x64 native builds >=11 were using "clang (clang/LLVM from Xcode 10.3)"
-  EXPECTED_FREETYPE=2.13.2 # Bundled version
+  EXPECTED_FREETYPE=2.13.3 # Bundled version
   EXPECTED_COMPILER="clang (clang/LLVM from Xcode 15.2)"
   # shellcheck disable=SC2166
   if [ "${MAJORVERSION}" = "8" ] && echo "$SBOMFILE" | grep _x64_; then
@@ -97,7 +97,7 @@ elif echo "$SBOMFILE" | grep _mac_; then
   fi
 fi
 
-[ "${MAJORVERSION}" -ge 20 ] && EXPECTED_FREETYPE=2.13.2 # Bundled version
+[ "${MAJORVERSION}" -ge 20 ] && EXPECTED_FREETYPE=2.13.3 # Bundled version
 
 RC=0
 if echo "$SBOMFILE" | grep 'linux_'; then


### PR DESCRIPTION
Ref upstream PRs in various repositories e.g. https://github.com/openjdk/jdk11u-dev/pull/3011
Fixes https://github.com/adoptium/temurin-build/issues/4220