### PR TITLE
Fix jdk11u Win x64 signing issue with variant-client jvm.dll

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -758,7 +758,8 @@ touchSignedBuildOutputFolders() {
   echo "Touching signed build folders within build output directory: ${buildOutputFolderName} using timestamp: ${signedFolderTimestamp}"
 
   # The following build exploded image output folders contain the signed executables
-  local signedFolders=("hotspot/variant-server" "jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources" "support")
+  # Note: hotspot/variant-client must also be touched, otherwise the output client/jvm.dll from there that gets copied to support/modules_libs/java.base/client/jvm.dll will get re-built
+  local signedFolders=("hotspot/variant-server" "hotspot/variant-client" "jdk/modules/jdk.jpackage/jdk/jpackage/internal/resources" "support")
   for signedFolder in "${signedFolders[@]}"
   do
     if [[ -d "${buildOutputFolderName}/${signedFolder}" ]]; then


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4226

jdk11u Windows builds the variant-client, output from which gets built into support/modules_libs/java.base/client/jvm.dll, thus to prevent support/modules_libs/java.base/client/jvm.dll from getting re-built after Eclipse signing, hotspot/variant-client must also be "touched".
