### PR TITLE
Avoid dependency of bundled freetype on harfbuzz

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -588,11 +588,11 @@ checkingAndDownloadingFreeType() {
     eval "${freetypeEnv}" && bash ./autogen.sh || exit 1
 
     local pngArg=""
-    if ./configure --help | grep "with-png"; then
+    if bash ./configure --help | grep "with-png"; then
       pngArg="--with-png=no"
     fi
     local harfbuzzArg=""
-    if ./configure --help | grep "with-harfbuzz"; then
+    if bash ./configure --help | grep "with-harfbuzz"; then
       harfbuzzArg="--with-harfbuzz=no"
     fi
 

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -591,10 +591,14 @@ checkingAndDownloadingFreeType() {
     if ./configure --help | grep "with-png"; then
       pngArg="--with-png=no"
     fi
+    local harfbuzzArg=""
+    if ./configure --help | grep "with-harfbuzz"; then
+      harfbuzzArg="--with-harfbuzz=no"
+    fi
 
     # We get the files we need at $WORKING_DIR/installedfreetype
     # shellcheck disable=SC2046
-    if ! (bash ./configure --prefix="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}"/installedfreetype "${pngArg}" "${BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]}" && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} all && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} install); then
+    if ! (bash ./configure --prefix="${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}"/installedfreetype "${pngArg}" "${harfbuzzArg}" "${BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]}" && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} all && ${BUILD_CONFIG[MAKE_COMMAND_NAME]} install); then
       # shellcheck disable=SC2154
       echo "Failed to configure and build libfreetype, exiting"
       exit


### PR DESCRIPTION
This avoids dependency of bundled freetype on system harfbuzz, as it can cause [issue with unresolved symbols](https://github.com/adoptium/temurin-build/issues/4159) depending on system.

Problem is, that harfbuzz in turn depends on freetype (also see [docs](https://github.com/freetype/freetype/blob/48f91b53311929deaf0a26140f06d9f657f1db13/docs/INSTALL.UNIX#L109)), but if version of system freetype is different (newer) than bundled freetype version, (system) harfbuzz fails on unresolved symbols.

Freetype automatically builds with harfbuzz support, if found. (linking against system harfbuzz). This explicitly disables harfbuzz support in freetype. It only affects builds (jdk < 11) with bundled freetype. Another option would be to also bundle harfbuzz.

Note that temurin builds on linux [no longer bundle freetype](https://github.com/adoptium/temurin-build/pull/2226).