### PR TITLE
validateSBOM: Update expected ALSA versions and RISC-V compiler

### DIFF
--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -71,6 +71,9 @@ elif echo "$SBOMFILE" | grep _linux_; then
   [ "${MAJORVERSION}" = "17" ] && EXPECTED_GCC=10.3.0
   [ "${MAJORVERSION}" -ge 20 ] && EXPECTED_GCC=11.3.0 && EXPECTED_FREETYPE=Unknown
   EXPECTED_ALSA=1.1.8
+  if echo "$SBOMFILE" | grep _aarch64_ > /dev/null; then
+     EXPECTED_ALSA=1.1.6 # Linux/aarch64 uses CentOS7.6 devkit, not 7.9
+  fi
   if echo "$SBOMFILE" | grep _riscv64_ > /dev/null; then
     EXPECTED_GCC=14.2.0
     EXPECTED_GLIBC=2.27 # Fedora 28

--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -33,7 +33,7 @@ EXPECTED_COMPILER="gcc (GNU Compiler Collection)"
 EXPECTED_GLIBC=""
 EXPECTED_GCC=""
 # [ "${MAJORVERSION}" = "17" ] && EXPECTED_GCC=10.3.0
-EXPECTED_ALSA="N.A"
+EXPECTED_ALSA=""
 #EXPECTED_FREETYPE=N.A # https://github.com/adoptium/temurin-build/issues/3493
 #EXPECTED_FREETYPE=https://github.com/freetype/freetype/commit/86bc8a95056c97a810986434a3f268cbe67f2902
 if echo "$SBOMFILE" | grep _solaris_; then
@@ -70,10 +70,11 @@ elif echo "$SBOMFILE" | grep _linux_; then
   [ "${MAJORVERSION}" = "11" ] && EXPECTED_GCC=7.5.0
   [ "${MAJORVERSION}" = "17" ] && EXPECTED_GCC=10.3.0
   [ "${MAJORVERSION}" -ge 20 ] && EXPECTED_GCC=11.3.0 && EXPECTED_FREETYPE=Unknown
-  EXPECTED_ALSA=1.1.6
+  EXPECTED_ALSA=1.1.8
   if echo "$SBOMFILE" | grep _riscv64_ > /dev/null; then
-    EXPECTED_GCC=10.5.0 # No devkit yet so default in Ubuntu 20.04
-    EXPECTED_GLIBC=2.31
+    EXPECTED_GCC=14.2.0
+    EXPECTED_GLIBC=2.27 # Fedora 28
+    EXPECTED_ALSA=1.1.1
     [ "${MAJORVERSION}" -lt 20 ] && EXPECTED_FREETYPE=2.10.1
   fi
 #elif echo $SBOMFILE | grep _mac_; then


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4129#issuecomment-3257655920

Done some tests and this allows [jdk-25+36-ea-beta](https://ci.adoptium.net/job/build-scripts/job/release/job/download_and_sbom_validation/106/) to pass but oddly the job I tried on the [latest 17 ea](https://ci.adoptium.net/job/build-scripts/job/release/job/download_and_sbom_validation/107/) wasn't happy for no immediately obvious reason.

Noting that as part of this I have also made the jobs automatically show the version and build branch that was used for the run (I usually add the tag manually when I'm running these) as part of https://github.com/adoptium/infrastructure/issues/434

Draft for now (but reviews welcome) to avoid merging for now in case until the jdk17 thing is understood (slightly possible its ea specific but that feels quite unlikely) but it will be suitable for merging in the next week regardless when we will be releasing jdk25 for the first time.