### PR TITLE
Solaris simple dotests.sh: Fix issues with PWD

### DIFF
--- a/sbin/solaris/dotests.sh
+++ b/sbin/solaris/dotests.sh
@@ -38,19 +38,19 @@ if [ $XVFB5 != 1 ]; then
 fi
 set -x
 rm -rf $HOME/workspace && mkdir $HOME/workspace && WORKSPACE=$HOME/workspace && export WORKSPACE
+pwd
 if [ "$3" = "usecache" ]; then
   cd aqa-tests || exit 1
 else
   rm -rf aqa-tests
   git clone https://github.com/adoptium/aqa-tests
-  cd aqa-tests
   if [ -z "${UPSTREAM_JOBLINK}" ]; then
     # Jenkins simpletest job will copy the artifacts to this location
-    if [ ! -r "$PWD/build_artifacts/filenames.txt" ]; then
-       echo "dotests.sh : UPSTREAM_JOBLINK not defined and $PWD/build_artifacts/filenames.txt does not exist" - cannot progress
+    if [ ! -r "build_artifacts/filenames.txt" ]; then
+       echo "dotests.sh : UPSTREAM_JOBLINK not defined and build_artifacts/filenames.txt does not exist" - cannot progress
        exit 1
     fi
-    JDK_TARBALL_NAME=$PWD/build_artifacts/`cat $PWD/build_artifacts/filenames.txt | grep "OpenJDK8U-jdk_.*tar.gz$"`
+    JDK_TARBALL_NAME=`pwd`/build_artifacts/`cat build_artifacts/filenames.txt | grep "OpenJDK8U-jdk_.*tar.gz$"`
   else
     # Linter can go do one if it objects to the backticks - "$(" is not understood by Solaris' bourne shell (SC2006)
     JDK_TARBALL_NAME=`curl -s "${UPSTREAM_JOBLINK}/artifact/workspace/target/filenames.txt" | grep "OpenJDK8U-jdk_.*tar.gz$"`
@@ -58,6 +58,7 @@ else
     echo Downloading and extracting JDK tarball ...
     curl -O "${UPSTREAM_JOBLINK}/artifact/workspace/target/$JDK_TARBALL_NAME" || exit 1
   fi
+  cd aqa-tests
   gzip -cd "$JDK_TARBALL_NAME" | tar xpf -
   echo Downloading and extracting JRE tarball ... Required for special.openjdk jdk_math_jre_0 target
   JRE_TARBALL_NAME="`echo $JDK_TARBALL_NAME | sed s/jdk/jre/`"


### PR DESCRIPTION
There was a discrepancy between x64 and sparcv9 because for some reason the SPARC runs were looking for the `build_artifacts` directory underneath the extracted `aqa_tests` but x64 wasn't. Fixed by switching the logic around so that the `cd aqa-tests` is not until later in the script.

New runs:
- [SPARC](https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-sparcv9-temurin-simpletest/119/)
- [x64](https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-x64-temurin-simpletest/35/)
- [x64 with UPSTREAM_JOBLINK](https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-x64-temurin-simpletest/36/)