### PR TITLE
Update windows "ReDist" devkit creation doc

### DIFF
--- a/docs/CreateWindowsReDistDevKit.md
+++ b/docs/CreateWindowsReDistDevKit.md
@@ -12,8 +12,8 @@ To extract the required Redist DLLs, the safest and easiest way is to locally in
 
 1. Determine the "Build Tools" version install bootstrapper required and download from here: https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history#fixed-version-bootstrappers
 
-  - If re-building an existing ReDist devkit, for the required VS Toolset version check the versions for the release: https://github.com/adoptium/devkit-binaries/releases
-  - eg. "vs2022_redist_14.40.33807_10.0.26100.1742", is VS2022 version 17.10.3, containing MS Toolset version "14.40.33807"
+- If re-building an existing ReDist devkit, for the required VS Toolset version check the versions for the release: https://github.com/adoptium/devkit-binaries/releases
+- eg. "vs2022_redist_14.40.33807_10.0.26100.1742", is VS2022 version 17.10.3, containing MS Toolset version "14.40.33807"
 
 2. Install locally Visual Studio on a Windows x64 VM using the following command:
 


### PR DESCRIPTION
Update windows devkit creation doc, correct some wording and be more specific on re-building a specific "ReDist" DevKit and what VS2022 and SDK need to be installed.
