### PR TITLE
Narrowed description of freetype switeches

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,20 +160,20 @@ disable the default fB--depth=1 shallow cloning of git repo(s).
 
 -f, --freetype-dir
 specify the location of an existing FreeType library.
-Do not use with -F, would invalidate this switch.
-DEPRECATED: have sense only for JDKs without in-tree freetype
+Do not use with -F, as it would invalidate this switch.
+DEPRECATED: Only makes sense for JDKs without a bundled freetype
 
 --freetype-build-param <parameter>
 specify any special freetype build parameters (required for some Operating Systems).
-DEPRECATED: have sense only for JDKs without in-tree freetype
+DEPRECATED: Only makes sense for JDKs without a bundled freetype
 
 --freetype-version <version>
 specify the version of freetype you are building.
-DEPRECATED: have sense only for JDKs without in-tree freetype
+DEPRECATED: Only makes sense for JDKs without a bundled freetype
 
 -F, --skip-freetype
 set JDK to link against system freetype,
-instead of building in-tree version
+instead of building bundled version
 
 -h, --help
 print the man page.

--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -115,20 +115,20 @@ disable the default \fB--depth=1\fR shallow cloning of git repo(s).
 .TP
 .BR \-f ", " \-\-freetype-dir " " \fI<path>\fR
 specify the location of an existing FreeType library.
-Do not use with \fB<-F>\fR, would invalidate this switch.
-DEPRECATED: have sense only for JDKs without in-tree freetype
+Do not use with \fB<-F>\fR, as it would invalidate this switch.
+DEPRECATED: Only makes sense for JDKs without a bundled freetype
 .TP
 .BR \-\-freetype-build-param " " \fI<parameter>\fR
 specify any special freetype build parameters (required for some OS's).
-DEPRECATED: have sense only for JDKs without in-tree freetype
+DEPRECATED: Only makes sense for JDKs without a bundled freetype
 .TP
 .BR \-\-freetype-version " " \fI<version>\fR
 specify the version of freetype you are building.
-DEPRECATED: have sense only for JDKs without in-tree freetype
+DEPRECATED: Only makes sense for JDKs without a bundled freetype
 .TP
 .BR \-F ", " \-\-skip-freetype
 set JDK to link against system freetype,
-instead of building in-tree version
+instead of building the bundled version
 .TP
 .BR \-h ", " \-\-help
 print this help.


### PR DESCRIPTION
See https://github.com/adoptium/temurin-build/pull/4287#issuecomment-3584716770

* On "old-jdk8" the docs man/readme lies - as using the --skip-freetype leads to use system freetype, the --freetype-dir is ignored (which is in ooposite to docs)
 * When --skip-freetype is omitted, the --freetype-dir works as expected.
* On "new-jdk8" and on 11+the usage of -freetype-dir is leading to imminent configure error
 * with added --skip-freetype its useless as before, as system is used.