### PR TITLE
Remove arm32 debug checks that were added for Scaleway/arm32

### DIFF
--- a/tooling/validateSBOM.sh
+++ b/tooling/validateSBOM.sh
@@ -112,8 +112,6 @@ arg_parser() {
     fi
     SBOM_NAME=${SBOM_LOCATION##*/}
     SBOM_LOCATION="${WORKSPACE_DIR}/${SBOM_NAME}"
-    echo SXAEC - $SBOM_NAME
-    ls -l $SBOM_LOCATION
   elif [ ! -r "$SBOM_LOCATION" ]; then
     echo "ERROR: SBOM_LOCATION could not be found/accessed: $SBOM_LOCATION"
     exit 1


### PR DESCRIPTION
This reverts commit a9a9e37b02d40a33f4c16ac0e81ce6b7967daef6.

This was added for debugging problems on Scaleway arm32 systems which we no longer use. This should have been reverted ages ago

Fixes https://github.com/adoptium/temurin-build/issues/2545

Noting that this was also causing problems if you run on a machine (e.g. build container) when nothing was running as the jenkins user as it fell over on `ps -fu jenkins` which was returning nothing)