### PR TITLE
Skip generating checksum files for SBOM artifacts in Solaris build

### DIFF
--- a/sbin/solaris/build-simple.sh
+++ b/sbin/solaris/build-simple.sh
@@ -155,13 +155,23 @@ scp -prP "${SSH_PORT}" $SSH_OPTS "${SSH_TARGET}:temurin-build/build-farm/workspa
 cd workspace/target || exit 1
 for FILE in OpenJDK*; do
     echo Creating metadata for ${FILE}
-    sha256sum $FILE > $FILE.sha256.txt
-    sha256=$(cat $FILE.sha256.txt | cut -d' ' -f1)
-    if [[ "$FILE" =~ .*sbom.*\.json ]]; then
-        metadata_file=${FILE%.*}-metadata.json
+
+    # Skip checksum generation for SBOM files
+    if [[ "$FILE" == *sbom.json ]]; then
+        echo "Skipping checksum generation for SBOM: $FILE"
+        sha256=""
     else
-        metadata_file=$FILE.json
+        sha256sum "$FILE" > "$FILE.sha256.txt"
+        sha256=$(cut -d' ' -f1 "$FILE.sha256.txt")
     fi
+
+    # Metadata filename: SBOM files get <name>-metadata.json (consistent with naming)
+    if [[ "$FILE" == *sbom.json ]]; then
+        metadata_file="${FILE%.*}-metadata.json"
+    else
+        metadata_file="$FILE.json"
+    fi
+
     createMetadataFile "$metadata_file" "${TARGET_ARCH}" "$SCM_REF" metadata/buildSource.txt metadata/version.txt "$sha256"
 done
 # Simple test job uses filenames.txt to determine the correct filenames to pull down


### PR DESCRIPTION
This PR modifies the Solaris build-simple.sh script to skip generating `.sha256.txt` checksum files for **SBOM JSON artifacts**. Previously, the script generated checksums for all artifacts, including SBOMs, which are not intended to be published. Closes #4316 

**Changes:**
- Added a conditional check in the `for FILE in OpenJDK*` loop to skip checksum generation for files matching `*sbom.json`.
- Metadata for SBOM files is still created, with the `sha256` field left empty.
- Checksum generation for other artifacts remains unchanged.

**Local Testing:**
Created a test workspace with dummy artifacts (`OpenJDK-fake.tar.gz` and `OpenJDK-sbom.json`).

**Verified that:**
- Non-SBOM files generate `.sha256.txt` as expected.
- SBOM files skip checksum creation and metadata includes an empty `sha256` field.
- Confirmed script logic works as intended without errors.

This change ensures Solaris builds behave consistently with other platforms and prevents unnecessary SBOM checksums from being generated.