### PR TITLE
Removing with-freetype-src and with-freetype=dir config args

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -643,23 +643,9 @@ configureAlsaLocation() {
 configureFreetypeLocation() {
   if [[ ! "${CONFIGURE_ARGS}" =~ "--with-freetype" ]]; then
     if [[ "${BUILD_CONFIG[FREETYPE]}" == "true" ]]; then
-      local freetypeDir="${BUILD_CONFIG[FREETYPE_DIRECTORY]}"
-      if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-        case "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" in
-          jdk8* | jdk9* | jdk10*) addConfigureArg "--with-freetype-src=" "${BUILD_CONFIG[WORKSPACE_DIR]}/libs/freetype" ;;
-          *) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled} ;;
-        esac
-      else
-        case "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" in
-          jdk8* | jdk9* | jdk10*) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-"${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedfreetype"} ;;
-          *) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled} ;;
-        esac
-      fi
-
-      if [[ -n "$freetypeDir" ]]; then
-        echo "setting freetype dir to ${freetypeDir}"
-        addConfigureArg "--with-freetype=" "${freetypeDir}"
-      fi
+      local freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled}
+      echo "setting freetype dir to ${freetypeDir}"
+      addConfigureArg "--with-freetype=" "${freetypeDir}"
     fi
   fi
 }


### PR DESCRIPTION
Because https://bugs.openjdk.org/browse/JDK-8193017 removed those arguments as valid options, and also removed the need for them.

Tests:
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-windows-x64-temurin/593/
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-mac-x64-temurin/580/