### PR TITLE
Skip generating checksum files for SBOM artifacts in Solaris build 

### DIFF
--- a/sbin/solaris/build-simple.sh
+++ b/sbin/solaris/build-simple.sh
@@ -159,21 +159,21 @@ cd workspace/target || exit 1
 for FILE in OpenJDK*; do
     echo "Creating metadata for ${FILE}"
 
-    sha_file="${FILE}.sha256.txt"
-    sha256sum "${FILE}" > "${sha_file}"
-    sha256=$(cut -d' ' -f1 "${sha_file}")
-
-    # Remove checksum file for SBOM artifacts after capturing SHA256
-    if [[ "${FILE}" == *sbom.json ]]; then
-        rm -f "${sha_file}"
+    if [[ "${FILE}" == *-sbom_* ]]; then
+        echo "SBOM detected – removing upstream checksum if present"
+        rm -f "${FILE}.sha256.txt"
+        sha256=""
         metadata_file="${FILE%.*}-metadata.json"
     else
+        sha256sum "${FILE}" > "${FILE}.sha256.txt"
+        sha256=$(cut -d' ' -f1 "${FILE}.sha256.txt")
         metadata_file="${FILE}.json"
     fi
 
     createMetadataFile "$metadata_file" "${TARGET_ARCH}" "$SCM_REF" \
         metadata/buildSource.txt metadata/version.txt "$sha256"
 done
+
 
 # Simple test job uses filenames.txt to determine the correct filenames to pull down
 ls -1 > filenames.txt


### PR DESCRIPTION
# Update Solaris build-simple.sh to handle SBOM checksums

This PR updates the Solaris `build-simple.sh` script to correctly handle SHA256 checksums for SBOM JSON artifacts. Previously, SBOM files either skipped checksums entirely or left temporary `.sha256.txt` files behind.
Closes #4316
## Changes

- The `for FILE in OpenJDK*` loop now:
  - Generates SHA256 for all files, including SBOM JSONs.
  - Captures the checksum for SBOM files but **removes the temporary `.sha256.txt`** immediately after.
  - Ensures metadata filenames for SBOM follow the `<name>-metadata.json` convention.
- Metadata for SBOM files now contains the correct SHA256 value while no leftover checksum files remain.
- Checksum generation for other artifacts remains unchanged.

## Local Testing

- Created a test workspace with dummy artifacts: `OpenJDK-fake.tar.gz` and `OpenJDK-fake.sbom.json`.
- Verified:
  - Non-SBOM files generate `.sha256.txt` as expected.
  - SBOM files include correct SHA256 in metadata and no `.sha256.txt` remains.
  - Script runs without errors.

This ensures Solaris builds behave consistently with other platforms and prevents unnecessary SBOM checksum files from being generated.
