### PR TITLE
switch back to system freetype on Solaris

### DIFF
--- a/build-farm/platform-specific-configurations/solaris.sh
+++ b/build-farm/platform-specific-configurations/solaris.sh
@@ -17,11 +17,11 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
-export BUILD_ARGS="${BUILD_ARGS} --skip-freetype --make-args SHELL=/bin/bash"
-
 # FREETYPE options here are needed to override the default use of in-tree freetype
 # as we're getting build failures using the in-tree one due to it not finding libc
 # Ref: https://github.com/adoptium/temurin-build/pull/4345
+
+export BUILD_ARGS="${BUILD_ARGS} --skip-freetype --make-args SHELL=/bin/bash"
 
 if [ "${ARCHITECTURE}" == "x64" ]; then
   export CUPS="--with-cups=/opt/sfw/cups"


### PR DESCRIPTION
Fixes the build failure on Solaris by switching away from the builtin freetype to the system one again.
