### PR TITLE
switch version parsing to use standard commands

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -276,7 +276,8 @@ versionNumbersFileParser() {
     [[ ! "${fileVersionString}" =~ ^jdk8u[0-9]+$ || $error ]] && echo "ERROR: build.sh: ${funcName}: version file could not be parsed." >&2 && exit 1
   else
     # File parsing logic for jdk11+.
-    patchNo="$(  awk -F= '/^DEFAULT_VERSION_PATCH/  {print$2}' "${numbersFile}")" || error="true"
+    # We use awk as a POSIX std (to be consistent with platforms like Solaris)
+    patchNo="$(  awk -F= '/^DEFAULT_VERSION_PATCH/{print$2}' "${numbersFile}")" || error="true"
     updateNo="$( awk -F= '/^DEFAULT_VERSION_UPDATE/ {print$2}' "${numbersFile}")" || error="true"
     interimNo="$(awk -F= '/^DEFAULT_VERSION_INTERIM/{print$2}' "${numbersFile}")" || error="true"
     featureNo="$(awk -F= '/^DEFAULT_VERSION_FEATURE/{print$2}' "${numbersFile}")" || error="true"


### PR DESCRIPTION
`grep -Eo` is not standard grep syntax and is incompatible with Solaris producing errors when this is run. The incompatible code was introduced in https://github.com/adoptium/temurin-build/pull/4304.

Change to using `awk` as it avoids the fork of additional processes to parse the files and is standard across UNIX-based systems.

@judovana has suggested using a simpler `grep` construct but personally I'm losing interest in testing things on this platform at the moment but happy if someone wishes to propose and test an alternative ;-)