### PR TITLE
Switching xcode version for jdk8u builds on mac

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -74,12 +74,7 @@ else
   fi
 fi
 
-
-#if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
-#then
-#  export SDKNAME="${XCODE_SWITCH_PATH}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk"
-#  # The configure option '--with-macosx-codesign-identity' is supported in JDK8 OpenJ9 and JDK11 and JDK14+
-#elif [[ ( "$JAVA_FEATURE_VERSION" -eq 11 ) || ( "$JAVA_FEATURE_VERSION" -ge 14 ) ]]
+# The configure option '--with-macosx-codesign-identity' is supported in JDK8 OpenJ9 and JDK11 and JDK14+
 if [[ ( "$JAVA_FEATURE_VERSION" -eq 11 ) || ( "$JAVA_FEATURE_VERSION" -ge 14 ) ]]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"


### PR DESCRIPTION
Along with an optional SDKNAME override if the jdk config script fails to use the new Xcode SDK.

The latter will be removed if the test run uses the correct SDK (once the infrastructure re-work is complete).

Resolves https://github.com/adoptium/temurin-build/issues/4354