### PR TITLE
Remove x64 mac mmacosx-version-min specification, use upstream value instead

### DIFF
--- a/.azure-devops/build/steps/macOS/build_hotspot.yml
+++ b/.azure-devops/build/steps/macOS/build_hotspot.yml
@@ -33,7 +33,7 @@ steps:
       ./makejdk-any-platform.sh \
         ${EXTRA_MAKEJDK_ANY_PLATFORM_OPTIONS} \
         --jdk-boot-dir "${JDK_BOOT_DIR}" \
-        --configure-args "${CONFIG_ARGS} --disable-warnings-as-errors --with-extra-cxxflags='-mmacosx-version-min=10.9'" \
+        --configure-args "${CONFIG_ARGS} --disable-warnings-as-errors" \
         --destination artifacts \
         --target-file-name "${FILENAME}.tar.gz" \
         --use-jep319-certs \

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -65,10 +65,7 @@ else
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched --enable-openssl-bundling"
   else
-    if [ "${ARCHITECTURE}" == "x64" ]; then
-      # We can only target 10.9 on intel macs
-      export cxx_flags_bucket="${cxx_flags_bucket} -mmacosx-version-min=10.9"
-    elif [[ "${MACHINEARCHITECTURE}" == "x64" ]] && [[ "${ARCHITECTURE}" == "aarch64" ]]; then
+    if [[ "${MACHINEARCHITECTURE}" == "x64" ]] && [[ "${ARCHITECTURE}" == "aarch64" ]]; then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=aarch64-apple-darwin"
     fi
   fi


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4364

Remove the temurin-build scripts x64 mac -mmacosx-version-min=10.9 override, be consistent and use the upstream 11.00.00 value.

Test build in Jenkins https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-x64-temurin/241/ - GOOD
