### PR TITLE
Update AIX PATH for xl 17 compiler

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -127,8 +127,8 @@ if [ "$JAVA_FEATURE_VERSION" -le 21 ] && [ "$JAVA_FEATURE_VERSION" -ge 11 ]; the
   export CXX=xlclang++
 fi
 if [ "$JAVA_FEATURE_VERSION" -ge 22 ]; then
-  export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/openxlC/17.1.1/bin:$PATH
-  export EXTRA_PATH=/opt/IBM/openxlC/17.1.1/tools
+  export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/openxlC/17/bin:$PATH
+  export EXTRA_PATH=/opt/IBM/openxlC/17/tools
   export TOOLCHAIN_TYPE="clang"
   export CC=ibm-clang_r
   export CXX=ibm-clang++_r


### PR DESCRIPTION
The IBM team installed the xl17 compiler onto build-osuosl-aix72-ppc64-4, but its a different version than the one installed on build-osuosl-aix72-ppc64-3

-3
```
root@adopt09:[/root]ls -la /opt/IBM/openxlC/
total 8
drwxr-xr-x    3 root     system          256 Apr 28 2023  .
drwxr-xr-x    7 root     system          256 Apr 28 2023  ..
drwxr-xr-x    8 root     system         4096 May 25 2023  17.1.1
```
-4
```
root@p10-aix-adopt05:[/root]ls -la /opt/IBM/openxlC
total 4
drwxr-xr-x  3 root system  256 Jan 29 12:18 .
drwxr-xr-x  8 root system  256 Oct 20 15:40 ..
lrwxrwxrwx  1 root system    7 Jan 29 12:18 17 -> 17.1.4/
drwxr-xr-x 10 root system 4096 Jan 29 08:58 17.1.4
```
Using the link allows us to have a standardised PATH despite different versions

