### PR TITLE
Correctly set CONFIGURE_ARGS that was used in make exploded when running assmble exploded

### DIFF
--- a/spec.gmk
+++ b/spec.gmk
@@ -1,5 +1,0 @@
-dsfgdsfg
-dfgdfg
-CONFIGURE_COMMAND_LINE := --with-vendor-name='Eclipse Adoptium' --with-vendor-url=https://adoptium.net/ --with-vendor-bug-url=https://github.com/adoptium/adoptium-support/issues --with-vendor-vm-bug-url=https://github.com/adoptium/adoptium-support/issues --with-version-opt=LTS --without-version-pre --with-version-build=10 --with-vendor-version-string=Temurin-25.0.2+10 --with-boot-jdk=/cygdrive/c/comp-jdk-build/jdk-24.0.2+12 --with-ucrt-dll-dir=/cygdrive/c/comp-jdk-build/devkit/ucrt/DLLs/x64 --with-msvcr-dll=/cygdrive/c/comp-jdk-build/devkit/x64/vcruntime140.dll --with-vcruntime-1-dll=/cygdrive/c/comp-jdk-build/devkit/x64/vcruntime140_1.dll --with-msvcp-dll=/cygdrive/c/comp-jdk-build/devkit/x64/msvcp140.dll --enable-linkable-runtime --with-debug-level=release --with-native-debug-symbols=external --with-source-date=version --with-build-user=admin --with-jvm-variants=server --disable-warnings-as-errors --disable-ccache --with-toolchain-version=2022 --with-freetype=bundled --with-zlib=bundled
-dfgdfg
-


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4379

The second phase "assemble exploded" for Windows and Mac was overriding the CONFIGURE_ARGS, which contains a new build timestamp, instead of using the existing configure arguments actually used to build the JDK during the make exploded phase.

Test builds:
- Windows : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-windows-x64-temurin/343/ - SUCCESS
SBOM Timestamp values all align correctly:
```
	
```
- Mac : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-aarch64-temurin/276/ - SUCCESS
SBOM Timestamp values all align correctly:
```
	{
          "name" : "Build Timestamp",
          "value" : "2026-02-04 14:00:33"
        },
          "name" : "full_version_output",
          "value" : "openjdk version \"21.0.10-beta\" 2026-01-20 OpenJDK Runtime Environment Temurin-21.0.10+7-202602041400 (build 21.0.10-beta+7-ea) OpenJDK 64-Bit Server VM Temurin-21.0.10+7-202602041400 (build 21.0.10-beta+7-ea, mixed mode, sharing)"
        },
        {
          "name" : "configure_args",
          "value" : "--verbose --with-vendor-name='Eclipse Adoptium' --with-vendor-url=https://adoptium.net/ --with-vendor-bug-url=https://github.com/adoptium/adoptium-support/issues --with-vendor-vm-bug-url=https://github.com/adoptium/adoptium-support/issues --with-version-pre=beta --with-version-build=7 --with-vendor-version-string=Temurin-21.0.10+7-202602041400 --with-boot-jdk=/Library/Java/JavaVirtualMachines/jdk20/Contents/Home --with-debug-level=release --with-native-debug-symbols=external --with-alsa=/Users/admin/workspace/workspace/build-scripts/jobs/jdk21u/jdk21u-mac-aarch64-temurin/workspace/./build//installedalsa --with-source-date=1770213633 --with-hotspot-build-time='2026-02-04 14:00:33' --disable-ccache --with-build-user=admin --with-jvm-variants=server --with-cacerts-src=/Users/admin/workspace/workspace/build-scripts/jobs/jdk21u/jdk21u-mac-aarch64-temurin/sbin/../security/certs --disable-warnings-as-errors --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/ --with-version-opt=ea --with-freetype=bundled --with-zlib=bundled"
        },
```



