### PR TITLE
Make sure reproducible build uses correct tag version default +0 for example jdk25u

### DIFF
--- a/tooling/reproducible/macos_repro_build_compare.sh
+++ b/tooling/reproducible/macos_repro_build_compare.sh
@@ -165,12 +165,6 @@ Get_SBOM_Values() {
     buildVersion=$(echo "$sbomContent" | jq -r '.metadata.component.version')
     buildArgs=$(echo "$sbomContent" | jq -r '.components[0].properties[] | select(.name == "makejdk_any_platform_args").value')
 
-  if [[ "$buildVersion" != *"+"* ]]; then
-    echo "Temurin version '${buildVersion}' is not a complete tag with a build number, adding +0 default"
-    buildVersion="${buildVersion}+0"
-    echo "  buildVersion=${buildVersion}"
-  fi
-
   # Check if the tool was found
   if [ -n "$macOSCompiler" ]; then
       echo "MacOS Compiler Version: $macOSCompiler"

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -197,12 +197,6 @@ Get_SBOM_Values() {
   buildVersion=$(echo "$sbomContent" | jq -r '.metadata.component.version')
   buildArgs=$(echo "$sbomContent" | jq -r '.components[0].properties[] | select(.name == "makejdk_any_platform_args").value')
 
-  if [[ "$buildVersion" != *"+"* ]]; then
-    echo "Temurin version '${buildVersion}' is not a complete tag with a build number, adding +0 default"
-    buildVersion="${buildVersion}+0"
-    echo "  buildVersion=${buildVersion}"
-  fi
-
   # Check if the tool was found
   if [ -n "$msvsWindowsCompiler" ]; then
       echo "MSVS Windows Compiler Version: $msvsWindowsCompiler"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4381

Allow linux reproducible build script to handle jdk25u(or oracle managed version) HEAD builds, which don't have any tags, which means we default to a "+0" build, as JVM only has jdk-25.0.3. This logic is only done for the Linux reproducible script, as Windows & Mac do not use the version in the same way.

Check for "+" in JVM version, and if no build present, add "+0" default.

jdk-25.0.3 Reproducible test re-run : 
- linux : https://ci.adoptium.net/job/Grinder/16081/
- 
