### PR TITLE
tactical fix for GLIBC version detection in download test

### DIFF
--- a/tooling/release_download_test.sh
+++ b/tooling/release_download_test.sh
@@ -367,8 +367,8 @@ verify_glibc_version() {
     print_verbose "IVT: Release does not contain a JRE for $OS/$ARCH so not running glibc version checks"
   else  
     print_verbose "IVT : Detected GLIBC version '$(strings tarballtest/bin/java | grep ^GLIBC)'"
-    if ! strings tarballtest/bin/java | grep ^GLIBC_2.17 > /dev/null; then
-      print_error "GLIBC version detected in the JDK java executable is not the expected 2.17"
+    if ! strings tarballtest/bin/java | grep ^GLIBC_2.2.5 > /dev/null; then
+      print_error "GLIBC version detected in the JDK java executable is not the expected 2.2.5"
       RC=4
     fi
   fi


### PR DESCRIPTION
Since we [switched the jenkins-worker node](https://github.com/adoptium/infrastructure/issues/4126) from being an OSUOSL aarch64 machine to an x64 one at Hetzner the download test job has failed to check the GLIBC version correctly as it extracts and verifies the version that is appropriate for the architecture.

This is a tactical fix to avoid the immediate problem as it changes the check to be correct for x64 but will not be appropriate if the test is run on other architectures.

Noting also that I'm surprised that this is correct for jdk21+ where I thought we'd switched over to building against the later glibc from EL7 to unify it with the other primary linux architectures 🤷🏻 

