### PR TITLE
Adding jdk27 to autotriage

### DIFF
--- a/.github/workflows/build-autotriage.yml
+++ b/.github/workflows/build-autotriage.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: "Run Build Auto Triage"
-        run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk25u jdk26head
+        run: bash "${PWD}/${TRIAGE_SCRIPT}" jdk8u jdk11u jdk17u jdk21u jdk25u jdk26 jdk27head
 
       - name: Create Issue From File
         env:


### PR DESCRIPTION
JDK26 is no longer head. Adjusting autotriage to match.