### PR TITLE
Force jdk-25+ Linux builds to use LC_ALL=C to ensure Adoptium Temurin builds on Centos7 are reproducible across OS distributions

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -941,7 +941,7 @@ executeTemplatedFile() {
   # For current jdk-25+ Temurin builds we need to force LC_ALL locale of "C" to avoid OpenJDK make choosing en_US.UTF-8 due to lack of C.UTF-8 on Centos7/RHEL7
   # en_US.UTF-8 is not language neutral causing sort order differences on differing linux OS distributions.
   # See ref: https://github.com/adoptium/infrastructure/issues/4289
-  # Note: Leave Alpine and Riscv64 as-is since "locale" is not valid in BusyBox and so C.UTF-8 is being selected by OpenJDK make as a default choice, and Riscv64 does have C.UTF8.
+  # Note: Leave Alpine and Riscv64 as-is since "locale" is not valid in BusyBox and so C.UTF-8 is being selected by OpenJDK make as a default choice, and Riscv64 does have C.UTF-8.
   local PATH_SAVE=""
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_TEMURIN}" ]] && [[ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 25 ]] && [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "linux" ]] && [[ "${BUILD_CONFIG[OS_FULL_VERSION]}" != *"Alpine"* ]] && [[ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "riscv64" ]]; then
     # Hide C.utf8 and en_US.utf8 flavours, as jdk-23+ OpenJDK logic will find those over C and Temurin linux jdk-25+ is currently built with C


### PR DESCRIPTION
Fixes https://github.com/adoptium/infrastructure/issues/4289 for current Centos7 build environment.

Force linux (except for Alpine) builds to use "C" (as aarch64 is already..), thus ensuring language neutral LC_ALL and thus consistent sort order across OS distributions. This then allows reproducible builds across Centos/RHEL7,8,9, Ubtuntu, ....
- Alpine was already choosing C.UTF-8 due to OpenJDK make not finding locale in BusyBox environment.
- Riscv64 left as-is, as riscv64 does have the correct language neutral C.UTF-8 already
- Added SBOM value "Build LC_ALL" to indicate LC_ALL value built with..

Test build: https://ci.adoptium.net/job/build-scripts/job/openjdk25-pipeline/150/ - SUCCESSFUL, all AQA-tests consistent with existing Temurin builds..
Test build only with Alpine & Riscv64 exclusion and SBOM value "Build LC_ALL" added: https://ci.adoptium.net/job/build-scripts/job/openjdk25-pipeline/154/ - GOOD (CycloneDX CLI had a http download 504 glitch re-run fine)
