### PR TITLE
Updating the freetype version expected in build sboms

### DIFF
--- a/tooling/validateSBOMcontent.sh
+++ b/tooling/validateSBOMcontent.sh
@@ -106,7 +106,7 @@ echo "BOOTJDK is ${BOOTJDK}"
 [ "${ALSA}"       != "$EXPECTED_ALSA"     ] && echo "NOTE: ALSA version not ${EXPECTED_ALSA} (SBOM has ${ALSA}) - ignoring because ALSA version is determined by devkit now"  # && RC=1
 
 # shellcheck disable=SC2086
-[ "${FREETYPE}"   != "$EXPECTED_FREETYPE" ]  && echo "ERROR: FreeType version not ${EXPECTED_FREETYPE} (SBOM has ${FREETYPE})"   && RC=1
+[ "${FREETYPE}"   != "$EXPECTED_FREETYPE" ] && echo "ERROR: FreeType version not ${EXPECTED_FREETYPE} (SBOM has ${FREETYPE})"   && RC=1
 
 echo "FREETYPE is ${FREETYPE}"
 


### PR DESCRIPTION
JDK26 GA has freetype 2.13.3, and so does jdk8, but the other jdk versions have 2.14.2. Updating the sbom checker to expect this.

I'll raise an issue shortly about how we can make this script smarter in the future.

Here's the issue for the freetype update: https://bugs.openjdk.org/browse/JDK-8379158