### PR TITLE
Enable jdk-21+ Mac -Wl,-reproducible linking on Xcode >= 15

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -105,9 +105,9 @@ fi
 echo "[WARNING] You may be asked for your su user password, attempting to switch Xcode version to ${XCODE_SWITCH_PATH}"
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
-# If using Xcode >= 15 for jdk-21+, then Apple have introduced linker option -deterministic, to enable reproducible dylib's
+# If using Xcode >= 15 for jdk-21+, then Apple have introduced linker option -reproducible, to enable reproducible dylib's
 if [ "$JAVA_FEATURE_VERSION" -ge 21 ] && [ "$(xcodebuild -version | grep 'Xcode' | awk '{print $2}' | cut -d. -f1)" -ge 15 ]; then
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-Wl,-deterministic"
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-Wl,-reproducible"
 fi
 
 # No MacOS builds available of OpenJDK 7, OpenJDK 8 can boot itself just fine.


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4414

Confirmed by performing two identical tag builds, that using "-Wl,-reproducible" does remove the LC_UUID differences in all dylibs

Test builds:
- jdk-21u : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-aarch64-temurin/295 - SUCCESS
- jdk-21u : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-x64-temurin/264 - SUCCESS
- jdk-25u : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-mac-x64-temurin/36 - SUCCESS
- jdk-25u : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-mac-aarch64-temurin/29 - SUCCESS

With AQA-tests:
- jdk21u : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-mac-aarch64-temurin/297/ - ALL Expected Pass
- jdk25u : https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-mac-x64-temurin/37/ - ALL Expected Pass
- 