### PR TITLE
Ensure Mac builds use the MacOSX.sdk from the selected Xcode for build reproducibility (#4416)

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -74,7 +74,24 @@ fi
 # The configure option '--with-macosx-codesign-identity' is supported in JDK8 OpenJ9 and JDK11 and JDK14+
 if [[ ( "$JAVA_FEATURE_VERSION" -eq 11 ) || ( "$JAVA_FEATURE_VERSION" -ge 14 ) ]]
 then
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+  sysrootSDK="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+
+  # Always use the selected Xcode default SDK to match the Xcode version being used if possible, this ensures "reproducible builds"
+  if [[ -d "${XCODE_SWITCH_PATH}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" ]]; then
+    sysrootSDK="${XCODE_SWITCH_PATH}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+    echo "Configuring build sysroot to use the Xcode SDK: ${sysrootSDK}"
+  else
+    echo "Warning: No 'MacOSX.sdk' found within the selected Xcode: ${XCODE_SWITCH_PATH}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs"
+    echo "Warning: Configuring build sysroot to use the system CommandLineTools SDK: ${sysrootSDK}"
+  fi
+
+  echo "MacOSX.sdk version for : ${sysrootSDK}"
+  echo "========================"
+  plutil -p "${sysrootSDK}/SDKSettings.plist" | grep '"Version"'
+  echo "========================"
+
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-sysroot=${sysrootSDK}"
+
   ## Login to KeyChain
   ## shellcheck disable=SC2046
   ## shellcheck disable=SC2006


### PR DESCRIPTION
Cherry-pick 
* Ensure Mac builds use the MacOSX.sdk from the selected Xcode for build reproducibility