### PR TITLE
Disable PCH for Temurin jdk-21+ for consistent reproducible linux builds

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -263,7 +263,7 @@ fi
 # ref: https://github.com/adoptium/temurin-build/issues/4401
 if [ "${VARIANT}" == "${BUILD_VARIANT_TEMURIN}" ] && [ "$JAVA_FEATURE_VERSION" -ge 21 ];
 then
-  echo "Disabling precompiled headers as this may introduce non-deterministic PCH gch binaries, especially if ASLR is enabled, see: https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html"
+  echo "Disabling precompiled headers as this may introduce non-deterministic PCH gch binaries, especially if ASLR is enabled, see: https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html and https://github.com/adoptium/temurin-build/issues/4401"
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-precompiled-headers"
 fi
 


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4401

- Disable precompiled headers for Temurin jdk-21+ to avoid non-determinism

Test builds with reproducible test group special.system:
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-linux-x64-temurin/49/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-linux-aarch64-temurin/44/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-linux-ppc64le-temurin/45/ - SUCCESS
- https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk25u/job/jdk25u-linux-s390x-temurin/45/ - SUCCESS

Complete jdk21 & 25 build & AQA test : 
- https://ci.adoptium.net/job/build-scripts/job/openjdk21-pipeline/455/
  - aarch64 linux - Good
  - ppc64le linux - Good
  - x64 linux - Good
  - alpine x64 linux - Good
  - alpine aarch64 linux - Good
  - s390x linux - Good
  - riscv64 linux - Good
- https://ci.adoptium.net/job/build-scripts/job/openjdk25-pipeline/171/
  - ppc64le linux - Good
  - aarch64 linux - Good
  - s390x linux - Good
  - x64 linux - Good
  - x64 alpine linux - Good
  - aarch64 alpine linux - Good
  - riscv64 linux - Good
