### PR TITLE
Repro_common runtimelink hash clean on Mac is missing the lib folder

### DIFF
--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -109,6 +109,7 @@ function removeJlinkRuntimelinkHashes() {
         if [[ "$OS" =~ Darwin* ]]; then
           sed -i "" -E 's/^([^|]+)\|([^|]+)\|[^|]+\|([^\.]+\.dylib$)/\1|\2||\3/g' "$f"
           sed -i "" -E 's/^([^|]+)\|([^|]+)\|[^|]+\|(bin\/.*$)/\1|\2||\3/g' "$f"
+          sed -i "" -E 's/^([^|]+)\|([^|]+)\|[^|]+\|(lib\/.*$)/\1|\2||\3/g' "$f"
           sed -i "" -E 's/^([^|]+)\|([^|]+)\|[^|]+\|(lib\/security\/cacerts$)/\1|\2||\3/g' "$f"
         elif [[ "$OS" =~ CYGWIN* ]]; then
           sed -i -E 's/^([^|]+)\|([^|]+)\|[^|]+\|([^\.]+\.dll$)/\1|\2||\3/g' "$f"


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4437

Mac lib/spawnhelper hash not being cleared in the runtimelink hash file
 