### PR TITLE
windows reproducible verification script fails with signtool on non-admin user

### DIFF
--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -486,6 +486,11 @@ function tempSign() {
     openssl req -x509 -quiet -newkey rsa:4096 -sha256 -days 3650 -passout pass:test -keyout $selfCert.key -out $selfCert.crt -subj "/CN=example.com" -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
     # nosemgrep
     openssl pkcs12 -export -passout pass:test -passin pass:test -out $selfCert.pfx -inkey $selfCert.key -in $selfCert.crt
+
+    pfxWin=$(cygpath -w "$selfCert.pfx")
+    cmd.exe /c "icacls \"$pfxWin\" /reset"
+    cmd.exe /c "icacls \"$pfxWin\" /grant %USERNAME%:F"
+
     FILES=$(find "${JDK_DIR}" -type f -name '*.exe' -o -name '*.dll')
     for f in $FILES
      do

--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -483,13 +483,10 @@ function tempSign() {
     # is only used for generating a temporary dummy signature required for
     # the comparison and not used for validating anything
     # nosemgrep
-    openssl req -x509 -quiet -newkey rsa:4096 -sha256 -days 3650 -passout pass:test -keyout $selfCert.key -out $selfCert.crt -subj "/CN=example.com" -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
+    openssl req -x509 -quiet -newkey rsa:4096 -sha256 -days 3650 -passout pass:test -keyout $selfCert.key -out $selfCert.crt -subj "/CN=example.com" -addext "extendedKeyUsage=codeSigning" -addext "keyUsage=digitalSignature" -addext "subjectAltName=DNS:example.com,DNS:*.example.com,IP:10.0.0.1"
+
     # nosemgrep
     openssl pkcs12 -export -passout pass:test -passin pass:test -out $selfCert.pfx -inkey $selfCert.key -in $selfCert.crt
-
-    pfxWin=$(cygpath -w "$selfCert.pfx")
-    cmd.exe /c "icacls \"$pfxWin\" /reset"
-    cmd.exe /c "icacls \"$pfxWin\" /grant %USERNAME%:F"
 
     FILES=$(find "${JDK_DIR}" -type f -name '*.exe' -o -name '*.dll')
     for f in $FILES


### PR DESCRIPTION
When running windows reproducible verification script on a non-admin user, the signtool signature removal fails to add & remove the temp signature:
```
SignTool Error: No certificates were found that met all the given criteria.
Adding Temp Signature for C:\comp-jdk-build\compare\src_jdk\bin\api-ms-win-core-console-l1-1-0.dll failed
```

This is due to missing openssl codesigning extensions:
```
-addext "extendedKeyUsage=codeSigning" -addext "keyUsage=digitalSignature"
```