### PR TITLE
Remove static-libs-graal for jdk-27+ ref: JDK-8382582

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -140,9 +140,9 @@ setVariablesForConfigure() {
     local jmods_image_path="" # not needed in JDK builds < 24
   fi
 
-  # JDK 22+ uses static-libs-graal-image target, using static-libs-graal
+  # JDK 22->26 uses static-libs-graal-image target, using static-libs-graal
   # folder.
-  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 22 ]; then
+  if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 22 ] && [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 27 ]; then
     local static_libs_path="static-libs-graal"
   else
     local static_libs_path="static-libs"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -125,9 +125,9 @@ buildOpenJDKViaDocker()
       local jmods_dir="" # not needed in JDK builds < 24
     fi
 
-    # JDK 22+ uses static-libs-graal-image target, using static-libs-graal
+    # JDK 22->26 uses static-libs-graal-image target, using static-libs-graal
     # folder.
-    if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 22 ]; then
+    if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -ge 22 ] && [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -lt 27 ]; then
       local static_libs_dir="static-libs-graal"
     else
       local static_libs_dir="static-libs"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -874,8 +874,10 @@ buildTemplatedFile() {
     ADDITIONAL_MAKE_TARGETS=" test-image debug-image"
   elif [ "$JDK_VERSION_NUMBER" -gt 8 ] && [ "$JDK_VERSION_NUMBER" -lt 22 ]; then
     ADDITIONAL_MAKE_TARGETS=" test-image static-libs-image"
-  elif [ "$JDK_VERSION_NUMBER" -ge 22 ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]; then
+  elif [ "$JDK_VERSION_NUMBER" -ge 22 ] && [ "$JDK_VERSION_NUMBER" -lt 27 ]; then
     ADDITIONAL_MAKE_TARGETS=" test-image static-libs-graal-image"
+  elif [ "$JDK_VERSION_NUMBER" -ge 27 ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]; then
+    ADDITIONAL_MAKE_TARGETS=" test-image static-libs-image"
   fi
 
   if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" == "true" ]]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -2107,6 +2107,11 @@ cleanAndMoveArchiveFiles() {
       fi
     fi
 
+    if [ "$JDK_VERSION_NUMBER" -ge 27 ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]; then
+      # Remove server jvm static lib after Graal target removal, https://bugs.openjdk.org/browse/JDK-8382582
+      rm -f "${staticLibsImagePath}"/lib/server/*jvm*
+    fi
+
     pushd ${staticLibsImagePath}
       case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
       *cygwin*)


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4478

Updated jdk-27+ builds to use standard static-libs-image target now graal static image removed. Ref: https://bugs.openjdk.org/browse/JDK-8382582

Full jdk-27 pipeline tests:
- https://ci.adoptium.net/job/build-scripts/job/openjdk27-pipeline/46 - Good, all tests run as have done historically

Re-build test after static image libjvm.a removal:
- https://ci.adoptium.net/job/build-scripts/job/openjdk27-pipeline/50/


