### PR TITLE
Enable windows_repro_build_compare.sh to handle Windows aarch64 cross-compiled target

### DIFF
--- a/tooling/reproducible/comparable_patch.sh
+++ b/tooling/reproducible/comparable_patch.sh
@@ -319,7 +319,8 @@ else
   exit 1
 fi
 
-expandJDK "$JDK_DIR" "$OS"
+cp -R "${JDK_DIR}" "${JDK_DIR}_CP"
+expandJDK "$JDK_DIR" "$OS" "${JDK_DIR}_CP"
 
 echo "Removing all Signatures from ${JDK_DIR} in a deterministic way"
 

--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -19,13 +19,13 @@ TEMURIN_TOOLS_BINREPL="temurin.tools.BinRepl"
 function expandJDK() {
   local JDK_DIR="$1"
   local OS="$2"
-  local work_JDK="$3"
+  local WORK_JDK="$3"
 
   local JDK_HOME_DIR="$JDK_DIR"
 
   if [[ "$OS" =~ Darwin* ]]; then
     JDK_HOME_DIR="$JDK_DIR/Contents/Home"
-    work_JDK="$3/Contents/Home"
+    WORK_JDK="$3/Contents/Home"
   fi
 
   echo "$(date +%T) : Expanding various components to enable comparisons ${JDK_DIR} (original files will be removed):"
@@ -38,7 +38,7 @@ function expandJDK() {
     modulesFile=$(cygpath -w $modulesFile)
     extractedDir=$(cygpath -w $extractedDir)
   fi
-  "${work_JDK}/bin/jimage" extract --dir "${extractedDir}" "${modulesFile}"
+  "${WORK_JDK}/bin/jimage" extract --dir "${extractedDir}" "${modulesFile}"
   rm "${JDK_HOME_DIR}/lib/modules"
   echo "$(date +%T) :   Unzipping lib/src.zip to normalize file permissions, then removing src.zip"
   unzip -q "${JDK_HOME_DIR}/lib/src.zip" -d "${JDK_HOME_DIR}/lib/src_zip_expanded"
@@ -56,7 +56,7 @@ function expandJDK() {
         f=$(cygpath -w $f)
         expand_dir=$(cygpath -w $expand_dir)
       fi
-      "${work_JDK}/bin/jmod" extract --dir "${expand_dir}" "$f"
+      "${WORK_JDK}/bin/jmod" extract --dir "${expand_dir}" "$f"
       rm "$f"
     done
 
@@ -158,10 +158,10 @@ function removeSystemModulesHashBuilderParams() {
   systemModules="SystemModules\$0.class SystemModules\$all.class SystemModules\$default.class SystemModules\$1.class SystemModules\$2.class SystemModules\$3.class SystemModules\$4.class SystemModules\$5.class"
   local JDK_DIR="$1"
   local OS="$2"
-  local work_JDK="$3"
+  local WORK_JDK="$3"
 
   if [[ "$OS" =~ Darwin* ]]; then
-    work_JDK="$3/Contents/Home"
+    WORK_JDK="$3/Contents/Home"
   fi
 
   for systemModule in $systemModules
@@ -173,7 +173,7 @@ function removeSystemModulesHashBuilderParams() {
           if [[ "$OS" =~ CYGWIN* ]]; then
             ff=$(cygpath -w $f)
           fi
-          "${work_JDK}"/bin/javap -v -sysinfo -l -p -c -s -constants "$ff" > "$f.javap.tmp"
+          "${WORK_JDK}"/bin/javap -v -sysinfo -l -p -c -s -constants "$ff" > "$f.javap.tmp"
           
           # Remove "instruction number:" prefix, so we can just match code
           if [[ "$OS" =~ Darwin* ]]; then
@@ -325,10 +325,10 @@ function removeMacOSNonComparableData() {
 function processModuleInfo() {
   local JDK_DIR="$1"
   local OS="$2"
-  local work_JDK="$3"
+  local WORK_JDK="$3"
 
   if [[ "$OS" =~ Darwin* ]]; then
-    work_JDK="$3/Contents/Home"
+    WORK_JDK="$3/Contents/Home"
   fi
 
   echo "$(date +%T) : Process Module Info from ${JDK_DIR}" 
@@ -341,7 +341,7 @@ function processModuleInfo() {
     if [[ "$OS" =~ CYGWIN* ]]; then
       ff=$(cygpath -w $f)
     fi
-    "${work_JDK}"/bin/javap -v -sysinfo -l -p -c -s -constants "$ff" > "$f.javap.tmp"
+    "${WORK_JDK}"/bin/javap -v -sysinfo -l -p -c -s -constants "$ff" > "$f.javap.tmp"
     cc=99
     foundAttr=false
     attrName=""

--- a/tooling/reproducible/repro_common.sh
+++ b/tooling/reproducible/repro_common.sh
@@ -19,19 +19,16 @@ TEMURIN_TOOLS_BINREPL="temurin.tools.BinRepl"
 function expandJDK() {
   local JDK_DIR="$1"
   local OS="$2"
+  local work_JDK="$3"
 
   local JDK_HOME_DIR="$JDK_DIR"
-  local JDK_COPY="${1}_CP"
-  local JDK_COPY_BIN="${JDK_COPY}/bin"
 
   if [[ "$OS" =~ Darwin* ]]; then
     JDK_HOME_DIR="$JDK_DIR/Contents/Home"
-    JDK_COPY_BIN="$JDK_COPY/Contents/Home/bin"
+    work_JDK="$3/Contents/Home"
   fi
 
   echo "$(date +%T) : Expanding various components to enable comparisons ${JDK_DIR} (original files will be removed):"
-  mkdir "${JDK_COPY}"
-  cp -R ${JDK_DIR}/* ${JDK_COPY}
 
   echo "$(date +%T) :   Using 'jimage extract' to expand lib/modules image into lib/modules_extracted"
   modulesFile="${JDK_HOME_DIR}/lib/modules"
@@ -41,7 +38,7 @@ function expandJDK() {
     modulesFile=$(cygpath -w $modulesFile)
     extractedDir=$(cygpath -w $extractedDir)
   fi
-  "${JDK_COPY_BIN}/jimage" extract --dir "${extractedDir}" "${modulesFile}"
+  "${work_JDK}/bin/jimage" extract --dir "${extractedDir}" "${modulesFile}"
   rm "${JDK_HOME_DIR}/lib/modules"
   echo "$(date +%T) :   Unzipping lib/src.zip to normalize file permissions, then removing src.zip"
   unzip -q "${JDK_HOME_DIR}/lib/src.zip" -d "${JDK_HOME_DIR}/lib/src_zip_expanded"
@@ -59,7 +56,7 @@ function expandJDK() {
         f=$(cygpath -w $f)
         expand_dir=$(cygpath -w $expand_dir)
       fi
-      "${JDK_COPY_BIN}/jmod" extract --dir "${expand_dir}" "$f"
+      "${work_JDK}/bin/jmod" extract --dir "${expand_dir}" "$f"
       rm "$f"
     done
 
@@ -80,7 +77,6 @@ function expandJDK() {
   unzip -qd "${JDK_HOME_DIR}/jmods/expanded_jdk.compiler.jmod/lib/ct-sym-expanded" "${JDK_HOME_DIR}/jmods/expanded_jdk.compiler.jmod/lib/ct.sym"
   rm "${JDK_HOME_DIR}/jmods/expanded_jdk.compiler.jmod/lib/ct.sym"
 
-  rm -rf "${JDK_COPY}"
 }
 
 # jdk-25+ Jlink runtimelink files contain signed binary "hash" lines in fs_* runtimelink files

--- a/tooling/reproducible/repro_compare.sh
+++ b/tooling/reproducible/repro_compare.sh
@@ -20,6 +20,7 @@ JDK_DIR1="$2"
 BLD_TYPE2="$3"
 JDK_DIR2="$4"
 OS="$5"
+WORK_JDK="${6:-}"
 
 # Log file for evidence
 EVIDENCE_LOG="reproducible_evidence.log"
@@ -34,7 +35,7 @@ checkJdkDir() {
 
   if [[ ! -d "${JDK_DIR}" ]] || [[ ! -d "${JDK_HOME_DIR}/bin"  ]]; then
     echo "$JDK_DIR does not exist or does not point at a JDK"
-    echo "repro_compare.sh (temurin|openjdk) JDK_DIR1 (temurin|openjdk) JDK_DIR2 OS"
+    echo "repro_compare.sh (temurin|openjdk) JDK_DIR1 (temurin|openjdk) JDK_DIR2 OS [WORK_JDK]"
     exit 1
   fi
 }
@@ -58,9 +59,13 @@ if [ -z "${PREPROCESS:-}" ] ; then
   PREPROCESS="yes"
 fi
 
-mkdir "${JDK_DIR}_BK"
-cp -R "${JDK_DIR1}"/* "${JDK_DIR}"_BK
-BK_JDK_DIR=$(realpath "${JDK_DIR}"_BK/)
+if [ -z "${WORK_JDK}" ] ; then
+  mkdir "${JDK_DIR}_BK"
+  cp -R "${JDK_DIR1}"/* "${JDK_DIR}"_BK
+  BK_JDK_DIR=$(realpath "${JDK_DIR}"_BK/)
+else
+  BK_JDK_DIR="${WORK_JDK}"
+fi
 
 JDK_DIR_Arr=("${JDK_DIR1}" "${JDK_DIR2}")
 if [ "$PREPROCESS" != "no" ] ; then
@@ -68,7 +73,7 @@ for  JDK_DIR in "${JDK_DIR_Arr[@]}"
 do
   echo "$(date +%T) : Pre-processing ${JDK_DIR}"
   rc=0
-  source "$(dirname "$0")"/repro_process.sh "${JDK_DIR}" "${OS}" || rc=$?
+  source "$(dirname "$0")"/repro_process.sh "${JDK_DIR}" "${OS}" "${BK_JDK_DIR}" || rc=$?
   if [ $rc != 0 ]; then
     echo "$(date +%T): Pre-processing of ${JDK_DIR} ${OS} failed"
     exit 1

--- a/tooling/reproducible/repro_process.sh
+++ b/tooling/reproducible/repro_process.sh
@@ -17,11 +17,12 @@ source "$(dirname "$0")"/repro_common.sh
 
 JDK_DIR="$1"
 OS="$2"
+WORK_JDK="$3"
 
 # This script unpacks the JDK_DIR and removes windows signing Signatures in a neutral way
 # ensuring identical output once Signature is removed.
 
-expandJDK "$JDK_DIR" "$OS"
+expandJDK "$JDK_DIR" "$OS" "$WORK_JDK"
 
 removeGeneratedClasses "$JDK_DIR" "$OS"
 if [[ "$OS" =~ CYGWIN* ]] || [[ "$OS" =~ Darwin* ]]; then

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -327,6 +327,16 @@ Get_SBOM_Values() {
       echo "This Is A Mandatory Element"
       exit 1
   fi
+  
+  # Determine target architecture from buildArgs
+  if [[ "$buildArgs" == *"--openjdk-target=aarch64-unknown-cygwin"* ]]; then
+      targetArch="arm64"
+      echo "Target Architecture (from buildArgs): arm64 (cross-compile)"
+  else
+      targetArch="x64"
+      echo "Target Architecture (from buildArgs): x64"
+  fi
+  export targetArch
   echo ""
 
   if [ "$REPRODUCIBLE_VERIFICATION" == true ]; then
@@ -371,7 +381,7 @@ Check_Architecture() {
     msvsArch="x86"
   elif [[ $systemArchitecture == *arm64* ]]; then
     echo "System Architecture: 64-bit (ARM)"
-    sysArch="Arm64"
+    sysArch="arm64"
     msvsArch="arm64"
   else
     echo "System Architecture: Other - Not Supported"
@@ -415,9 +425,9 @@ Check_VS_Versions() {
   fi
   echo "Visual Studio Base Path = $MSVS_SEARCH_PATH"
 
-  # Add Host Architecture To Exe name
-  C_COMPILER_PATH="Host$msvsArch/$msvsArch"
-  CPP_COMPILER_PATH="Host$msvsArch/$msvsArch"
+  # Add Host Architecture and target To Exe name
+  C_COMPILER_PATH="Host$msvsArch/$targetArch"
+  CPP_COMPILER_PATH="Host$msvsArch/$targetArch"
 
   # Define Search Path For C Compilers
   echo ""
@@ -513,13 +523,13 @@ Check_UCRT_Location() {
   URCT_CYGPATH=$(cygpath -u "$WIN_URCT_BASE")
   WIN_URCT_PATH="$URCT_CYGPATH"
   # Only Search For DLLs for the correct architecture
-  UCRTCOUNT=$(find "$WIN_URCT_PATH" | grep $msvsArch | grep -ic ucrtbase.dll)
+  UCRTCOUNT=$(find "$WIN_URCT_PATH" | grep $targetArch | grep -ic ucrtbase.dll)
   if [ "$UCRTCOUNT" -eq 0 ] ; then
     echo "ERROR - NO ucrtbase.dll Could Be Found For The Base Path Specified - Exiting"
     exit 1
   else
     UCRT_FOUND=0
-    dll_paths=$(find "$WIN_URCT_PATH" -name 'ucrtbase.dll' | grep $msvsArch 2>/dev/null)
+    dll_paths=$(find "$WIN_URCT_PATH" -name 'ucrtbase.dll' | grep $targetArch 2>/dev/null)
     for dll in $dll_paths ; do
       dllpath=$(cygpath -s -m "$dll")
       # Check The Version Of Each
@@ -639,10 +649,10 @@ Prepare_Env_For_OpenJDK_Build() {
     unzip -q "${USER_DEVKIT_LOCATION}" -d "$WORK_DIR/devkit"
   fi
 
-  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-ucrt-dll-dir=[^ ]*|--with-ucrt-dll-dir=$WORK_DIR/devkit/ucrt/DLLs/$msvsArch|")"
-  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-msvcr-dll=[^ ]*|--with-msvcr-dll=$WORK_DIR/devkit/$msvsArch/vcruntime140.dll|")"
-  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-vcruntime-1-dll=[^ ]*|--with-vcruntime-1-dll=$WORK_DIR/devkit/$msvsArch/vcruntime140_1.dll|")"
-  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-msvcp-dll=[^ ]*|--with-msvcp-dll=$WORK_DIR/devkit/$msvsArch/msvcp140.dll|")"
+  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-ucrt-dll-dir=[^ ]*|--with-ucrt-dll-dir=$WORK_DIR/devkit/ucrt/DLLs/$targetArch|")"
+  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-msvcr-dll=[^ ]*|--with-msvcr-dll=$WORK_DIR/devkit/$targetArch/vcruntime140.dll|")"
+  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-vcruntime-1-dll=[^ ]*|--with-vcruntime-1-dll=$WORK_DIR/devkit/$targetArch/vcruntime140_1.dll|")"
+  adoptiumConfigureArgs="$(echo "$adoptiumConfigureArgs" | sed -e "s|--with-msvcp-dll=[^ ]*|--with-msvcp-dll=$WORK_DIR/devkit/$targetArch/msvcp140.dll|")"
 
   echo ""
   echo "OpenJDK Configure Argument List = "

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -30,6 +30,7 @@ SBOM_URL=""
 TARBALL_URL=""
 REPORT_DIR=""
 USER_DEVKIT_LOCATION=""
+WORK_JDK_DIR=""
 REPRODUCIBLE_VERIFICATION=false
 
 while [[ $# -gt 0 ]] ; do
@@ -50,6 +51,9 @@ while [[ $# -gt 0 ]] ; do
     "--user-devkit-location" )
     USER_DEVKIT_LOCATION="$1"; shift;;
 
+    "--work-jdk" )
+    WORK_JDK_DIR="$1"; shift;;
+
     "--reproducible-verification" )
     REPRODUCIBLE_VERIFICATION=true;;
 
@@ -67,6 +71,7 @@ if [ -z "$SBOM_URL" ] || [ -z "$TARBALL_URL" ] || [ -z "$REPORT_DIR" ]; then
   echo "    --report-dir [REPORT_DIR] : should be the FULL path OR a URL to the output directory for the comparison report"
   echo "  Optional:"
   echo "    --user-devkit-location [USER_DEVKIT_LOCATION] : FULL path OR a URL location of user built Windows Redist DLL DevKit"
+  echo "    --work-jdk [WORK_JDK_DIR] : FULL path to a suitable host JDK used by [`repro_compare.sh`](tooling/reproducible/repro_compare.sh:18) for preprocessing cross-compiled targets"
   echo "    --reproducible-verification : Enables Reproducible Verification mode, where native OpenJDK source and make used rather than temurin-build scripts"
   exit 1
 fi
@@ -802,9 +807,9 @@ Compare_JDK() {
   set +e
   cd "$ScriptPath" || exit 1
   if [ "$REPRODUCIBLE_VERIFICATION" == true ]; then
-    ./repro_compare.sh temurin $WORK_DIR/compare/src_jdk hotspot $WORK_DIR/compare/tar_jdk CYGWIN 2>&1 &
+    ./repro_compare.sh temurin $WORK_DIR/compare/src_jdk hotspot $WORK_DIR/compare/tar_jdk CYGWIN "${WORK_JDK_DIR}" 2>&1 &
   else
-    ./repro_compare.sh temurin $WORK_DIR/compare/src_jdk temurin $WORK_DIR/compare/tar_jdk CYGWIN 2>&1 &
+    ./repro_compare.sh temurin $WORK_DIR/compare/src_jdk temurin $WORK_DIR/compare/tar_jdk CYGWIN "${WORK_JDK_DIR}" 2>&1 &
   fi
   pid=$!
   wait $pid

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -246,11 +246,6 @@ Get_SBOM_Values() {
   TEMURIN_VERSION="jdk-"$(echo "$sbomContent" | jq -r '.metadata.component.version' | sed 's/-beta//' | cut -f1 -d"-")
   buildArgs=$(echo "$sbomContent" | jq -r '.components[0].properties[] | select(.name == "makejdk_any_platform_args").value')
 
-
-# temp hack!!!
-TEMURIN_COMPONENT_VERSION="21.0.11+10-LTS"
-TEMURIN_VERSION="jdk-21.0.11+10-LTS"
-
   # Temurin beta-ea builds have release tags ending "-ea-beta"
   if [[ "$TEMURIN_COMPONENT_VERSION" == *-beta*-ea ]]; then
     TEMURIN_VERSION="${TEMURIN_VERSION}-ea-beta"

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -246,9 +246,6 @@ Get_SBOM_Values() {
   TEMURIN_VERSION="jdk-"$(echo "$sbomContent" | jq -r '.metadata.component.version' | sed 's/-beta//' | cut -f1 -d"-")
   buildArgs=$(echo "$sbomContent" | jq -r '.components[0].properties[] | select(.name == "makejdk_any_platform_args").value')
 
-TEMURIN_COMPONENT_VERSION="21.0.11+10-LTS"
-TEMURIN_VERSION="jdk-"$(echo "21.0.11+10-LTS" | sed 's/-beta//' | cut -f1 -d"-")
-
   # Temurin beta-ea builds have release tags ending "-ea-beta"
   if [[ "$TEMURIN_COMPONENT_VERSION" == *-beta*-ea ]]; then
     TEMURIN_VERSION="${TEMURIN_VERSION}-ea-beta"

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -246,6 +246,9 @@ Get_SBOM_Values() {
   TEMURIN_VERSION="jdk-"$(echo "$sbomContent" | jq -r '.metadata.component.version' | sed 's/-beta//' | cut -f1 -d"-")
   buildArgs=$(echo "$sbomContent" | jq -r '.components[0].properties[] | select(.name == "makejdk_any_platform_args").value')
 
+TEMURIN_COMPONENT_VERSION="21.0.11+10-LTS"
+TEMURIN_VERSION="jdk-"$(echo "21.0.11+10-LTS" | sed 's/-beta//' | cut -f1 -d"-")
+
   # Temurin beta-ea builds have release tags ending "-ea-beta"
   if [[ "$TEMURIN_COMPONENT_VERSION" == *-beta*-ea ]]; then
     TEMURIN_VERSION="${TEMURIN_VERSION}-ea-beta"

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -71,7 +71,7 @@ if [ -z "$SBOM_URL" ] || [ -z "$TARBALL_URL" ] || [ -z "$REPORT_DIR" ]; then
   echo "    --report-dir [REPORT_DIR] : should be the FULL path OR a URL to the output directory for the comparison report"
   echo "  Optional:"
   echo "    --user-devkit-location [USER_DEVKIT_LOCATION] : FULL path OR a URL location of user built Windows Redist DLL DevKit"
-  echo "    --work-jdk [WORK_JDK_DIR] : FULL path to a suitable host JDK used by [`repro_compare.sh`](tooling/reproducible/repro_compare.sh:18) for preprocessing cross-compiled targets"
+  echo "    --work-jdk [WORK_JDK_DIR] : FULL path to a suitable host JDK used by [repro_compare.sh](tooling/reproducible/repro_compare.sh:18) for preprocessing cross-compiled targets"
   echo "    --reproducible-verification : Enables Reproducible Verification mode, where native OpenJDK source and make used rather than temurin-build scripts"
   exit 1
 fi

--- a/tooling/reproducible/windows_repro_build_compare.sh
+++ b/tooling/reproducible/windows_repro_build_compare.sh
@@ -246,6 +246,11 @@ Get_SBOM_Values() {
   TEMURIN_VERSION="jdk-"$(echo "$sbomContent" | jq -r '.metadata.component.version' | sed 's/-beta//' | cut -f1 -d"-")
   buildArgs=$(echo "$sbomContent" | jq -r '.components[0].properties[] | select(.name == "makejdk_any_platform_args").value')
 
+
+# temp hack!!!
+TEMURIN_COMPONENT_VERSION="21.0.11+10-LTS"
+TEMURIN_VERSION="jdk-21.0.11+10-LTS"
+
   # Temurin beta-ea builds have release tags ending "-ea-beta"
   if [[ "$TEMURIN_COMPONENT_VERSION" == *-beta*-ea ]]; then
     TEMURIN_VERSION="${TEMURIN_VERSION}-ea-beta"
@@ -338,8 +343,8 @@ Get_SBOM_Values() {
       targetArch="arm64"
       echo "Target Architecture (from buildArgs): arm64 (cross-compile)"
   else
-      targetArch="x64"
-      echo "Target Architecture (from buildArgs): x64"
+      targetArch=""
+      echo "No Target Architecture (from buildArgs)"
   fi
   export targetArch
   echo ""
@@ -391,6 +396,11 @@ Check_Architecture() {
   else
     echo "System Architecture: Other - Not Supported"
     exit 1
+  fi
+
+  # If no target arch in BuildArgs then we are not cross-compiling, then default to system
+  if [[ -z "$targetArch" ]]; then
+    targetArch="$msvsArch"
   fi
 
   if [[ "$sysArch" == "$msvsArch" ]]; then
@@ -820,9 +830,15 @@ Compare_JDK() {
   if [ "$REPRODUCIBLE_VERIFICATION" == true ]; then
     EVIDENCE_LOG="$PWD/reproducible_evidence.log"
     if [ $rc -eq 0 ]; then
+      # Adjust Target Arch to standard Adoptium format
+      evidenceArch=""
+      if [ $targetArch = "arm64" ] ; then evidenceArch="aarch64" ; fi
+      if [ $targetArch = "x64" ] ; then evidenceArch="x64" ; fi
+      if [ $targetArch = "x86" ] ; then evidenceArch="x86" ; fi
+
       echo "Successful 100% Reproducible Verification" >> "${EVIDENCE_LOG}"
       echo "Eclipse Temurin version: ${TEMURIN_VERSION}" >> "${EVIDENCE_LOG}"
-      echo "                   arch: ${NATIVE_API_ARCH}" >> "${EVIDENCE_LOG}"
+      echo "                   arch: ${evidenceArch}" >> "${EVIDENCE_LOG}"
       echo "                     os: windows" >> "${EVIDENCE_LOG}"
       echo "                 sha256: ${JDK_TAR_HASH}" >> "${EVIDENCE_LOG}"
     else


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4480

Assisted-by: IBM Bob

- repro_compare.sh has been extended with an optional 6th argument which is a suitable WORK_JDK. the repro_common.sh scripts have been augmented to use this.
- windows_repro_build_compare.sh has also been augmented to check the buildArgs to see if this is a Windows aarch64 cross-compile target, and use that as the MS VisualStudio targetArch