### PR TITLE
Move "Initiating build" message to after "git fetch"

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -3043,8 +3043,8 @@ createTargetDir
 echo "build.sh : $(date +%T) : Configuring workspace inc. clone and cacerts generation ..."
 configureWorkspace
 
-echo "build.sh : $(date +%T) : Initiating build ..."
 getOpenJDKUpdateAndBuildVersion
+echo "build.sh : $(date +%T) : Initiating build ..."
 if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
   # Not required for VS2022 and later which we are defaulting to
   if [[ "${CONFIGURE_ARGS}" =~ "--with-toolchain-version=201" ]]; then


### PR DESCRIPTION
The `build.sh : Initiating build` timestamp message is displayed before the `git fetch` operation which can take quite a bit of time to complete. I've seen it take up to 15 minutes.
This can impact any analysis of data from those time stamps as it includes things which are nothing to do with the build. This PR moves the message to after `getOpenJDKUpdateAndBuildVersion` which is where the `git fetch` operation happens.

(Should/could this phase be next to the extract instead of after the cacerts generation?)