### PR TITLE
#2058 allow absolute path to be passed to -s and -d

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -275,7 +275,13 @@ function parseConfigurationArguments() {
         BUILD_CONFIG[DISABLE_ADOPT_BRANCH_SAFETY]=true;;
 
         "--destination" | "-d" )
-        BUILD_CONFIG[TARGET_DIR]="$1"; shift;;
+        if [[ "$1" = /* ]]; then
+          BUILD_CONFIG[WORKSPACE_DIR]="$(dirname "$1")"
+          BUILD_CONFIG[TARGET_DIR]="$(basename "$1")"
+        else
+          BUILD_CONFIG[TARGET_DIR]="$1"
+        fi
+        shift;;
 
         "-D" )
         if which podman > /dev/null ; then BUILD_CONFIG[CONTAINER_COMMAND]="podman" ; else BUILD_CONFIG[CONTAINER_COMMAND]="docker" ; fi;
@@ -353,7 +359,12 @@ function parseConfigurationArguments() {
         BUILD_CONFIG[RELEASE]=true;;
 
         "--source" | "-s" )
-        BUILD_CONFIG[WORKING_DIR]="$1"; shift;;
+        if [[ "$1" = /* ]]; then
+          BUILD_CONFIG[WORKSPACE_DIR]="$1"
+        else
+          BUILD_CONFIG[WORKING_DIR]="$1"
+        fi
+        shift;;
 
         "--ssh" | "-S" )
         BUILD_CONFIG[USE_SSH]=true;;


### PR DESCRIPTION
https://github.com/adoptium/temurin-build/issues/2058

what this does not solve is the -T or --target-file-name , as it states "name" and not "path" hence absolute path should not be passed as name in my opinion. 
But I am open to discussion.